### PR TITLE
ci: preflight-assert the signing certificate matches the profile (#960)

### DIFF
--- a/.github/workflows/e2e2z-release.yml
+++ b/.github/workflows/e2e2z-release.yml
@@ -792,13 +792,20 @@ jobs:
             -c 'Add :provisioningProfiles dict' \
             -c "Add :provisioningProfiles:cash.free2z.e2e2z string $PROFILE_NAME" \
             unsigned-ios/ExportOptions.plist
+          # The signing preflight (#960) travels with the payload for the same
+          # reason ExportOptions.plist does: the signing job may not check the
+          # repository out, so the checker it runs has to arrive already bound
+          # to this source by the attestation over CHECKSUMS.sha256. Copied
+          # verbatim from the repository root, where its node-test holds it to
+          # its negative control on every pull request.
+          cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" unsigned-ios/verify-signing-identity.mjs
           version=${RELEASE_IDENTITY%+*}
           build=${RELEASE_IDENTITY#*+}
           jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
             --arg version "$version" --arg build "$build" --arg profileName "$PROFILE_NAME" \
             '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,version:$version,build:$build,applicationId:"cash.free2z.e2e2z",profileName:$profileName,kind:"ios-unsigned-xcarchive"}' \
             > unsigned-ios/source-record.json
-          (cd unsigned-ios && shasum -a 256 e2e2z.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256)
+          (cd unsigned-ios && shasum -a 256 e2e2z.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256)
           artifact_sha256=$(shasum -a 256 unsigned-ios/e2e2z.xcarchive.zip | awk '{print $1}')
           payload_sha256=$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')
           echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
@@ -832,6 +839,11 @@ jobs:
         with:
           name: internal-e2e2z-ios-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: unsigned-ios
+      # For the signing preflight the payload carries (#960). Pinned exactly
+      # like every other toolchain here; the job installs no dependencies.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
       - name: Verify source-bound artifact
         env:
           EXPECTED_ARCHIVE_SHA256: ${{ needs.ios-build.outputs.artifact_sha256 }}
@@ -844,10 +856,11 @@ jobs:
           [[ "$EXPECTED_ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid expected iOS archive digest" >&2; exit 1; }
           [[ "$EXPECTED_PAYLOAD_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid expected iOS payload digest" >&2; exit 1; }
           expected_members=$(printf '%s\n' \
-            ./CHECKSUMS.sha256 ./ExportOptions.plist ./e2e2z.xcarchive.zip ./source-record.json | LC_ALL=C sort)
+            ./CHECKSUMS.sha256 ./ExportOptions.plist ./e2e2z.xcarchive.zip ./source-record.json \
+            ./verify-signing-identity.mjs | LC_ALL=C sort)
           actual_members=$(cd unsigned-ios && find . -mindepth 1 -print | LC_ALL=C sort)
           [[ "$actual_members" == "$expected_members" ]] || { echo "unexpected unsigned iOS artifact inventory" >&2; exit 1; }
-          for member in CHECKSUMS.sha256 ExportOptions.plist e2e2z.xcarchive.zip source-record.json; do
+          for member in CHECKSUMS.sha256 ExportOptions.plist e2e2z.xcarchive.zip source-record.json verify-signing-identity.mjs; do
             [[ -f "unsigned-ios/$member" && ! -L "unsigned-ios/$member" ]] || { echo "unsafe unsigned iOS member: $member" >&2; exit 1; }
           done
           test "$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
@@ -933,15 +946,26 @@ jobs:
           security list-keychains -d user -s "$keychain"
           identity_sha=$(security find-identity -v -p codesigning "$keychain" | awk '/Apple Distribution: Corpora Inc/ {print $2; exit}')
           [[ "$identity_sha" =~ ^[0-9A-F]{40}$ ]] || { echo "expected exactly one Apple Distribution identity" >&2; exit 1; }
-          profile_authorizes_identity=false
-          certificate_index=0
-          while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$secret_dir/profile.plist" 2>/dev/null); do
-            printf '%s' "$certificate_base64" | base64 --decode > "$secret_dir/profile-certificate.der"
-            profile_sha=$(openssl x509 -inform DER -in "$secret_dir/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
-            [[ "$profile_sha" != "$identity_sha" ]] || profile_authorizes_identity=true
-            certificate_index=$((certificate_index + 1))
-          done
-          [[ "$profile_authorizes_identity" == true ]] || { echo "provisioning profile does not authorize the imported signing identity" >&2; exit 1; }
+          # #960. A profile authorizes specific certificates by embedding them.
+          # If this .p12 holds a different identity the archive still exports --
+          # for twenty more minutes -- and then fails at -exportArchive with a
+          # message that never names the mismatch. So assert the pairing here,
+          # along with the archive's own certificate/key coherence, the bundle
+          # id, the team, and both expiry dates (they differ: the certificate
+          # dies before the profile does, and its date is not the one anyone
+          # watches). The self-test runs first, so the verdict that follows
+          # comes from a checker just watched to reject a mismatched pair.
+          node unsigned-ios/verify-signing-identity.mjs --self-test
+          node unsigned-ios/verify-signing-identity.mjs \
+            --label 'e2e2z iOS App Store' \
+            --profile "$secret_dir/e2e2z.mobileprovision" \
+            --p12 "$secret_dir/distribution.p12" \
+            --p12-password-env CERTIFICATE_PASSWORD \
+            --keychain-identity-sha1 "$identity_sha" \
+            --bundle-id cash.free2z.e2e2z \
+            --team-id F9AV5HKF6N \
+            --expect-profile-uuid "$EXPECTED_PROFILE_UUID" \
+            --expect-profile-name "$EXPECTED_PROFILE_NAME"
           profile_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$profile_dir"
           profile_candidate="$profile_dir/$profile_uuid.mobileprovision"

--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -119,6 +119,23 @@ jobs:
           node scripts/check-f2z-images.mjs --self-test
           node scripts/check-f2z-images.mjs
 
+      # Unconditional for the third time, and for the most literal reason of
+      # the three: the check this exercises runs only in a protected release
+      # job, on a macOS runner, against secrets no pull request can see. There
+      # is no diff that "selects" it. If it were gated on anything, the release
+      # path's only preflight would be a script nobody had ever watched fail.
+      #
+      # It runs here rather than in a wallet job because it guards both release
+      # workflows (ZUULI and e2e2z) and lives at the repository root, outside
+      # every app's change detector. The suite builds throwaway self-signed
+      # certificates with openssl and proves the preflight accepts the pair the
+      # profile authorizes and rejects the one it does not -- no Apple
+      # credential, and nothing here touches the network. See #960.
+      - name: Verify the Apple signing preflight still rejects a mismatched identity
+        run: |
+          node scripts/verify-signing-identity.mjs --self-test
+          node --test scripts/verify-signing-identity.node-test.mjs
+
       # rs/rust-toolchain.toml and rs/crates/*/Cargo.toml restate
       # wallet/rust-toolchain.toml, and are registered in the script's own
       # TOOLCHAIN_RESTATEMENTS/MANIFESTS arrays rather than by flags here. A

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -751,13 +751,21 @@ jobs:
             </dict>
           </dict></plist>
           PLIST
+          # The signing preflight (#960) travels with the payload for the same
+          # reason ExportOptions.plist is written here: the signing job may not
+          # check the repository out, so the checker it runs has to arrive
+          # already bound to this source by the attestation over
+          # CHECKSUMS.sha256. Copied verbatim from the repository root, where
+          # verify-signing-identity.node-test.mjs holds it to its negative
+          # control on every pull request.
+          cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" unsigned-ios/verify-signing-identity.mjs
           version=${RELEASE_IDENTITY%+*}
           build=${RELEASE_IDENTITY#*+}
           jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
             --arg version "$version" --arg build "$build" \
             '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,version:$version,build:$build,kind:"ios-unsigned-xcarchive"}' \
             > unsigned-ios/source-record.json
-          (cd unsigned-ios && shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256)
+          (cd unsigned-ios && shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256)
           artifact_sha256=$(shasum -a 256 unsigned-ios/ZUULI.xcarchive.zip | awk '{print $1}')
           payload_sha256=$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')
           echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
@@ -793,6 +801,11 @@ jobs:
         with:
           name: internal-zuuli-ios-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: unsigned-ios
+      # For the signing preflight the payload carries (#960). Pinned exactly
+      # like the upload job's, and the job still installs no dependencies.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
       - name: Verify source-bound artifact
         env:
           EXPECTED_ARCHIVE_SHA256: ${{ needs.ios-build.outputs.artifact_sha256 }}
@@ -805,10 +818,11 @@ jobs:
           [[ "$EXPECTED_ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid expected iOS archive digest" >&2; exit 1; }
           [[ "$EXPECTED_PAYLOAD_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid expected iOS payload digest" >&2; exit 1; }
           expected_members=$(printf '%s\n' \
-            ./CHECKSUMS.sha256 ./ExportOptions.plist ./ZUULI.xcarchive.zip ./source-record.json | LC_ALL=C sort)
+            ./CHECKSUMS.sha256 ./ExportOptions.plist ./ZUULI.xcarchive.zip ./source-record.json \
+            ./verify-signing-identity.mjs | LC_ALL=C sort)
           actual_members=$(cd unsigned-ios && find . -mindepth 1 -print | LC_ALL=C sort)
           [[ "$actual_members" == "$expected_members" ]] || { echo "unexpected unsigned iOS artifact inventory" >&2; exit 1; }
-          for member in CHECKSUMS.sha256 ExportOptions.plist ZUULI.xcarchive.zip source-record.json; do
+          for member in CHECKSUMS.sha256 ExportOptions.plist ZUULI.xcarchive.zip source-record.json verify-signing-identity.mjs; do
             [[ -f "unsigned-ios/$member" && ! -L "unsigned-ios/$member" ]] || { echo "unsafe unsigned iOS member: $member" >&2; exit 1; }
           done
           test "$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
@@ -887,15 +901,26 @@ jobs:
           security list-keychains -d user -s "$keychain"
           identity_sha=$(security find-identity -v -p codesigning "$keychain" | awk '/Apple Distribution: Corpora Inc/ {print $2; exit}')
           [[ "$identity_sha" =~ ^[0-9A-F]{40}$ ]] || { echo "expected exactly one Apple Distribution identity" >&2; exit 1; }
-          profile_authorizes_identity=false
-          certificate_index=0
-          while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$secret_dir/profile.plist" 2>/dev/null); do
-            printf '%s' "$certificate_base64" | base64 --decode > "$secret_dir/profile-certificate.der"
-            profile_sha=$(openssl x509 -inform DER -in "$secret_dir/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
-            [[ "$profile_sha" != "$identity_sha" ]] || profile_authorizes_identity=true
-            certificate_index=$((certificate_index + 1))
-          done
-          [[ "$profile_authorizes_identity" == true ]] || { echo "provisioning profile does not authorize the imported signing identity" >&2; exit 1; }
+          # #960. A profile authorizes specific certificates by embedding them.
+          # If this .p12 holds a different identity the archive still builds --
+          # for twenty more minutes -- and then fails at -exportArchive with a
+          # message that never names the mismatch. So assert the pairing here,
+          # along with the archive's own certificate/key coherence, the bundle
+          # id, the team, and both expiry dates (they differ: the certificate
+          # dies before the profile does, and its date is not the one anyone
+          # watches). The self-test runs first, so the verdict that follows
+          # comes from a checker just watched to reject a mismatched pair.
+          node unsigned-ios/verify-signing-identity.mjs --self-test
+          node unsigned-ios/verify-signing-identity.mjs \
+            --label 'ZUULI iOS App Store' \
+            --profile "$secret_dir/zuuli.mobileprovision" \
+            --p12 "$secret_dir/distribution.p12" \
+            --p12-password-env CERTIFICATE_PASSWORD \
+            --keychain-identity-sha1 "$identity_sha" \
+            --bundle-id cash.free2z.zuuli \
+            --team-id F9AV5HKF6N \
+            --expect-profile-uuid e5ead62c-83ec-4e54-abb6-4770833b5e0d \
+            --expect-profile-name 'ZUULI App Store CI'
           profile_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$profile_dir"
           profile_candidate="$profile_dir/$profile_uuid.mobileprovision"
@@ -1423,10 +1448,15 @@ jobs:
           cp "${dmgs[0]}" unsigned-macos/ZUULI-layout.dmg
           cp src-tauri/Entitlements.plist unsigned-macos/Entitlements.plist
           cp src-tauri/Info.macos.plist unsigned-macos/Info.macos.plist
+          # The signing preflight (#960), carried into the protected job the
+          # same way the iOS lane carries it: that job may not check the
+          # repository out, so the checker arrives bound to this source by the
+          # attestation over CHECKSUMS.sha256.
+          cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" unsigned-macos/verify-signing-identity.mjs
           jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
             '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,kind:"macos-unsigned-app-and-layout"}' \
             > unsigned-macos/source-record.json
-          (cd unsigned-macos && shasum -a 256 Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json > CHECKSUMS.sha256)
+          (cd unsigned-macos && shasum -a 256 Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256)
           artifact_sha256=$(shasum -a 256 unsigned-macos/ZUULI.app.zip | awk '{print $1}')
           payload_sha256=$(shasum -a 256 unsigned-macos/CHECKSUMS.sha256 | awk '{print $1}')
           echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
@@ -1466,6 +1496,11 @@ jobs:
         with:
           name: internal-zuuli-macos-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: unsigned-macos
+      # For the signing preflight the payload carries (#960). Pinned exactly
+      # like the upload job's, and the job still installs no dependencies.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
       - name: Verify source-bound artifact
         env:
           EXPECTED_APP_SHA256: ${{ needs.macos-build.outputs.artifact_sha256 }}
@@ -1478,10 +1513,11 @@ jobs:
           [[ "$EXPECTED_APP_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid expected macOS app digest" >&2; exit 1; }
           [[ "$EXPECTED_PAYLOAD_SHA256" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid expected macOS payload digest" >&2; exit 1; }
           expected_members=$(printf '%s\n' \
-            ./CHECKSUMS.sha256 ./Entitlements.plist ./Info.macos.plist ./ZUULI-layout.dmg ./ZUULI.app.zip ./source-record.json | LC_ALL=C sort)
+            ./CHECKSUMS.sha256 ./Entitlements.plist ./Info.macos.plist ./ZUULI-layout.dmg ./ZUULI.app.zip \
+            ./source-record.json ./verify-signing-identity.mjs | LC_ALL=C sort)
           actual_members=$(cd unsigned-macos && find . -mindepth 1 -print | LC_ALL=C sort)
           [[ "$actual_members" == "$expected_members" ]] || { echo "unexpected unsigned macOS artifact inventory" >&2; exit 1; }
-          for member in CHECKSUMS.sha256 Entitlements.plist Info.macos.plist ZUULI-layout.dmg ZUULI.app.zip source-record.json; do
+          for member in CHECKSUMS.sha256 Entitlements.plist Info.macos.plist ZUULI-layout.dmg ZUULI.app.zip source-record.json verify-signing-identity.mjs; do
             [[ -f "unsigned-macos/$member" && ! -L "unsigned-macos/$member" ]] || { echo "unsafe unsigned macOS member: $member" >&2; exit 1; }
           done
           test "$(shasum -a 256 unsigned-macos/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
@@ -1588,15 +1624,21 @@ jobs:
           [[ "$identity_count" -eq 1 ]] || { echo "expected exactly one Developer ID signing identity" >&2; exit 1; }
           identity_sha=$(security find-identity -v -p codesigning "$keychain" | grep -F "$APPLE_SIGNING_IDENTITY" | awk '{print $2}')
           [[ "$identity_sha" =~ ^[0-9A-F]{40}$ ]] || { echo "invalid Developer ID signing identity digest" >&2; exit 1; }
-          profile_authorizes_identity=false
-          certificate_index=0
-          while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$secret_dir/profile.plist" 2>/dev/null); do
-            printf '%s' "$certificate_base64" | base64 --decode > "$secret_dir/profile-certificate.der"
-            profile_sha=$(openssl x509 -inform DER -in "$secret_dir/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
-            [[ "$profile_sha" != "$identity_sha" ]] || profile_authorizes_identity=true
-            certificate_index=$((certificate_index + 1))
-          done
-          [[ "$profile_authorizes_identity" == true ]] || { echo "Developer ID profile does not authorize the imported signing identity" >&2; exit 1; }
+          # #960, the Developer ID half of it. Same failure mode as the iOS
+          # lane -- a certificate no profile authorizes signs an app that only
+          # fails later -- plus the expiry the release calendar does not track:
+          # the Developer ID certificate expires on its own schedule, well
+          # before the profile that embeds it. The self-test runs first, so the
+          # verdict comes from a checker just watched to reject a mismatch.
+          node unsigned-macos/verify-signing-identity.mjs --self-test
+          node unsigned-macos/verify-signing-identity.mjs \
+            --label 'ZUULI macOS Developer ID' \
+            --profile "$secret_dir/zuuli.provisionprofile" \
+            --p12 "$secret_dir/developer-id.p12" \
+            --p12-password-env CERTIFICATE_PASSWORD \
+            --keychain-identity-sha1 "$identity_sha" \
+            --bundle-id cash.free2z.zuuli \
+            --team-id F9AV5HKF6N
           verify_keychain_entitlements() {
             local entitlements=$1
             plutil -lint "$entitlements"

--- a/scripts/verify-signing-identity.mjs
+++ b/scripts/verify-signing-identity.mjs
@@ -1,0 +1,1045 @@
+#!/usr/bin/env node
+
+// Assert that the Apple signing certificate we are about to sign with is one
+// the provisioning profile actually authorizes -- before `xcodebuild archive`
+// or `xcodebuild -exportArchive`, not twenty minutes into a macOS runner.
+//
+// WHY THIS EXISTS (issue #960)
+//
+// A provisioning profile authorizes a specific set of certificates by embedding
+// their DER bytes in `DeveloperCertificates`. If the imported `.p12` holds a
+// different identity, every step up to export succeeds: the keychain import
+// works, `security find-identity` lists a perfectly valid Apple Distribution
+// identity, the archive builds. The failure arrives only at
+// `xcodebuild -exportArchive`, near the end of the job, worded in a way that
+// never names the mismatch.
+//
+// Two Apple Distribution certificates exist for team F9AV5HKF6N:
+//
+//   5F:06:...:B5:B7  expires 2027-08-08  <- the only one any profile embeds
+//   D1:78:...:E8:F9  expires 2027-04-16  <- no profile authorizes it
+//
+// and the trap is that `security find-identity -v -p codesigning` on the dev
+// machine returns only the second, because the first certificate's private key
+// is in no keychain -- it lives solely inside a .p12. Deriving the identity
+// from the keychain therefore yields a key no profile accepts. That wrong
+// certificate was in fact installed into the `e2e2z-app-stores` environment:
+// all four secrets present, correctly named, and wrong in content. A presence
+// check cannot see that class of bug; only comparing the material can.
+//
+// Note also that the two expiry dates differ. The profile runs to 2027-08-08
+// and the certificate dies first, on 2027-04-16 -- and the certificate's date
+// is not the one anyone watches. So both are reported, always, on success as
+// well as on failure.
+//
+// WHAT IT ASSERTS
+//
+//   1. profile-authorizes-certificate  the leaf certificate's SHA-1 appears in
+//                                      the profile's DeveloperCertificates
+//   2. certificate-key-pair            the .p12's certificate and private key
+//                                      are the same key pair (catches a
+//                                      truncated or mis-assembled export)
+//   3. keychain-identity               the identity the keychain will sign with
+//                                      is the leaf we just checked (optional)
+//   4. application-identifier          the profile's entitlement equals
+//                                      <team>.<bundle id>
+//   5. team-identifier                 the profile's TeamIdentifier equals the
+//                                      expected team
+//   6. profile-validity                now is inside the profile's window
+//   7. certificate-validity            now is inside the certificate's window
+//
+// 6 and 7 also warn when either date is inside --warn-days (default 30).
+//
+// PORTABILITY, AND WHY IT IS NOT A SHELL SCRIPT
+//
+// `security` and `PlistBuddy`/`plutil` are macOS-only, so a check built on them
+// can only be tested where the credentials are -- which is to say, never. The
+// parsing and comparison here is pure Node: the plist parser below is
+// hand-written, certificates are read with node:crypto's X509Certificate, and
+// fingerprints are the SHA-1 of the DER, which is exactly what `openssl x509
+// -fingerprint -sha1` prints. `security cms -D` is used to unwrap a CMS-signed
+// profile when it is available, and `openssl smime -verify` when it is not, so
+// the whole path -- including a real .mobileprovision and a real .p12 -- runs
+// on Linux CI with no Apple credentials at all. See --self-test and
+// scripts/verify-signing-identity.node-test.mjs.
+//
+// The release workflows cannot check the repository out in a signing job (the
+// credential boundary forbids it), so they carry this file into the job inside
+// the attested unsigned artifact, the same way asc-testflight.mjs reaches the
+// upload job.
+
+import { spawnSync } from "node:child_process";
+import { X509Certificate, createHash, createPrivateKey, createPublicKey } from "node:crypto";
+import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+const MINIMUM_NODE_MAJOR = 20;
+const DEFAULT_WARN_DAYS = 30;
+const DAY_MS = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// plist
+// ---------------------------------------------------------------------------
+
+const ENTITIES = new Map([
+  ["amp", "&"],
+  ["lt", "<"],
+  ["gt", ">"],
+  ["quot", '"'],
+  ["apos", "'"],
+]);
+
+function decodeEntities(text) {
+  return text.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (match, body) => {
+    if (body.startsWith("#x") || body.startsWith("#X")) {
+      return String.fromCodePoint(Number.parseInt(body.slice(2), 16));
+    }
+    if (body.startsWith("#")) {
+      return String.fromCodePoint(Number.parseInt(body.slice(1), 10));
+    }
+    const replacement = ENTITIES.get(body);
+    if (replacement === undefined) throw new Error(`unsupported XML entity &${body};`);
+    return replacement;
+  });
+}
+
+// A deliberately small XML-plist reader. It accepts exactly the element set
+// Apple emits in a decoded provisioning profile and throws on anything else,
+// because silently ignoring an element it does not understand is how a parser
+// starts reporting a profile that is not the profile on disk.
+export function parsePlistXml(source) {
+  const src = String(source);
+  let index = 0;
+
+  const fail = (message) => {
+    throw new Error(`plist parse error at offset ${index}: ${message}`);
+  };
+
+  const skipIgnorable = () => {
+    for (;;) {
+      while (index < src.length && /\s/.test(src[index])) index += 1;
+      if (src.startsWith("<?", index)) {
+        const end = src.indexOf("?>", index);
+        if (end < 0) fail("unterminated processing instruction");
+        index = end + 2;
+        continue;
+      }
+      if (src.startsWith("<!--", index)) {
+        const end = src.indexOf("-->", index);
+        if (end < 0) fail("unterminated comment");
+        index = end + 3;
+        continue;
+      }
+      if (src.startsWith("<!", index)) {
+        const end = src.indexOf(">", index);
+        if (end < 0) fail("unterminated declaration");
+        index = end + 1;
+        continue;
+      }
+      return;
+    }
+  };
+
+  const readTag = () => {
+    skipIgnorable();
+    if (src[index] !== "<") fail("expected an element");
+    const end = src.indexOf(">", index);
+    if (end < 0) fail("unterminated element");
+    let raw = src.slice(index + 1, end);
+    index = end + 1;
+    const closing = raw.startsWith("/");
+    if (closing) raw = raw.slice(1);
+    const selfClosing = raw.endsWith("/");
+    if (selfClosing) raw = raw.slice(0, -1);
+    const name = raw.trim().split(/\s+/)[0];
+    if (!name) fail("empty element name");
+    return { name, closing, selfClosing };
+  };
+
+  const readTextUntilClose = (name) => {
+    const close = `</${name}>`;
+    const end = src.indexOf(close, index);
+    if (end < 0) fail(`unterminated <${name}>`);
+    const raw = src.slice(index, end);
+    index = end + close.length;
+    return decodeEntities(raw);
+  };
+
+  const parseValue = (tag) => {
+    if (tag.closing) fail(`unexpected </${tag.name}>`);
+    switch (tag.name) {
+      case "dict": {
+        const value = new Map();
+        if (tag.selfClosing) return value;
+        for (;;) {
+          const next = readTag();
+          if (next.closing && next.name === "dict") return value;
+          if (next.name !== "key" || next.closing || next.selfClosing) fail("expected <key>");
+          const key = readTextUntilClose("key");
+          value.set(key, parseValue(readTag()));
+        }
+      }
+      case "array": {
+        const value = [];
+        if (tag.selfClosing) return value;
+        for (;;) {
+          const next = readTag();
+          if (next.closing && next.name === "array") return value;
+          value.push(parseValue(next));
+        }
+      }
+      case "string":
+        return tag.selfClosing ? "" : readTextUntilClose("string");
+      case "data": {
+        if (tag.selfClosing) return Buffer.alloc(0);
+        const encoded = readTextUntilClose("data").replace(/\s+/g, "");
+        if (!/^[A-Za-z0-9+/]*={0,2}$/.test(encoded)) fail("<data> is not base64");
+        return Buffer.from(encoded, "base64");
+      }
+      case "date": {
+        const text = tag.selfClosing ? "" : readTextUntilClose("date");
+        const value = new Date(text);
+        if (Number.isNaN(value.getTime())) fail(`invalid <date> ${text}`);
+        return value;
+      }
+      case "integer":
+      case "real": {
+        const text = tag.selfClosing ? "" : readTextUntilClose(tag.name);
+        const value = Number(text.trim());
+        if (!Number.isFinite(value)) fail(`invalid <${tag.name}> ${text}`);
+        return value;
+      }
+      case "true":
+      case "false": {
+        if (!tag.selfClosing) readTextUntilClose(tag.name);
+        return tag.name === "true";
+      }
+      default:
+        return fail(`unsupported plist element <${tag.name}>`);
+    }
+  };
+
+  skipIgnorable();
+  let tag = readTag();
+  if (tag.name === "plist" && !tag.closing) tag = readTag();
+  return parseValue(tag);
+}
+
+// ---------------------------------------------------------------------------
+// certificates
+// ---------------------------------------------------------------------------
+
+export function certificateFingerprintSha1(der) {
+  const digest = createHash("sha1").update(der).digest("hex").toUpperCase();
+  return digest.replace(/(.{2})(?=.)/g, "$1:");
+}
+
+export function normalizeFingerprint(value) {
+  return String(value).trim().toUpperCase().replace(/[^0-9A-F]/g, "");
+}
+
+function commonName(certificate) {
+  const subject = String(certificate.subject ?? "");
+  const match = subject.split("\n").find((line) => line.startsWith("CN="));
+  return match ? match.slice(3) : subject.replace(/\n/g, ", ");
+}
+
+function publicKeyDigest(keyObject) {
+  return createHash("sha256")
+    .update(keyObject.export({ type: "spki", format: "der" }))
+    .digest("hex");
+}
+
+export function describeCertificate(der) {
+  const certificate = new X509Certificate(der);
+  const notBefore = certificate.validFromDate ?? new Date(certificate.validFrom);
+  const notAfter = certificate.validToDate ?? new Date(certificate.validTo);
+  if (Number.isNaN(notBefore.getTime()) || Number.isNaN(notAfter.getTime())) {
+    throw new Error("certificate carries an unreadable validity window");
+  }
+  return {
+    fingerprint: certificateFingerprintSha1(certificate.raw),
+    commonName: commonName(certificate),
+    notBefore,
+    notAfter,
+    publicKeySha256: publicKeyDigest(certificate.publicKey),
+    der: certificate.raw,
+  };
+}
+
+// PEM bundles come back from openssl with human-readable preamble between the
+// blocks; take only the blocks.
+export function splitPemCertificates(pem) {
+  const blocks = String(pem).match(
+    /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g,
+  );
+  return blocks ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// external tools
+// ---------------------------------------------------------------------------
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "buffer",
+    maxBuffer: 32 * 1024 * 1024,
+    ...options,
+  });
+  if (result.error) {
+    return { ok: false, stdout: Buffer.alloc(0), stderr: String(result.error.message) };
+  }
+  return {
+    ok: result.status === 0,
+    stdout: result.stdout ?? Buffer.alloc(0),
+    stderr: (result.stderr ?? Buffer.alloc(0)).toString("utf8"),
+  };
+}
+
+// A .mobileprovision / .provisionprofile is a CMS SignedData envelope around
+// the plist. `security cms -D` is the Apple way and is used when present;
+// `openssl smime -verify -noverify` reads the same envelope everywhere else,
+// which is what makes this testable on Linux.
+export function decodeProvisioningProfile(bytes, { openssl = "openssl", security = "/usr/bin/security" } = {}) {
+  const head = bytes.subarray(0, 8).toString("latin1");
+  if (head.startsWith("<?xml") || head.startsWith("<plist")) {
+    return { plist: bytes.toString("utf8"), decoder: "already-decoded" };
+  }
+  if (head.startsWith("bplist")) {
+    throw new Error(
+      "the provisioning profile decoded to a binary plist; convert it with `plutil -convert xml1` first",
+    );
+  }
+
+  const scratch = mkdtempSync(join(tmpdir(), "verify-signing-identity-cms."));
+  try {
+    const profilePath = join(scratch, "profile.bin");
+    writeFileSync(profilePath, bytes, { mode: 0o600 });
+    const attempts = [];
+    if (existsSync(security)) {
+      attempts.push({ decoder: "security cms -D", command: security, args: ["cms", "-D", "-i", profilePath] });
+    }
+    attempts.push({
+      decoder: "openssl smime -verify -noverify",
+      command: openssl,
+      args: ["smime", "-verify", "-noverify", "-inform", "DER", "-in", profilePath],
+    });
+    attempts.push({
+      decoder: "openssl cms -verify -no_verify",
+      command: openssl,
+      args: ["cms", "-verify", "-no_verify", "-inform", "DER", "-in", profilePath],
+    });
+
+    const errors = [];
+    for (const attempt of attempts) {
+      const result = run(attempt.command, attempt.args);
+      if (result.ok && result.stdout.length > 0) {
+        return { plist: result.stdout.toString("utf8"), decoder: attempt.decoder };
+      }
+      errors.push(`${attempt.decoder}: ${result.stderr.trim() || "produced no output"}`);
+    }
+    throw new Error(`could not decode the provisioning profile\n  ${errors.join("\n  ")}`);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+// openssl 3 refuses the RC2-40 encryption Keychain Access used for years
+// unless -legacy is passed; LibreSSL (what /usr/bin/openssl is on macOS) has no
+// such flag and reads those archives directly. Try plain first, then -legacy,
+// and report both failures rather than one.
+export function extractPkcs12(p12Path, passwordEnvName, { openssl = "openssl", env = process.env } = {}) {
+  if (!(passwordEnvName in env)) {
+    throw new Error(`${passwordEnvName} is not set, so the .p12 cannot be opened`);
+  }
+  // Nothing is written to disk here: the private key comes back on openssl's
+  // stdout and stays in memory.
+  {
+    const attempts = [[], ["-legacy"]];
+    const errors = [];
+    let certificatesPem = null;
+    let keyPem = null;
+    for (const extra of attempts) {
+      const certificates = run(
+        openssl,
+        ["pkcs12", "-in", p12Path, "-passin", `env:${passwordEnvName}`, "-nokeys", "-clcerts", ...extra],
+        { env },
+      );
+      const key = run(
+        openssl,
+        ["pkcs12", "-in", p12Path, "-passin", `env:${passwordEnvName}`, "-nocerts", "-nodes", ...extra],
+        { env },
+      );
+      if (certificates.ok && key.ok) {
+        certificatesPem = certificates.stdout.toString("utf8");
+        keyPem = key.stdout.toString("utf8");
+        break;
+      }
+      const label = extra.length === 0 ? "openssl pkcs12" : "openssl pkcs12 -legacy";
+      errors.push(`${label}: ${(certificates.ok ? key.stderr : certificates.stderr).trim() || "failed"}`);
+    }
+    if (certificatesPem === null || keyPem === null) {
+      throw new Error(
+        `could not read the signing archive with openssl (wrong password, or an encoding openssl will not open)\n  ${errors.join("\n  ")}`,
+      );
+    }
+
+    let certificates = splitPemCertificates(certificatesPem);
+    if (certificates.length === 0) {
+      const all = run(openssl, ["pkcs12", "-in", p12Path, "-passin", `env:${passwordEnvName}`, "-nokeys"], { env });
+      certificates = all.ok ? splitPemCertificates(all.stdout.toString("utf8")) : [];
+    }
+    if (certificates.length === 0) {
+      throw new Error("the signing archive contains no certificate");
+    }
+
+    const privateKey = createPrivateKey(keyPem);
+    const privateKeyPublicSha256 = publicKeyDigest(createPublicKey(privateKey));
+    const described = certificates.map((pem) => describeCertificate(Buffer.from(pem, "utf8")));
+    const matching = described.filter((entry) => entry.publicKeySha256 === privateKeyPublicSha256);
+    const leaf = matching.length === 1 ? matching[0] : described[0];
+    return {
+      leaf,
+      certificateCount: described.length,
+      privateKeyPublicSha256,
+      privateKeyType: privateKey.asymmetricKeyType ?? "unknown",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// profile model
+// ---------------------------------------------------------------------------
+
+export function readProfile(plistXml) {
+  const root = parsePlistXml(plistXml);
+  if (!(root instanceof Map)) throw new Error("the provisioning profile is not a plist dictionary");
+  const entitlements = root.get("Entitlements");
+  const developerCertificates = root.get("DeveloperCertificates") ?? [];
+  if (!Array.isArray(developerCertificates)) {
+    throw new Error("the profile's DeveloperCertificates is not an array");
+  }
+  const certificates = developerCertificates.map((der) => {
+    if (!Buffer.isBuffer(der)) throw new Error("a DeveloperCertificates entry is not <data>");
+    return describeCertificate(der);
+  });
+  const applicationIdentifier = entitlements instanceof Map
+    ? entitlements.get("application-identifier") ?? entitlements.get("com.apple.application-identifier")
+    : undefined;
+  const teamIdentifiers = root.get("TeamIdentifier");
+  return {
+    name: root.get("Name"),
+    uuid: root.get("UUID"),
+    teamIdentifiers: Array.isArray(teamIdentifiers) ? teamIdentifiers : [],
+    applicationIdentifier,
+    creationDate: root.get("CreationDate"),
+    expirationDate: root.get("ExpirationDate"),
+    certificates,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// evaluation
+// ---------------------------------------------------------------------------
+
+const iso = (date) => (date instanceof Date ? date.toISOString().replace(/\.\d{3}Z$/, "Z") : "unknown");
+const daysUntil = (date, now) =>
+  date instanceof Date ? Math.floor((date.getTime() - now.getTime()) / DAY_MS) : Number.NaN;
+
+// Pure: everything above turns bytes into these two plain objects, and this
+// decides. That split is what lets the negative control run anywhere.
+export function evaluateSigningIdentity({
+  profile,
+  leaf,
+  expected = {},
+  now = new Date(),
+  warnDays = DEFAULT_WARN_DAYS,
+}) {
+  const assertions = [];
+  const add = (name, status, detail) => assertions.push({ name, status, detail });
+
+  const leafFingerprint = normalizeFingerprint(leaf.fingerprint);
+  const authorized = profile.certificates.map((certificate) => ({
+    ...certificate,
+    normalized: normalizeFingerprint(certificate.fingerprint),
+  }));
+  const match = authorized.find((certificate) => certificate.normalized === leafFingerprint);
+
+  if (authorized.length === 0) {
+    add(
+      "profile-authorizes-certificate",
+      "fail",
+      "the provisioning profile embeds no DeveloperCertificates at all, so it authorizes nothing",
+    );
+  } else if (match) {
+    add(
+      "profile-authorizes-certificate",
+      "pass",
+      `the profile authorizes ${leaf.fingerprint} (${leaf.commonName})`,
+    );
+  } else {
+    add(
+      "profile-authorizes-certificate",
+      "fail",
+      [
+        `the imported certificate ${leaf.fingerprint} (${leaf.commonName}, expires ${iso(leaf.notAfter)})`,
+        `is not among the ${authorized.length} certificate(s) this profile authorizes:`,
+        ...authorized.map(
+          (certificate) =>
+            `  ${certificate.fingerprint} (${certificate.commonName}, expires ${iso(certificate.notAfter)})`,
+        ),
+        "signing would still produce an archive and fail only at `xcodebuild -exportArchive`.",
+        "the .p12 in the environment holds the wrong identity, or the profile is not the one issued for it.",
+      ].join("\n"),
+    );
+  }
+
+  if (expected.privateKeyPublicSha256 !== undefined) {
+    if (expected.privateKeyPublicSha256 === leaf.publicKeySha256) {
+      add(
+        "certificate-key-pair",
+        "pass",
+        `the archive's certificate and private key are one ${expected.privateKeyType ?? "key"} pair (SPKI ${leaf.publicKeySha256.slice(0, 16)}…)`,
+      );
+    } else {
+      add(
+        "certificate-key-pair",
+        "fail",
+        [
+          "the .p12's certificate and private key are different key pairs -- the export is truncated or mis-assembled.",
+          `  certificate public key SPKI sha256 ${leaf.publicKeySha256}`,
+          `  private key public key SPKI sha256 ${expected.privateKeyPublicSha256}`,
+        ].join("\n"),
+      );
+    }
+  }
+
+  if (expected.keychainIdentitySha1 !== undefined) {
+    const keychain = normalizeFingerprint(expected.keychainIdentitySha1);
+    if (keychain.length !== 40) {
+      add("keychain-identity", "fail", `"${expected.keychainIdentitySha1}" is not a SHA-1 identity digest`);
+    } else if (keychain === leafFingerprint) {
+      add("keychain-identity", "pass", `the keychain will sign with ${leaf.fingerprint}`);
+    } else {
+      add(
+        "keychain-identity",
+        "fail",
+        [
+          "the identity the keychain would sign with is not the certificate checked above.",
+          `  keychain identity ${keychain.replace(/(.{2})(?=.)/g, "$1:")}`,
+          `  archive leaf      ${leaf.fingerprint}`,
+        ].join("\n"),
+      );
+    }
+  }
+
+  if (expected.bundleId !== undefined) {
+    const team = expected.teamId ?? profile.teamIdentifiers[0];
+    const wanted = `${team}.${expected.bundleId}`;
+    if (profile.applicationIdentifier === wanted) {
+      add("application-identifier", "pass", `the profile is issued for ${wanted}`);
+    } else {
+      add(
+        "application-identifier",
+        "fail",
+        `the profile is issued for ${profile.applicationIdentifier ?? "no application-identifier"}, not ${wanted}`,
+      );
+    }
+  }
+
+  if (expected.teamId !== undefined) {
+    if (profile.teamIdentifiers.length === 1 && profile.teamIdentifiers[0] === expected.teamId) {
+      add("team-identifier", "pass", `the profile belongs to team ${expected.teamId}`);
+    } else {
+      add(
+        "team-identifier",
+        "fail",
+        `expected exactly team ${expected.teamId}; the profile carries [${profile.teamIdentifiers.join(", ")}]`,
+      );
+    }
+  }
+
+  if (expected.profileUuid !== undefined) {
+    add(
+      "profile-uuid",
+      profile.uuid === expected.profileUuid ? "pass" : "fail",
+      `profile UUID ${profile.uuid ?? "absent"}${profile.uuid === expected.profileUuid ? "" : ` does not equal the expected ${expected.profileUuid}`}`,
+    );
+  }
+  if (expected.profileName !== undefined) {
+    add(
+      "profile-name",
+      profile.name === expected.profileName ? "pass" : "fail",
+      `profile name ${JSON.stringify(profile.name ?? null)}${profile.name === expected.profileName ? "" : ` does not equal the expected ${JSON.stringify(expected.profileName)}`}`,
+    );
+  }
+
+  const profileDays = daysUntil(profile.expirationDate, now);
+  if (!(profile.expirationDate instanceof Date)) {
+    add("profile-validity", "fail", "the profile carries no readable ExpirationDate");
+  } else if (profile.creationDate instanceof Date && profile.creationDate.getTime() > now.getTime()) {
+    add("profile-validity", "fail", `the profile is not valid until ${iso(profile.creationDate)}`);
+  } else if (profileDays < 0) {
+    add("profile-validity", "fail", `the provisioning profile expired on ${iso(profile.expirationDate)}`);
+  } else if (profileDays <= warnDays) {
+    add(
+      "profile-validity",
+      "warn",
+      `the provisioning profile expires on ${iso(profile.expirationDate)} -- ${profileDays} day(s) from now`,
+    );
+  } else {
+    add("profile-validity", "pass", `the profile is valid until ${iso(profile.expirationDate)} (${profileDays} days)`);
+  }
+
+  const certificateDays = daysUntil(leaf.notAfter, now);
+  const alsoProfile = profile.expirationDate instanceof Date
+    ? ` (the profile runs to ${iso(profile.expirationDate)}, so the certificate is what expires first)`
+    : "";
+  if (leaf.notBefore instanceof Date && leaf.notBefore.getTime() > now.getTime()) {
+    add("certificate-validity", "fail", `the signing certificate is not valid until ${iso(leaf.notBefore)}`);
+  } else if (certificateDays < 0) {
+    add(
+      "certificate-validity",
+      "fail",
+      `the signing certificate expired on ${iso(leaf.notAfter)}${alsoProfile}`,
+    );
+  } else if (certificateDays <= warnDays) {
+    add(
+      "certificate-validity",
+      "warn",
+      `the signing certificate expires on ${iso(leaf.notAfter)} -- ${certificateDays} day(s) from now${alsoProfile}`,
+    );
+  } else {
+    add(
+      "certificate-validity",
+      "pass",
+      `the certificate is valid until ${iso(leaf.notAfter)} (${certificateDays} days)`,
+    );
+  }
+
+  const failures = assertions.filter((assertion) => assertion.status === "fail");
+  const warnings = assertions.filter((assertion) => assertion.status === "warn");
+  return { ok: failures.length === 0, assertions, failures, warnings };
+}
+
+export function renderReport({ profile, leaf, verdict, now, context = {} }) {
+  const lines = [];
+  lines.push("Apple signing preflight");
+  if (context.label) lines.push(`  target                ${context.label}`);
+  if (context.decoder) lines.push(`  profile decoded by    ${context.decoder}`);
+  lines.push(`  evaluated at          ${iso(now)}`);
+  lines.push("");
+  lines.push("  imported certificate");
+  lines.push(`    sha-1               ${leaf.fingerprint}`);
+  lines.push(`    subject             ${leaf.commonName}`);
+  lines.push(`    not before          ${iso(leaf.notBefore)}`);
+  lines.push(`    not after           ${iso(leaf.notAfter)}  (${daysUntil(leaf.notAfter, now)} days)`);
+  lines.push("");
+  lines.push("  provisioning profile");
+  lines.push(`    name                ${profile.name ?? "(none)"}`);
+  lines.push(`    uuid                ${profile.uuid ?? "(none)"}`);
+  lines.push(`    team                ${profile.teamIdentifiers.join(", ") || "(none)"}`);
+  lines.push(`    app identifier      ${profile.applicationIdentifier ?? "(none)"}`);
+  lines.push(
+    `    expires             ${iso(profile.expirationDate)}  (${daysUntil(profile.expirationDate, now)} days)`,
+  );
+  lines.push(`    authorizes          ${profile.certificates.length} certificate(s)`);
+  for (const certificate of profile.certificates) {
+    const marker = normalizeFingerprint(certificate.fingerprint) === normalizeFingerprint(leaf.fingerprint)
+      ? "<= imported"
+      : "";
+    lines.push(
+      `      ${certificate.fingerprint}  ${iso(certificate.notAfter)}  ${certificate.commonName} ${marker}`.trimEnd(),
+    );
+  }
+  lines.push("");
+  for (const assertion of verdict.assertions) {
+    const badge = assertion.status === "pass" ? "PASS" : assertion.status === "warn" ? "WARN" : "FAIL";
+    const [first, ...rest] = assertion.detail.split("\n");
+    lines.push(`  ${badge} ${assertion.name}: ${first}`);
+    for (const line of rest) lines.push(`       ${line}`);
+  }
+  if (!verdict.ok) {
+    lines.push("");
+    lines.push(
+      `  FAILED: ${verdict.failures.map((failure) => failure.name).join(", ")} -- refusing to sign.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const OPTIONS = {
+  profile: { type: "string" },
+  p12: { type: "string" },
+  "p12-password-env": { type: "string" },
+  certificate: { type: "string" },
+  "keychain-identity-sha1": { type: "string" },
+  "bundle-id": { type: "string" },
+  "team-id": { type: "string" },
+  "expect-profile-uuid": { type: "string" },
+  "expect-profile-name": { type: "string" },
+  "warn-days": { type: "string" },
+  now: { type: "string" },
+  label: { type: "string" },
+  openssl: { type: "string" },
+  "allow-missing-inputs": { type: "boolean" },
+  "self-test": { type: "boolean" },
+  help: { type: "boolean" },
+};
+
+const USAGE = `usage: verify-signing-identity.mjs --profile <file> (--p12 <file> --p12-password-env <NAME> | --certificate <file>) [options]
+
+  --profile <file>                 .mobileprovision/.provisionprofile, or an already decoded plist
+  --p12 <file>                     the signing archive that was imported into the keychain
+  --p12-password-env <NAME>        environment variable holding the .p12 password (never an argument)
+  --certificate <file>             leaf certificate (PEM or DER), instead of --p12
+  --keychain-identity-sha1 <hex>   the identity 'security find-identity' resolved, to bind what will sign
+  --bundle-id <id>                 e.g. cash.free2z.zuuli
+  --team-id <id>                   e.g. F9AV5HKF6N (defaults to $APPLE_TEAM_ID)
+  --expect-profile-uuid <uuid>     optional exact profile UUID
+  --expect-profile-name <name>     optional exact profile name
+  --warn-days <n>                  warn when either expiry is within n days (default ${DEFAULT_WARN_DAYS})
+  --now <iso>                      evaluate against this instant instead of the clock
+  --label <text>                   a name for this signing path, printed in the report
+  --allow-missing-inputs           print a SKIP line and exit 0 when no Apple inputs are present
+  --self-test                      build throwaway certificates and prove the check still rejects a mismatch
+`;
+
+function readInputs(values, env) {
+  const profilePath = values.profile;
+  const p12Path = values.p12;
+  const certificatePath = values.certificate;
+  const present = [profilePath, p12Path, certificatePath].filter(
+    (candidate) => candidate !== undefined && candidate !== "" && existsSync(candidate),
+  );
+  if (present.length === 0) {
+    if (values["allow-missing-inputs"]) return { skip: true };
+    throw new Error(
+      "no Apple signing inputs were given. Pass --profile with --p12 or --certificate, or --allow-missing-inputs for a path that legitimately has none.",
+    );
+  }
+  if (!profilePath || !existsSync(profilePath)) {
+    throw new Error("a provisioning profile is required: pass --profile");
+  }
+
+  const { plist, decoder } = decodeProvisioningProfile(readFileSync(profilePath), {
+    openssl: values.openssl ?? "openssl",
+  });
+  const profile = readProfile(plist);
+
+  let leaf;
+  let expectedKeyPair = {};
+  if (p12Path && existsSync(p12Path)) {
+    const passwordEnv = values["p12-password-env"];
+    if (!passwordEnv) throw new Error("--p12 requires --p12-password-env");
+    const extracted = extractPkcs12(p12Path, passwordEnv, { openssl: values.openssl ?? "openssl", env });
+    leaf = extracted.leaf;
+    expectedKeyPair = {
+      privateKeyPublicSha256: extracted.privateKeyPublicSha256,
+      privateKeyType: extracted.privateKeyType,
+    };
+  } else if (certificatePath && existsSync(certificatePath)) {
+    leaf = describeCertificate(readFileSync(certificatePath));
+  } else {
+    throw new Error("a signing certificate is required: pass --p12 or --certificate");
+  }
+
+  return { skip: false, profile, leaf, decoder, expectedKeyPair };
+}
+
+export function runCli(argv, { env = process.env, stdout = process.stdout, stderr = process.stderr } = {}) {
+  let values;
+  try {
+    ({ values } = parseArgs({ args: argv, options: OPTIONS, allowPositionals: false }));
+  } catch (error) {
+    stderr.write(`verify-signing-identity: ${error.message}\n${USAGE}`);
+    return 2;
+  }
+  if (values.help) {
+    stdout.write(USAGE);
+    return 0;
+  }
+
+  const major = Number.parseInt(process.versions.node.split(".")[0], 10);
+  if (Number.isFinite(major) && major < MINIMUM_NODE_MAJOR) {
+    stderr.write(
+      `verify-signing-identity: node ${MINIMUM_NODE_MAJOR}+ is required, this is ${process.versions.node}\n`,
+    );
+    return 2;
+  }
+
+  let inputs;
+  try {
+    inputs = readInputs(values, env);
+  } catch (error) {
+    stderr.write(`verify-signing-identity: ${error.message}\n`);
+    return 1;
+  }
+  if (inputs.skip) {
+    stdout.write(
+      `verify-signing-identity: SKIP -- ${values.label ? `${values.label}: ` : ""}no Apple signing inputs on this path, nothing to verify\n`,
+    );
+    return 0;
+  }
+
+  const now = values.now ? new Date(values.now) : new Date();
+  if (Number.isNaN(now.getTime())) {
+    stderr.write(`verify-signing-identity: --now ${values.now} is not a date\n`);
+    return 2;
+  }
+  const warnDays = values["warn-days"] === undefined ? DEFAULT_WARN_DAYS : Number(values["warn-days"]);
+  if (!Number.isFinite(warnDays) || warnDays < 0) {
+    stderr.write(`verify-signing-identity: --warn-days ${values["warn-days"]} is not a day count\n`);
+    return 2;
+  }
+
+  const teamId = values["team-id"] ?? env.APPLE_TEAM_ID;
+  const verdict = evaluateSigningIdentity({
+    profile: inputs.profile,
+    leaf: inputs.leaf,
+    now,
+    warnDays,
+    expected: {
+      ...inputs.expectedKeyPair,
+      keychainIdentitySha1: values["keychain-identity-sha1"],
+      bundleId: values["bundle-id"],
+      teamId,
+      profileUuid: values["expect-profile-uuid"],
+      profileName: values["expect-profile-name"],
+    },
+  });
+
+  const report = renderReport({
+    profile: inputs.profile,
+    leaf: inputs.leaf,
+    verdict,
+    now,
+    context: { label: values.label, decoder: inputs.decoder },
+  });
+  (verdict.ok ? stdout : stderr).write(`${report}\n`);
+  if (env.GITHUB_STEP_SUMMARY) {
+    try {
+      appendFileSync(env.GITHUB_STEP_SUMMARY, `\n\`\`\`\n${report}\n\`\`\`\n`);
+    } catch {
+      // A step summary is a convenience; never fail a release over it.
+    }
+  }
+  return verdict.ok ? 0 : 1;
+}
+
+// ---------------------------------------------------------------------------
+// fixtures + self-test
+// ---------------------------------------------------------------------------
+
+function opensslOrThrow(openssl, args, options) {
+  const result = run(openssl, args, options);
+  if (!result.ok) {
+    throw new Error(`openssl ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout;
+}
+
+// Throwaway self-signed material, so the negative control is a real
+// certificate/profile pair rather than a hand-edited fixture. No Apple
+// credential is involved and nothing here leaves the temporary directory.
+export function buildFixtures(directory, { openssl = "openssl", teamId = "TEAMFIXTUR", bundleId = "cash.free2z.fixture" } = {}) {
+  const identity = (name, days) => {
+    const keyPath = join(directory, `${name}.key.pem`);
+    const certPath = join(directory, `${name}.cert.pem`);
+    opensslOrThrow(openssl, [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath, "-days", String(days),
+      "-subj", `/C=US/O=Fixture Inc/OU=${teamId}/CN=Apple Distribution: Fixture ${name}`,
+    ]);
+    const der = new X509Certificate(readFileSync(certPath)).raw;
+    return { name, keyPath, certPath, der, fingerprint: certificateFingerprintSha1(der) };
+  };
+
+  const authorized = identity("A", 800);
+  const impostor = identity("B", 800);
+
+  const profileExpiry = new Date(Date.now() + 900 * DAY_MS);
+  const plist = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    "<dict>",
+    "\t<key>Name</key>",
+    "\t<string>Fixture App Store CI</string>",
+    "\t<key>UUID</key>",
+    "\t<string>00000000-0000-4000-8000-000000000001</string>",
+    "\t<key>TeamIdentifier</key>",
+    `\t<array><string>${teamId}</string></array>`,
+    "\t<key>DeveloperCertificates</key>",
+    `\t<array><data>${authorized.der.toString("base64")}</data></array>`,
+    "\t<key>Entitlements</key>",
+    "\t<dict>",
+    "\t\t<key>application-identifier</key>",
+    `\t\t<string>${teamId}.${bundleId}</string>`,
+    "\t</dict>",
+    "\t<key>CreationDate</key>",
+    `\t<date>${iso(new Date(Date.now() - DAY_MS))}</date>`,
+    "\t<key>ExpirationDate</key>",
+    `\t<date>${iso(profileExpiry)}</date>`,
+    "</dict>",
+    "</plist>",
+    "",
+  ].join("\n");
+  const plistPath = join(directory, "profile.plist");
+  writeFileSync(plistPath, plist);
+
+  // A real CMS envelope, so the decode path is exercised rather than assumed.
+  const profilePath = join(directory, "fixture.mobileprovision");
+  opensslOrThrow(openssl, [
+    "smime", "-sign", "-signer", authorized.certPath, "-inkey", authorized.keyPath,
+    "-in", plistPath, "-outform", "DER", "-nodetach", "-noattr", "-binary", "-out", profilePath,
+  ]);
+
+  const password = "fixture-password";
+  const archive = (holder) => {
+    const p12Path = join(directory, `${holder.name}.p12`);
+    opensslOrThrow(
+      openssl,
+      ["pkcs12", "-export", "-inkey", holder.keyPath, "-in", holder.certPath, "-passout", "env:FIXTURE_P12_PASSWORD", "-out", p12Path],
+      { env: { ...process.env, FIXTURE_P12_PASSWORD: password } },
+    );
+    return p12Path;
+  };
+
+  return {
+    teamId,
+    bundleId,
+    password,
+    profilePath,
+    plistPath,
+    profileExpiry,
+    authorized: { ...authorized, p12Path: archive(authorized) },
+    impostor: { ...impostor, p12Path: archive(impostor) },
+  };
+}
+
+class Recorder {
+  constructor() {
+    this.text = "";
+  }
+  write(chunk) {
+    this.text += chunk;
+    return true;
+  }
+}
+
+// Every case here is also a node:test in scripts/verify-signing-identity.node-test.mjs.
+// This entry point exists so the release job itself watches the check fail
+// before it trusts the check's verdict on the real credentials.
+export function selfTest({ log = (line) => process.stdout.write(`${line}\n`), openssl = "openssl" } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "verify-signing-identity-selftest."));
+  const failures = [];
+  const record = (name, ok, detail) => {
+    log(`  ${ok ? "ok  " : "FAIL"} ${name}${detail ? ` -- ${detail}` : ""}`);
+    if (!ok) failures.push(name);
+  };
+  try {
+    const fixtures = buildFixtures(directory, { openssl });
+    const env = { ...process.env, FIXTURE_P12_PASSWORD: fixtures.password, GITHUB_STEP_SUMMARY: "" };
+    const invoke = (extra) => {
+      const stdout = new Recorder();
+      const stderr = new Recorder();
+      const code = runCli(
+        [
+          "--profile", fixtures.profilePath,
+          "--p12-password-env", "FIXTURE_P12_PASSWORD",
+          "--bundle-id", fixtures.bundleId,
+          "--team-id", fixtures.teamId,
+          ...extra,
+        ],
+        { env, stdout, stderr },
+      );
+      return { code, out: stdout.text + stderr.text };
+    };
+
+    const good = invoke(["--p12", fixtures.authorized.p12Path]);
+    record("a matching certificate and profile pass", good.code === 0, good.code === 0 ? "" : good.out);
+    record(
+      "the passing report still names both expiry dates",
+      good.out.includes(iso(fixtures.profileExpiry)) && good.out.includes("not after"),
+    );
+
+    // The negative control. This is the whole point of the file.
+    const bad = invoke(["--p12", fixtures.impostor.p12Path]);
+    record("a certificate no profile authorizes is rejected", bad.code === 1);
+    record(
+      "the rejection names both fingerprints",
+      bad.out.includes(fixtures.impostor.fingerprint) && bad.out.includes(fixtures.authorized.fingerprint),
+      bad.out.includes(fixtures.impostor.fingerprint) ? "" : "imported fingerprint missing from the message",
+    );
+    record(
+      "the rejection names the failing assertion",
+      bad.out.includes("FAILED: profile-authorizes-certificate"),
+    );
+
+    const wrongBundle = invoke(["--p12", fixtures.authorized.p12Path, "--bundle-id", "cash.free2z.other"]);
+    record("a profile issued for another bundle id is rejected", wrongBundle.code === 1);
+
+    const wrongTeam = invoke(["--p12", fixtures.authorized.p12Path, "--team-id", "WRONGTEAM0"]);
+    record("a profile from another team is rejected", wrongTeam.code === 1);
+
+    const wrongKeychain = invoke([
+      "--p12", fixtures.authorized.p12Path,
+      "--keychain-identity-sha1", fixtures.impostor.fingerprint,
+    ]);
+    record("a keychain identity other than the archive leaf is rejected", wrongKeychain.code === 1);
+
+    // The certificate outlives nothing and the profile outlives it: the exact
+    // shape of the real fleet, where the profile date is the one people watch.
+    const leaf = describeCertificate(fixtures.authorized.der);
+    const afterCertificate = new Date(leaf.notAfter.getTime() + DAY_MS);
+    const expired = invoke(["--p12", fixtures.authorized.p12Path, "--now", afterCertificate.toISOString()]);
+    record("an expired certificate under a live profile is rejected", expired.code === 1);
+    record(
+      "the expiry rejection reports both dates",
+      expired.out.includes(iso(leaf.notAfter)) && expired.out.includes(iso(fixtures.profileExpiry)),
+    );
+
+    const soon = new Date(leaf.notAfter.getTime() - 5 * DAY_MS);
+    const warned = invoke(["--p12", fixtures.authorized.p12Path, "--now", soon.toISOString()]);
+    record("a certificate expiring within the warning window still passes", warned.code === 0);
+    record("...and says so", warned.out.includes("WARN certificate-validity"));
+
+    const missing = runCli(["--allow-missing-inputs", "--label", "android"], {
+      env,
+      stdout: new Recorder(),
+      stderr: new Recorder(),
+    });
+    record("a path with no Apple inputs skips cleanly", missing === 0);
+    const missingStrict = runCli([], { env, stdout: new Recorder(), stderr: new Recorder() });
+    record("...but not silently: missing inputs without the flag fail", missingStrict === 1);
+  } catch (error) {
+    record("self-test fixtures", false, error.message);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  if (failures.length > 0) {
+    log(`verify-signing-identity --self-test FAILED: ${failures.join(", ")}`);
+    return 1;
+  }
+  log("verify-signing-identity --self-test passed");
+  return 0;
+}
+
+function main(argv) {
+  if (argv.includes("--self-test")) {
+    return selfTest();
+  }
+  return runCli(argv);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/verify-signing-identity.mjs
+++ b/scripts/verify-signing-identity.mjs
@@ -448,6 +448,10 @@ export function readProfile(plistXml) {
 const iso = (date) => (date instanceof Date ? date.toISOString().replace(/\.\d{3}Z$/, "Z") : "unknown");
 const daysUntil = (date, now) =>
   date instanceof Date ? Math.floor((date.getTime() - now.getTime()) / DAY_MS) : Number.NaN;
+const daysLabel = (date, now) => {
+  const days = daysUntil(date, now);
+  return Number.isFinite(days) ? `${days} days` : "unknown";
+};
 
 // Pure: everything above turns bytes into these two plain objects, and this
 // decides. That split is what lets the negative control run anywhere.
@@ -636,7 +640,7 @@ export function renderReport({ profile, leaf, verdict, now, context = {} }) {
   lines.push(`    sha-1               ${leaf.fingerprint}`);
   lines.push(`    subject             ${leaf.commonName}`);
   lines.push(`    not before          ${iso(leaf.notBefore)}`);
-  lines.push(`    not after           ${iso(leaf.notAfter)}  (${daysUntil(leaf.notAfter, now)} days)`);
+  lines.push(`    not after           ${iso(leaf.notAfter)}  (${daysLabel(leaf.notAfter, now)})`);
   lines.push("");
   lines.push("  provisioning profile");
   lines.push(`    name                ${profile.name ?? "(none)"}`);
@@ -644,7 +648,7 @@ export function renderReport({ profile, leaf, verdict, now, context = {} }) {
   lines.push(`    team                ${profile.teamIdentifiers.join(", ") || "(none)"}`);
   lines.push(`    app identifier      ${profile.applicationIdentifier ?? "(none)"}`);
   lines.push(
-    `    expires             ${iso(profile.expirationDate)}  (${daysUntil(profile.expirationDate, now)} days)`,
+    `    expires             ${iso(profile.expirationDate)}  (${daysLabel(profile.expirationDate, now)})`,
   );
   lines.push(`    authorizes          ${profile.certificates.length} certificate(s)`);
   for (const certificate of profile.certificates) {

--- a/scripts/verify-signing-identity.node-test.mjs
+++ b/scripts/verify-signing-identity.node-test.mjs
@@ -1,0 +1,512 @@
+// The negative control for scripts/verify-signing-identity.mjs (issue #960).
+//
+// A signing preflight nobody has watched fail is a green check, not a check.
+// So every case here builds real throwaway material with openssl -- two
+// self-signed certificates, a CMS-wrapped provisioning profile embedding only
+// the first, and a PKCS#12 archive for each -- and then proves the preflight
+// accepts the pair that belongs together and rejects the pair that does not.
+//
+// This runs on Linux with no Apple credentials, by construction: the profile is
+// decoded through `openssl smime -verify` when `security` is absent, and the
+// decoder test below forces that path even on macOS. Nothing here skips: if
+// openssl is missing the suite fails loudly rather than reporting success.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, test } from "node:test";
+
+import {
+  buildFixtures,
+  certificateFingerprintSha1,
+  decodeProvisioningProfile,
+  describeCertificate,
+  evaluateSigningIdentity,
+  extractPkcs12,
+  parsePlistXml,
+  readProfile,
+  runCli,
+  selfTest,
+} from "./verify-signing-identity.mjs";
+
+const DAY_MS = 86_400_000;
+
+class Recorder {
+  constructor() {
+    this.text = "";
+  }
+  write(chunk) {
+    this.text += chunk;
+    return true;
+  }
+}
+
+let directory;
+let fixtures;
+let profile;
+
+before(() => {
+  const openssl = spawnSync("openssl", ["version"], { encoding: "utf8" });
+  assert.equal(
+    openssl.status,
+    0,
+    "openssl is required to build the throwaway signing material this suite is made of",
+  );
+  directory = mkdtempSync(join(tmpdir(), "verify-signing-identity-test."));
+  fixtures = buildFixtures(directory);
+  profile = readProfile(decodeProvisioningProfile(readFileSync(fixtures.profilePath)).plist);
+});
+
+after(() => {
+  if (directory) rmSync(directory, { recursive: true, force: true });
+});
+
+const invoke = (extra) => {
+  const stdout = new Recorder();
+  const stderr = new Recorder();
+  const code = runCli(
+    [
+      "--profile",
+      fixtures.profilePath,
+      "--p12-password-env",
+      "FIXTURE_P12_PASSWORD",
+      "--bundle-id",
+      fixtures.bundleId,
+      "--team-id",
+      fixtures.teamId,
+      ...extra,
+    ],
+    {
+      env: { ...process.env, FIXTURE_P12_PASSWORD: fixtures.password, GITHUB_STEP_SUMMARY: "" },
+      stdout,
+      stderr,
+    },
+  );
+  return { code, stdout: stdout.text, stderr: stderr.text, output: stdout.text + stderr.text };
+};
+
+describe("the profile/certificate pairing", () => {
+  test("the certificate the profile embeds is accepted", () => {
+    const result = invoke(["--p12", fixtures.authorized.p12Path]);
+    assert.equal(result.code, 0, result.output);
+    assert.match(result.stdout, /PASS profile-authorizes-certificate/);
+  });
+
+  // THE NEGATIVE CONTROL. Same team, same shape, valid certificate, correct
+  // password, and no profile authorizes it: exactly the environment that was
+  // populated correctly in form and wrong in content.
+  test("a certificate no profile authorizes is rejected", () => {
+    const result = invoke(["--p12", fixtures.impostor.p12Path]);
+    assert.equal(result.code, 1, "the mismatched identity was accepted");
+    assert.match(result.stderr, /FAIL profile-authorizes-certificate/);
+    assert.match(result.stderr, /FAILED: profile-authorizes-certificate/);
+  });
+
+  test("the rejection names both fingerprints and both expiry dates", () => {
+    const result = invoke(["--p12", fixtures.impostor.p12Path]);
+    assert.ok(
+      result.stderr.includes(fixtures.impostor.fingerprint),
+      "the message must name the certificate that was imported",
+    );
+    assert.ok(
+      result.stderr.includes(fixtures.authorized.fingerprint),
+      "the message must name the certificate the profile authorizes",
+    );
+    const leaf = describeCertificate(fixtures.impostor.der);
+    assert.ok(result.stderr.includes(leaf.notAfter.toISOString().replace(/\.\d{3}Z$/, "Z")));
+    assert.ok(result.stderr.includes(fixtures.profileExpiry.toISOString().replace(/\.\d{3}Z$/, "Z")));
+  });
+
+  test("a profile that embeds no certificates authorizes nothing", () => {
+    const verdict = evaluateSigningIdentity({
+      profile: { ...profile, certificates: [] },
+      leaf: describeCertificate(fixtures.authorized.der),
+      expected: {},
+    });
+    assert.equal(verdict.ok, false);
+    assert.match(verdict.failures[0].detail, /embeds no DeveloperCertificates/);
+  });
+});
+
+describe("the archive's own coherence", () => {
+  test("a well-formed archive yields one certificate that matches its key", () => {
+    const extracted = extractPkcs12(fixtures.authorized.p12Path, "FIXTURE_P12_PASSWORD", {
+      env: { ...process.env, FIXTURE_P12_PASSWORD: fixtures.password },
+    });
+    assert.equal(extracted.leaf.fingerprint, fixtures.authorized.fingerprint);
+    assert.equal(extracted.leaf.publicKeySha256, extracted.privateKeyPublicSha256);
+    assert.equal(
+      invoke(["--p12", fixtures.authorized.p12Path]).stdout.includes("PASS certificate-key-pair"),
+      true,
+    );
+  });
+
+  test("a certificate and key from different pairs are rejected", () => {
+    const verdict = evaluateSigningIdentity({
+      profile,
+      leaf: describeCertificate(fixtures.authorized.der),
+      expected: {
+        privateKeyPublicSha256: describeCertificate(fixtures.impostor.der).publicKeySha256,
+        privateKeyType: "rsa",
+      },
+    });
+    assert.equal(verdict.ok, false);
+    assert.deepEqual(
+      verdict.failures.map((failure) => failure.name),
+      ["certificate-key-pair"],
+    );
+    assert.match(verdict.failures[0].detail, /truncated or mis-assembled/);
+  });
+
+  test("the wrong password fails loudly rather than reporting nothing to check", () => {
+    assert.throws(
+      () =>
+        extractPkcs12(fixtures.authorized.p12Path, "FIXTURE_P12_PASSWORD", {
+          env: { ...process.env, FIXTURE_P12_PASSWORD: "not-the-password" },
+        }),
+      /could not read the signing archive/,
+    );
+  });
+});
+
+describe("what the keychain will actually sign with", () => {
+  test("the imported archive's leaf is accepted", () => {
+    const result = invoke([
+      "--p12",
+      fixtures.authorized.p12Path,
+      "--keychain-identity-sha1",
+      fixtures.authorized.fingerprint.replace(/:/g, ""),
+    ]);
+    assert.equal(result.code, 0, result.output);
+    assert.match(result.stdout, /PASS keychain-identity/);
+  });
+
+  // The trap in #960 in its purest form: `security find-identity` resolves an
+  // identity that is not the one in the archive we checked.
+  test("an identity other than the archive's leaf is rejected", () => {
+    const result = invoke([
+      "--p12",
+      fixtures.authorized.p12Path,
+      "--keychain-identity-sha1",
+      fixtures.impostor.fingerprint.replace(/:/g, ""),
+    ]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /FAIL keychain-identity/);
+  });
+});
+
+describe("identity of the app being signed", () => {
+  test("a profile issued for another bundle id is rejected", () => {
+    const result = invoke(["--p12", fixtures.authorized.p12Path, "--bundle-id", "cash.free2z.other"]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /FAIL application-identifier/);
+  });
+
+  test("a profile from another team is rejected", () => {
+    const result = invoke(["--p12", fixtures.authorized.p12Path, "--team-id", "OTHERTEAM1"]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /FAIL team-identifier/);
+  });
+
+  test("APPLE_TEAM_ID stands in for --team-id and is held to the same rule", () => {
+    const stdout = new Recorder();
+    const stderr = new Recorder();
+    const code = runCli(
+      [
+        "--profile",
+        fixtures.profilePath,
+        "--p12",
+        fixtures.authorized.p12Path,
+        "--p12-password-env",
+        "FIXTURE_P12_PASSWORD",
+        "--bundle-id",
+        fixtures.bundleId,
+      ],
+      {
+        env: {
+          ...process.env,
+          FIXTURE_P12_PASSWORD: fixtures.password,
+          APPLE_TEAM_ID: "OTHERTEAM1",
+          GITHUB_STEP_SUMMARY: "",
+        },
+        stdout,
+        stderr,
+      },
+    );
+    assert.equal(code, 1);
+    assert.match(stderr.text, /FAIL team-identifier/);
+  });
+
+  test("an unexpected profile uuid or name is rejected", () => {
+    assert.equal(invoke(["--p12", fixtures.authorized.p12Path, "--expect-profile-uuid", "nope"]).code, 1);
+    assert.equal(invoke(["--p12", fixtures.authorized.p12Path, "--expect-profile-name", "nope"]).code, 1);
+    assert.equal(
+      invoke([
+        "--p12",
+        fixtures.authorized.p12Path,
+        "--expect-profile-uuid",
+        profile.uuid,
+        "--expect-profile-name",
+        profile.name,
+      ]).code,
+      0,
+    );
+  });
+
+  test("the macOS spelling of the entitlement is read too", () => {
+    const macos = readProfile(
+      readFileSync(fixtures.plistPath, "utf8").replace(
+        "<key>application-identifier</key>",
+        "<key>com.apple.application-identifier</key>",
+      ),
+    );
+    assert.equal(macos.applicationIdentifier, `${fixtures.teamId}.${fixtures.bundleId}`);
+  });
+});
+
+describe("the two expiry dates, which are not the same date", () => {
+  const leaf = () => describeCertificate(fixtures.authorized.der);
+
+  test("a live pair passes and reports both dates", () => {
+    const result = invoke(["--p12", fixtures.authorized.p12Path]);
+    assert.equal(result.code, 0, result.output);
+    assert.ok(result.stdout.includes(leaf().notAfter.toISOString().replace(/\.\d{3}Z$/, "Z")));
+    assert.ok(result.stdout.includes(fixtures.profileExpiry.toISOString().replace(/\.\d{3}Z$/, "Z")));
+  });
+
+  // The fixture mirrors the real fleet: the profile outlives the certificate,
+  // so the date on the calendar is not the date that ends the release.
+  test("the certificate expires before the profile does", () => {
+    assert.ok(leaf().notAfter.getTime() < fixtures.profileExpiry.getTime());
+  });
+
+  test("an expired certificate under a still-valid profile is rejected", () => {
+    const result = invoke([
+      "--p12",
+      fixtures.authorized.p12Path,
+      "--now",
+      new Date(leaf().notAfter.getTime() + DAY_MS).toISOString(),
+    ]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /FAIL certificate-validity/);
+    assert.match(result.stderr, /the certificate is what expires first/);
+    assert.match(result.stderr, /PASS profile-validity/);
+  });
+
+  test("an expired profile under a still-valid certificate is rejected", () => {
+    const result = invoke([
+      "--p12",
+      fixtures.authorized.p12Path,
+      "--now",
+      new Date(fixtures.profileExpiry.getTime() + DAY_MS).toISOString(),
+    ]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /FAIL profile-validity/);
+  });
+
+  test("a certificate not yet valid is rejected", () => {
+    const result = invoke([
+      "--p12",
+      fixtures.authorized.p12Path,
+      "--now",
+      new Date(leaf().notBefore.getTime() - DAY_MS).toISOString(),
+    ]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /FAIL certificate-validity/);
+  });
+
+  test("an expiry inside the warning window warns without failing the release", () => {
+    const result = invoke([
+      "--p12",
+      fixtures.authorized.p12Path,
+      "--now",
+      new Date(leaf().notAfter.getTime() - 5 * DAY_MS).toISOString(),
+    ]);
+    assert.equal(result.code, 0, result.output);
+    assert.match(result.stdout, /WARN certificate-validity/);
+    assert.match(result.stdout, /5 day\(s\) from now/);
+  });
+
+  test("--warn-days sets the window", () => {
+    const now = new Date(leaf().notAfter.getTime() - 45 * DAY_MS).toISOString();
+    assert.match(invoke(["--p12", fixtures.authorized.p12Path, "--now", now]).stdout, /PASS certificate-validity/);
+    assert.match(
+      invoke(["--p12", fixtures.authorized.p12Path, "--now", now, "--warn-days", "60"]).stdout,
+      /WARN certificate-validity/,
+    );
+  });
+});
+
+describe("paths that carry no Apple inputs", () => {
+  test("skipping is explicit, opt-in, and logged", () => {
+    const stdout = new Recorder();
+    const code = runCli(["--allow-missing-inputs", "--label", "android"], {
+      env: { ...process.env, GITHUB_STEP_SUMMARY: "" },
+      stdout,
+      stderr: new Recorder(),
+    });
+    assert.equal(code, 0);
+    assert.match(stdout.text, /SKIP -- android: no Apple signing inputs/);
+  });
+
+  test("missing inputs without the flag are a failure, not a skip", () => {
+    const stderr = new Recorder();
+    const code = runCli([], { env: { ...process.env }, stdout: new Recorder(), stderr });
+    assert.equal(code, 1);
+    assert.match(stderr.text, /no Apple signing inputs were given/);
+  });
+
+  test("a certificate without a profile is a failure", () => {
+    const stderr = new Recorder();
+    const code = runCli(["--certificate", fixtures.authorized.certPath, "--allow-missing-inputs"], {
+      env: { ...process.env },
+      stdout: new Recorder(),
+      stderr,
+    });
+    assert.equal(code, 1);
+    assert.match(stderr.text, /a provisioning profile is required/);
+  });
+});
+
+describe("reading the material", () => {
+  // security(1) is macOS-only, so the release path would be untestable if this
+  // were the only decoder. Forcing the openssl decoder proves the fallback that
+  // Linux CI uses is the same code the runners exercise.
+  test("a CMS-wrapped profile decodes without security(1)", () => {
+    const decoded = decodeProvisioningProfile(readFileSync(fixtures.profilePath), {
+      security: "/nonexistent/security",
+    });
+    assert.match(decoded.decoder, /^openssl /);
+    assert.equal(readProfile(decoded.plist).uuid, profile.uuid);
+  });
+
+  test("an already-decoded plist is accepted as-is", () => {
+    const decoded = decodeProvisioningProfile(readFileSync(fixtures.plistPath));
+    assert.equal(decoded.decoder, "already-decoded");
+  });
+
+  test("an undecodable profile fails rather than parsing to nothing", () => {
+    assert.throws(
+      () => decodeProvisioningProfile(Buffer.from("not a provisioning profile at all")),
+      /could not decode the provisioning profile/,
+    );
+  });
+
+  test("a binary plist says what to do instead of misreporting", () => {
+    assert.throws(
+      () => decodeProvisioningProfile(Buffer.from("bplist00  ")),
+      /plutil -convert xml1/,
+    );
+  });
+
+  test("the fingerprint is the SHA-1 openssl prints", () => {
+    const openssl = spawnSync(
+      "openssl",
+      ["x509", "-in", fixtures.authorized.certPath, "-noout", "-fingerprint", "-sha1"],
+      { encoding: "utf8" },
+    );
+    assert.equal(openssl.status, 0, openssl.stderr);
+    assert.equal(
+      openssl.stdout.trim().split("=").slice(1).join("=").toUpperCase(),
+      certificateFingerprintSha1(fixtures.authorized.der),
+    );
+  });
+
+  test("the plist reader handles the element set Apple emits", () => {
+    const parsed = parsePlistXml(`<?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0"><dict>
+        <key>Name</key><string>A &amp; B &lt;x&gt;</string>
+        <key>Count</key><integer>3</integer>
+        <key>Ratio</key><real>0.5</real>
+        <key>Yes</key><true/>
+        <key>No</key><false/>
+        <key>When</key><date>2027-08-08T20:33:04Z</date>
+        <key>Blob</key><data>aGVsbG8=</data>
+        <key>List</key><array><string>one</string><dict><key>k</key><string>v</string></dict></array>
+        <key>Empty</key><array/>
+      </dict></plist>`);
+    assert.equal(parsed.get("Name"), "A & B <x>");
+    assert.equal(parsed.get("Count"), 3);
+    assert.equal(parsed.get("Ratio"), 0.5);
+    assert.equal(parsed.get("Yes"), true);
+    assert.equal(parsed.get("No"), false);
+    assert.equal(parsed.get("When").toISOString(), "2027-08-08T20:33:04.000Z");
+    assert.equal(parsed.get("Blob").toString("utf8"), "hello");
+    assert.equal(parsed.get("List")[1].get("k"), "v");
+    assert.deepEqual(parsed.get("Empty"), []);
+  });
+
+  test("an element the reader does not understand is an error, not a silent omission", () => {
+    assert.throws(
+      () => parsePlistXml("<plist><dict><key>k</key><uid>1</uid></dict></plist>"),
+      /unsupported plist element <uid>/,
+    );
+  });
+
+  test("a DeveloperCertificates entry that is not <data> is an error", () => {
+    assert.throws(
+      () =>
+        readProfile(
+          "<plist><dict><key>DeveloperCertificates</key><array><string>nope</string></array></dict></plist>",
+        ),
+      /not <data>/,
+    );
+  });
+
+  test("a truncated certificate in the profile is an error, not an unauthorized-looking pass", () => {
+    const broken = readFileSync(fixtures.plistPath, "utf8").replace(
+      fixtures.authorized.der.toString("base64"),
+      fixtures.authorized.der.subarray(0, 40).toString("base64"),
+    );
+    assert.throws(() => readProfile(broken));
+  });
+});
+
+describe("the release path uses this file", () => {
+  test("--self-test passes, so a release job can prove the check before trusting it", () => {
+    const lines = [];
+    assert.equal(selfTest({ log: (line) => lines.push(line) }), 0, lines.join("\n"));
+    assert.ok(lines.some((line) => line.includes("a certificate no profile authorizes is rejected")));
+  });
+
+  test("--self-test fails when the check is broken", () => {
+    // Prove the self-test is load-bearing: break the fixture material it
+    // depends on and it must go red rather than sail through.
+    const scratch = mkdtempSync(join(tmpdir(), "verify-signing-identity-broken."));
+    try {
+      const shim = join(scratch, "openssl");
+      writeFileSync(shim, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+      const lines = [];
+      assert.equal(selfTest({ log: (line) => lines.push(line), openssl: shim }), 1);
+      assert.ok(lines.some((line) => line.startsWith("  FAIL")));
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test("both release workflows invoke the preflight before exporting the archive", () => {
+    const repoRoot = new URL("..", import.meta.url);
+    for (const [workflow, bundleId] of [
+      [".github/workflows/zuuli-release.yml", "cash.free2z.zuuli"],
+      [".github/workflows/e2e2z-release.yml", "cash.free2z.e2e2z"],
+    ]) {
+      const source = readFileSync(new URL(workflow, repoRoot), "utf8");
+      const preflight = source.indexOf("verify-signing-identity.mjs --self-test");
+      const verdict = source.indexOf("--keychain-identity-sha1");
+      const exportArchive = source.indexOf("xcodebuild -exportArchive");
+      assert.ok(preflight > 0, `${workflow} does not self-test the signing preflight`);
+      assert.ok(verdict > preflight, `${workflow} does not run the signing preflight`);
+      assert.ok(
+        verdict < exportArchive,
+        `${workflow} runs the signing preflight after xcodebuild -exportArchive, which is too late`,
+      );
+      assert.ok(
+        source.includes(`--bundle-id ${bundleId}`),
+        `${workflow} does not bind the preflight to ${bundleId}`,
+      );
+    }
+  });
+});

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -529,6 +529,31 @@ The Developer ID provisioning profile must authorize
 profile to authorize that restricted entitlement. The signer embeds the profile
 and rejects a wrong team, application identifier, access-group allowlist, or
 signing certificate before it signs the app.
+
+Installing the *right-looking* certificate is the failure this warns about. A
+provisioning profile authorizes specific certificates by embedding them; a
+`.p12` holding any other identity imports cleanly, resolves a perfectly valid
+signing identity, builds an archive, and fails only at
+`xcodebuild -exportArchive` twenty minutes later with a message that never names
+the mismatch. Two Apple Distribution certificates exist for `F9AV5HKF6N`, and
+the one `security find-identity -v -p codesigning` returns on a developer
+machine is **not** the one the profiles embed — the authorized certificate's
+private key is in no Keychain, only in the `.p12`. Do not derive the secret from
+the Keychain; export the archive whose leaf SHA-1 appears in
+`DeveloperCertificates`. Both iOS and macOS signing jobs now run
+`scripts/verify-signing-identity.mjs` (carried into the job inside the attested
+unsigned payload, since a credential job may not check the repository out)
+before they sign or export, asserting that pairing plus the archive's own
+certificate/key coherence, the bundle id, the team, and both expiry dates —
+which are not the same date, and the certificate's is the earlier one. Verify a
+newly installed pair locally with:
+
+```bash
+node scripts/verify-signing-identity.mjs \
+  --profile ZUULI_App_Store_CI.mobileprovision \
+  --p12 zuuli-distribution.p12 --p12-password-env P12_PASSWORD \
+  --bundle-id cash.free2z.zuuli --team-id F9AV5HKF6N
+```
 Base64 values are decoded only inside the system-tool credential jobs into
 mode-0700 runner-temporary directories and destroyed even when a job fails.
 Dependency-controlled build jobs neither reference the protected environment

--- a/wallet/zuuli/scripts/apple-credential-boundary.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.mjs
@@ -102,9 +102,9 @@ const ALLOWED_JOB_SECRETS = new Map([
 // all unenumerated execution paths. Update only after reviewing the full job.
 const CREDENTIAL_JOB_SHA256 = new Map([
   ["android-sign-upload", "4e80aa8c0832bc6b180f6121191d9e7ae1f178e2ff98e910b98f3e534d0745c4"],
-  ["ios-sign", "6e63107606388e3862f81e41da65b1fa8bfca1588b5232f9ca4354203536393c"],
+  ["ios-sign", "366e19b3185e0392a9ade22f72de7766699cb629487ffbd4f77057bd7eb1149c"],
   ["ios-upload", "3ed7cb28646aed24a7df2c347b8ad54838f009841fdd52c64ca1002886aae4b2"],
-  ["macos-sign", "6c6d01bef2cc6feae4c3d250081f39f31101131dc88cd99fa0b5fb4ec5ea14eb"],
+  ["macos-sign", "4aabc59a06ab3f589515caab2b2ea9c1dadd9cda08958f0d03ec54e95f46d7e7"],
 ]);
 // The credential-free builder is also exact: its source-identity check and
 // compile happen in separate steps, so an unreviewed command between them
@@ -366,6 +366,37 @@ function requireText(failures, label, source, needle) {
 
 function rejectText(failures, label, source, needle) {
   if (source.includes(needle)) failures.push(`${label} contains forbidden ${JSON.stringify(needle)}`);
+}
+
+// #960. A signing job must prove the certificate it imported is one the
+// provisioning profile authorizes, bound to the identity the keychain actually
+// resolved, and it must do so *before* it signs or exports anything -- a check
+// that runs afterwards costs the same twenty minutes it exists to save. The
+// self-test is required alongside the verdict for the reason every other
+// checker in this repository requires one: a preflight nobody has watched fail
+// is a green step, not a check.
+function requireSigningPreflight(failures, label, source, { checker, before }) {
+  const selfTestCommand = `${checker} --self-test`;
+  const selfTest = source.indexOf(selfTestCommand);
+  if (selfTest < 0) {
+    failures.push(`${label} does not self-test the signing preflight`);
+    return;
+  }
+  const verdict = source.indexOf(checker, selfTest + selfTestCommand.length);
+  if (verdict < 0) {
+    failures.push(`${label} does not run the signing preflight`);
+    return;
+  }
+  const identity = source.indexOf("--keychain-identity-sha1", verdict);
+  if (identity < 0) {
+    failures.push(`${label} does not bind the signing preflight to the resolved keychain identity`);
+  }
+  const boundary = source.indexOf(before);
+  if (boundary < 0) {
+    failures.push(`${label} is missing ${JSON.stringify(before)}`);
+  } else if (verdict > boundary) {
+    failures.push(`${label} runs the signing preflight after ${JSON.stringify(before)}, which is too late`);
+  }
 }
 
 export function releaseIndexResultsAreComplete(target, results) {
@@ -1202,8 +1233,25 @@ export function verifyAppleCredentialBoundary(
     failures,
     "iOS unsigned builder",
     jobs.get("ios-build"),
-    "ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+    "ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256",
   );
+  // #960. The provisioning profile authorizes specific certificates; a .p12
+  // holding any other identity signs an archive that fails only at
+  // -exportArchive, twenty minutes later, with a message that never names the
+  // mismatch. The credential-free builder therefore carries the preflight into
+  // the payload -- it cannot be fetched inside the signing job, which may not
+  // check the repository out -- and the signing job must run it, against the
+  // identity the keychain resolved, before it exports anything.
+  requireText(
+    failures,
+    "iOS unsigned builder",
+    jobs.get("ios-build"),
+    'cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" unsigned-ios/verify-signing-identity.mjs',
+  );
+  requireSigningPreflight(failures, "iOS signer", jobs.get("ios-sign"), {
+    checker: "node unsigned-ios/verify-signing-identity.mjs",
+    before: "xcodebuild -exportArchive",
+  });
   requireText(failures, "iOS signer", jobs.get("ios-sign"), "EXPECTED_PAYLOAD_SHA256");
   requireText(
     failures,
@@ -1249,8 +1297,20 @@ export function verifyAppleCredentialBoundary(
     failures,
     "macOS unsigned builder",
     jobs.get("macos-build"),
-    "Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json > CHECKSUMS.sha256",
+    "Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256",
   );
+  // #960 again, for Developer ID. Same pairing failure, plus the expiry nobody
+  // tracks: the certificate dies before the profile that embeds it does.
+  requireText(
+    failures,
+    "macOS unsigned builder",
+    jobs.get("macos-build"),
+    'cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" unsigned-macos/verify-signing-identity.mjs',
+  );
+  requireSigningPreflight(failures, "macOS signer", jobs.get("macos-sign"), {
+    checker: "node unsigned-macos/verify-signing-identity.mjs",
+    before: "codesign --force --deep",
+  });
   requireText(
     failures,
     "macOS unsigned builder",

--- a/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
@@ -56,9 +56,10 @@ function removeLast(source, needle) {
 }
 
 const buildJob = (name, command) => {
+  const payload = name === "ios-build" ? "unsigned-ios" : "unsigned-macos";
   const checksumMembers = name === "ios-build"
-    ? "ZUULI.xcarchive.zip ExportOptions.plist source-record.json"
-    : "Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json";
+    ? "ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs"
+    : "Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json verify-signing-identity.mjs";
   const macosPolicy = name === "macos-build"
     ? "      - run: node scripts/macos-keychain-entitlements.mjs\n"
     : "";
@@ -69,6 +70,7 @@ const buildJob = (name, command) => {
       - run: npm ci
 ${macosPolicy}      - run: |
           ${command} --no-sign
+          cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" ${payload}/verify-signing-identity.mjs
           shasum -a 256 ${checksumMembers} > CHECKSUMS.sha256
       - run: scripts/assert-no-apple-credentials.sh
       - uses: actions/attest-build-provenance@sha
@@ -91,6 +93,13 @@ const credentialJob = (name, command, secret) => {
           gh attestation verify unsigned-macos/CHECKSUMS.sha256 --repo repo${profileValidityMarkers}
           verify_developer_id_profile "$secret_dir/profile.plist" "$profile_now"${captureAuthorityMarkers}`
         : "          echo verified";
+  // #960: the signing preflight, run against the identity the keychain
+  // resolved, before anything is signed or exported.
+  const preflightMarkers = name === "ios-sign" || name === "macos-sign"
+    ? `          node ${name === "ios-sign" ? "unsigned-ios" : "unsigned-macos"}/verify-signing-identity.mjs --self-test
+          node ${name === "ios-sign" ? "unsigned-ios" : "unsigned-macos"}/verify-signing-identity.mjs \\
+            --keychain-identity-sha1 "$identity_sha"`
+    : "          echo materialized";
   const cleanupMarkers = name === "ios-sign" || name === "macos-sign"
     ? name === "ios-sign"
       ? "          echo original-keychains.txt cleanup-failed\n          if [[ -n \"$profile_path\" ]] && ! rm -f -- \"$profile_path\"; then echo cleanup; fi\n          if [[ -e \"$HOME/Library/MobileDevice/Provisioning Profiles/e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision\" ]]; then echo survived; fi"
@@ -107,7 +116,9 @@ ${trustMarker}
       - name: Materialize
         env:
           VALUE: \${{ secrets.${selectedSecret} }}
-        run: echo materialized
+        run: |
+          echo materialized
+${preflightMarkers}
       - name: Operate
         run: ${command}
       - name: Destroy ephemeral credential
@@ -231,7 +242,7 @@ ${finalizeJob("ios-verify")}
 ${credentialJob("ios-upload", "xcrun altool --upload-app", "ASC_KEY_BASE64")}
 ${finalizeJob("ios-finalize")}
 ${buildJob("macos-build", "tauri build")}
-${credentialJob("macos-sign", "codesign --entitlements unsigned-macos/Entitlements.plist app && echo signed-entitlements.plist embedded.provisionprofile APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64 '\"keychain-access-groups\"[0]' && xcrun notarytool submit app")}
+${credentialJob("macos-sign", "codesign --force --deep --entitlements unsigned-macos/Entitlements.plist app && echo signed-entitlements.plist embedded.provisionprofile APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64 '\"keychain-access-groups\"[0]' && xcrun notarytool submit app")}
 ${finalizeJob("macos-finalize")}
   linux:
     container:
@@ -1343,8 +1354,8 @@ for (const [name, mutate, expected] of [
   [
     "rejects a build without a post-build credential canary",
     (source) => source.replace(
-      "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256\n      - run: scripts/assert-no-apple-credentials.sh",
-      "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+      "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256\n      - run: scripts/assert-no-apple-credentials.sh",
+      "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256",
     ),
     "ios-build must run the credential canary after the unsigned build",
   ],
@@ -1578,13 +1589,13 @@ for (const [name, mutate, expected] of [
   ],
   [
     "rejects an unsigned iOS manifest that omits ExportOptions",
-    (source) => source.replace("ZUULI.xcarchive.zip ExportOptions.plist source-record.json", "ZUULI.xcarchive.zip source-record.json"),
-    "iOS unsigned builder is missing \"ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256\"",
+    (source) => source.replace("ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs", "ZUULI.xcarchive.zip source-record.json verify-signing-identity.mjs"),
+    "iOS unsigned builder is missing \"ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256\"",
   ],
   [
     "rejects an unsigned macOS manifest that omits the shipping layout",
-    (source) => source.replace("Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json", "Entitlements.plist Info.macos.plist ZUULI.app.zip source-record.json"),
-    "macOS unsigned builder is missing \"Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json > CHECKSUMS.sha256\"",
+    (source) => source.replace("Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json verify-signing-identity.mjs", "Entitlements.plist Info.macos.plist ZUULI.app.zip source-record.json verify-signing-identity.mjs"),
+    "macOS unsigned builder is missing \"Entitlements.plist Info.macos.plist ZUULI.app.zip ZUULI-layout.dmg source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256\"",
   ],
   [
     "rejects a macOS build that skips the entitlement policy",
@@ -1704,8 +1715,8 @@ for (const [name, mutate, expected] of [
     "rejects an extra builder file followed by credential-job execution",
     (source) => source
       .replace(
-        "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
-        "          touch post-sign.sh\n          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+        "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256",
+        "          touch post-sign.sh\n          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json verify-signing-identity.mjs > CHECKSUMS.sha256",
       )
       .replace(
         "run: xcodebuild -exportArchive",
@@ -1736,6 +1747,56 @@ for (const [name, mutate, expected] of [
       "  ios-sign:\n    defaults: { run: { shell: python } }\n",
     ),
     "ios-sign credential execution program changed",
+  ],
+  // #960. Each of these is a way the signing preflight could be present in
+  // spirit and absent in effect, which is exactly how the environment that
+  // caused the issue passed every check it had.
+  [
+    "rejects a builder that does not carry the signing preflight into the payload",
+    (source) => removeLast(
+      source,
+      '          cp "$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs" unsigned-macos/verify-signing-identity.mjs\n',
+    ),
+    'macOS unsigned builder is missing "cp \\"$GITHUB_WORKSPACE/scripts/verify-signing-identity.mjs\\" unsigned-macos/verify-signing-identity.mjs"',
+  ],
+  [
+    "rejects a signer that never runs the signing preflight",
+    (source) => source.replace(
+      `          node unsigned-ios/verify-signing-identity.mjs --self-test
+          node unsigned-ios/verify-signing-identity.mjs \\
+            --keychain-identity-sha1 "$identity_sha"`,
+      "          echo trusted the certificate",
+    ),
+    "iOS signer does not self-test the signing preflight",
+  ],
+  [
+    "rejects a signer that runs the preflight without proving it can still fail",
+    (source) => source.replace(
+      "          node unsigned-ios/verify-signing-identity.mjs --self-test\n",
+      "",
+    ),
+    "iOS signer does not self-test the signing preflight",
+  ],
+  [
+    "rejects a preflight not bound to the identity the keychain resolved",
+    (source) => source.replace('\n            --keychain-identity-sha1 "$identity_sha"', ""),
+    "iOS signer does not bind the signing preflight to the resolved keychain identity",
+  ],
+  [
+    "rejects a preflight that runs after the archive has already been exported",
+    (source) => source.replace(
+      "          node unsigned-ios/verify-signing-identity.mjs --self-test",
+      "          xcodebuild -exportArchive\n          node unsigned-ios/verify-signing-identity.mjs --self-test",
+    ),
+    'iOS signer runs the signing preflight after "xcodebuild -exportArchive", which is too late',
+  ],
+  [
+    "rejects a macOS preflight that runs after the app has already been signed",
+    (source) => source.replace(
+      "          node unsigned-macos/verify-signing-identity.mjs --self-test",
+      "          codesign --force --deep app\n          node unsigned-macos/verify-signing-identity.mjs --self-test",
+    ),
+    'macOS signer runs the signing preflight after "codesign --force --deep", which is too late',
   ],
 ]) {
   test(name, () => {

--- a/wallet/zuuli/scripts/status-freshness.mjs
+++ b/wallet/zuuli/scripts/status-freshness.mjs
@@ -21,7 +21,7 @@ const releasingPath = "wallet/zuuli/docs/releasing.md";
 // before hashing. The semantic section/table checks remain independent so a
 // reviewer gets a precise diagnostic rather than an opaque digest alone.
 const RELEASING_DOCUMENT_SHA256 =
-  "943027c8f04b49397959e60c97ed0ae432bbfdff6a48ac7bb2b2ac437daf017d";
+  "352cf01bb042188fb514b9157b22e6e292064566dd2bb1cfcd0673724436b100";
 const STATUS_DOCUMENT_SHA256 =
   "8bf0489474acee6dfd1cb4175088befc7ac58d7e5c78f1c033a63e229db8b21a";
 const statusSourceMarkerPattern =


### PR DESCRIPTION
Closes #960.

## The failure this stops

A provisioning profile authorizes specific certificates by embedding their DER
in `DeveloperCertificates`. A `.p12` holding any other identity passes
everything the release path had: the import works, `security find-identity`
returns a valid Apple Distribution identity, the archive builds. It fails
twenty minutes later at `xcodebuild -exportArchive`, worded in a way that never
names the mismatch — and the wrong one of the team's two Apple Distribution
certificates *was* installed into `e2e2z-app-stores`: four secrets, present,
correctly named, wrong in content. A presence check cannot see that.

## What landed

`scripts/verify-signing-identity.mjs` — one shared preflight, run by both
release workflows right after the certificate is imported and the profile
installed, and **before** anything is signed or exported:

| assertion | catches |
|---|---|
| `profile-authorizes-certificate` | the leaf's SHA-1 is not in `DeveloperCertificates` (the primary check) |
| `certificate-key-pair` | a truncated or mis-assembled `.p12` whose cert and key are different pairs |
| `keychain-identity` | the identity `find-identity` resolved is not the leaf that was checked |
| `application-identifier` | a profile issued for another bundle id |
| `team-identifier` | a profile from another team (`--team-id`, defaulting to `$APPLE_TEAM_ID`) |
| `profile-validity` / `certificate-validity` | either window expired, or inside `--warn-days` (default 30) |

**The failure output is the deliverable.** It names the imported fingerprint,
every certificate the profile *does* authorize with its own expiry, both expiry
dates, and which assertion failed:

```
  FAIL profile-authorizes-certificate: the imported certificate 88:05:…:74:8B
       (Apple Distribution: Fixture B, expires 2028-11-14T22:36:05Z)
       is not among the 1 certificate(s) this profile authorizes:
         51:BB:…:A8:67 (Apple Distribution: Fixture A, expires 2028-11-14T22:36:05Z)
       signing would still produce an archive and fail only at `xcodebuild -exportArchive`.
       the .p12 in the environment holds the wrong identity, or the profile is not the one issued for it.

  FAILED: profile-authorizes-certificate -- refusing to sign.
```

Both dates are printed on success too, because they differ and the certificate
is the one that dies first (2027-04-16 vs the profile's 2027-08-08) — the date
nobody watches.

## Proving it fails

`scripts/verify-signing-identity.node-test.mjs` (36 assertions) builds real
throwaway material with `openssl`: two self-signed certificates, a CMS-wrapped
provisioning profile embedding only the first, and a PKCS#12 for each. It then
proves the matched pair passes and **the mismatched pair is rejected**, that the
message carries both fingerprints and both dates, that a cert/key mismatch, a
wrong bundle id, a wrong team, a wrong keychain identity, an expired certificate
under a live profile, and an expired profile are each rejected, and that a
near-expiry warns without failing. Nothing skips: `openssl` missing is an
assertion failure, not a skip, and one test forces the non-macOS decoder so the
Linux path is exercised even here.

This is possible because the parsing is pure Node — a small XML-plist reader,
`node:crypto`'s `X509Certificate`, SHA-1 over the DER (asserted equal to what
`openssl x509 -fingerprint -sha1` prints). `security cms -D` unwraps the profile
where it exists, `openssl smime -verify` where it does not, and openssl is used
only to open the `.p12`.

It runs unconditionally in `rs / changes` — the one job no diff can skip —
together with the script's own `--self-test`, which the release jobs also run
immediately before trusting its verdict.

## Wiring

Signing jobs may not check the repository out (the credential boundary forbids
it), so the checker travels inside the **attested unsigned payload**, exactly as
`asc-testflight.mjs` already reaches the upload job: the credential-free builder
copies it in, `CHECKSUMS.sha256` covers it, the attestation binds it to the
released source, and the signing job's inventory check names it.

It replaces the three hand-inlined copies of the `DeveloperCertificates` loop:
ZUULI iOS, ZUULI macOS Developer ID, and e2e2z iOS. `apple-credential-boundary.mjs`
now *requires* the preflight in both signing jobs, requires it to be bound to
the resolved keychain identity, and requires it to run before the export or the
signature — with a mutation test for each of those five ways it could be present
in form and absent in effect. The two credential-job digests and the
`releasing.md` surface digest move with the reviewed change.

Target-aware by construction: only the iOS/macOS signing jobs call it, Android
paths are untouched, and `--allow-missing-inputs` makes a path with no Apple
inputs print an explicit `SKIP` line rather than fail (missing inputs *without*
that flag are still an error, so a skip is never silent).

## Not done, deliberately

- **The free2z mobile release workflow does not exist yet** — another agent is
  building it. It needs the same two lines (`cp` into the payload from the
  builder, `--self-test` + the verdict in the signer) when it lands.
- The macOS **DMG**-signing step re-imports the same Developer ID `.p12` but has
  no profile to check it against, so it keeps its existing identity assertion.
- The `PlistBuddy` extraction of the profile's UUID/name/team/app-id stays in
  both signing jobs: the UUID is needed to install the profile anyway, and a
  second, independent parser agreeing is worth more than the deleted lines.

## Verified locally

- `node scripts/verify-signing-identity.mjs --self-test` and
  `node --test scripts/verify-signing-identity.node-test.mjs` — 36/36 (macOS;
  the openssl decoder path is covered explicitly, but Linux CI is the first run
  on Linux)
- `node scripts/check-github-actions-pins.mjs`, `check-workflow-gates.mjs`,
  `check-markdown-links.mjs` — live and `--self-test`
- `wallet/zuuli`: `apple-credential-boundary.mjs` + its node-test (203/203),
  `macos-keychain-entitlements.mjs`, `verify-ci-cache-policy.mjs`,
  `status-freshness` / `artifact-sbom` / `aab-payload-digest` /
  `release-tag-identity` node-tests
- `wallet/e2e2z`: `release-path` and `authority-boundary` node-tests
- All three touched workflows parse as YAML, and every touched `run:` block is
  `bash -n` clean

**Not verified, and cannot be from here:** the preflight has never run against a
real Apple `.p12` or `.mobileprovision` on a macOS runner. The `security cms -D`
and `openssl pkcs12` invocations mirror what these jobs already do, and the
`-legacy` retry covers OpenSSL 3 versus LibreSSL, but the first real proof is
the next release run.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
