### PR TITLE
docs: per-app export-classification records for the three Tauri apps (#961)

### DIFF
--- a/wallet/e2e2z/docs/export-classification.md
+++ b/wallet/e2e2z/docs/export-classification.md
@@ -1,0 +1,294 @@
+# Export classification record — e2e2z (`cash.free2z.e2e2z`)
+
+> **Status: facts assembled. Nothing here is a determination.**
+>
+> This document is the engineering half of [#961](https://github.com/free2z/zuu/issues/961):
+> a per-app inventory of the cryptography that actually ships, measured from the
+> dependency graph rather than assumed. **Corpora approves the classification
+> basis and export counsel resolves the legal points.** Every proposal below is
+> labelled as a proposal and carries its own counter-argument. No value of
+> `ITSAppUsesNonExemptEncryption`, `iosUsesNonExemptEncryption`, or any CI
+> assertion about them was changed by the work that produced this file.
+>
+> Companion records: [ZUULI](../../zuuli/docs/export-classification.md),
+> [free2z](../../free2z/docs/export-classification.md).
+
+## 1. Why this app cannot inherit ZUULI's basis
+
+`wallet/e2e2z/src-tauri/Info.ios.plist` declares
+`ITSAppUsesNonExemptEncryption = false`, `wallet/e2e2z/release.json` pins
+`iosUsesNonExemptEncryption: false`, `release.schema.json` fixes it as
+`"const": false`, and `.github/workflows/e2e2z-release.yml` asserts it on the
+shipped bundle. The declaration is therefore made in-repo and mechanically
+frozen; App Store Connect never asks, because the plist key answers at upload
+time.
+
+The only recorded basis in the tree is ZUULI's, in
+[`wallet/zuuli/docs/releasing.md`](../../zuuli/docs/releasing.md), which says
+ZUULI's non-OS cryptography "uses published, non-proprietary algorithms and is
+**limited to its Zcash wallet and financial-transaction functionality**." e2e2z
+is not a wallet and holds no seed. Its function *is* message confidentiality.
+That basis does not describe it, and copying it forward is the specific defect
+#961 exists to fix.
+
+## 2. How this inventory was measured
+
+Measured at `origin/main` `28f09c6c`, on the iOS release target, with build
+scripts, proc-macro-only paths and dev-dependencies excluded from the shipped
+set:
+
+```
+cd wallet/e2e2z/src-tauri
+cargo tree --locked --edges normal --target aarch64-apple-ios --prefix none
+```
+
+360 packages resolve. The JavaScript bundle was checked separately: neither
+`wallet/e2e2z/package.json` nor its lockfile contains a cryptographic library,
+and `wallet/e2e2z/src/lib/enrollment/deviceKeys.ts` states as a rule that there
+is no `crypto.subtle` in this frontend and there must never be one. **All of
+e2e2z's cryptography is in the Rust binary or in the OS.**
+
+Re-run the command above after any dependency change; a diff in the crate list
+is the trigger to revisit this record.
+
+## 3. What ships in the release binary
+
+### 3.1 Message confidentiality — MLS, bundled
+
+| Crate | Version | Reached through | Primitive / role |
+|---|---|---|---|
+| `openmls` | 0.9.0 | `f2z-msg-mls` → `tauri-plugin-f2zmsg` | MLS (RFC 9420) group messaging protocol |
+| `openmls_libcrux_crypto` | 0.4.0 | `f2z-msg-mls` | The crypto provider; selects libcrux for every primitive |
+| `openmls_traits`, `openmls_memory_storage` | 0.6.0 / 0.6.0 | `openmls` | Provider/storage traits |
+| `hpke-rs`, `hpke-rs-crypto`, `hpke-rs-libcrux` | 0.7.0 | `openmls_libcrux_crypto`, `openmls` | HPKE (RFC 9180) — MLS welcome/init-key encryption |
+| `libcrux-kem`, `libcrux-ml-kem` | 0.0.9 / 0.0.10 | `hpke-rs-libcrux` | **ML-KEM-768** (FIPS 203), the PQ half of X-Wing |
+| `libcrux-curve25519`, `libcrux-ecdh` | 0.0.8 | `hpke-rs-libcrux` | **X25519** (RFC 7748), the classical half of X-Wing |
+| `libcrux-chacha20poly1305`, `libcrux-poly1305`, `libcrux-aead`, `libcrux-aes` | 0.0.9 / 0.0.6 / 0.0.9 / 0.0.9 | `hpke-rs-libcrux`, `openmls_libcrux_crypto` | **ChaCha20-Poly1305** (RFC 8439) AEAD; AES is linked by the provider but not selected by our ciphersuite |
+| `libcrux-sha2`, `libcrux-sha3` | 0.0.8 / 0.0.10 | provider, ML-KEM | **SHA-256/512** (FIPS 180-4), **SHA-3/SHAKE** (FIPS 202) |
+| `libcrux-hkdf`, `libcrux-hmac`, `libcrux-hmac-drbg` | 0.0.8 / 0.0.8 / 0.0.1 | provider | **HKDF** (RFC 5869), **HMAC** (RFC 2104 / FIPS 198-1) |
+| `libcrux-ed25519` | 0.0.9 | `f2z-msg-mls` (our own `Signer`) | **Ed25519** (RFC 8032) — MLS leaf signatures |
+| `libcrux-p256` | 0.0.8 | provider | NIST P-256; linked, not selected by our ciphersuite |
+| `tls_codec` | 0.5.0 | `openmls`, `f2z-msg-identity` | RFC 9420 wire encoding (not TLS transport, not cryptography) |
+
+The ciphersuite is a compile-time constant with exactly one value
+(`rs/crates/f2z-msg-mls/src/engine.rs`):
+
+```rust
+pub const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519;
+```
+
+It is not negotiable and not configurable, and `keypackage.rs` refuses any key
+package that names a different one, so a relay cannot downgrade a client.
+
+**Purpose:** message confidentiality and sender authentication, end to end,
+between devices. Application payloads travel as MLS `PrivateMessage`
+(RFC 9420 §6.3); the relay sees an opaque blob and a queue address.
+
+### 3.2 Identity and key hierarchy — bundled
+
+| Crate | Reached through | Primitive / role |
+|---|---|---|
+| `ed25519-dalek` 2.2.0 and 3.0.0 | `f2z-msg-identity`, `f2z-kt-core` | **Ed25519** — device credential issuance, directory/queue authentication, KT log signatures |
+| `blake2` 0.10.6 | `f2z-msg-identity` | **BLAKE2b-512** (RFC 7693) with a 16-byte personalization — the ZIP 32 idiom used for the seed-derived messaging tree |
+| `hkdf` 0.12.4 + `sha2` 0.10.9/0.11.0 | `f2z-msg-identity` | **HKDF-SHA-256** — the four account leaves |
+| `blake3` 1.8.7 | `akd_core` → `f2z-kt-core` | BLAKE3 hashing inside the key-transparency (AKD) tree |
+| `curve25519-dalek` 4.1.3 and 5.0.0, `signature`, `zeroize`, `subtle` | above | Curve arithmetic, signature traits, secret hygiene, constant-time comparison |
+
+Per-device keys (`DeviceSignatureKey`, the X-Wing `DeviceInitKey`, per-queue
+keys) come from the **OS CSPRNG** (`rand` 0.10 in `tauri-plugin-f2zmsg`, over
+`getrandom`) and are never seed-derived. e2e2z does not link
+`tauri-plugin-zcash` and cannot reach a seed; a build that links it fails
+`wallet/e2e2z/scripts/authority-boundary.node-test.mjs`.
+
+**Purpose:** authentication and signing (identity → device binding), plus key
+derivation. Not confidentiality.
+
+### 3.3 Transport — bundled TLS
+
+| Crate | Version | Reached through | Role |
+|---|---|---|---|
+| `rustls` | 0.23.43 | `ureq` → `f2z-kt-client`; `tokio-tungstenite` → `tauri-plugin-f2zmsg` | **TLS 1.2/1.3** (RFC 8446 / RFC 5246) client |
+| `ring` | 0.17.14 | `rustls` | rustls's default crypto provider — AES-GCM, ChaCha20-Poly1305, ECDHE, ECDSA/RSA verification, SHA-2, HMAC/HKDF |
+| `rustls-webpki` | 0.103.15 | `rustls` | X.509 path validation |
+| `rustls-platform-verifier` | 0.7.0 | `ureq` | Delegates certificate trust to the **OS** trust store (`security-framework` on Apple) |
+| `webpki-roots` | 0.26.11, 1.0.9 | `tokio-tungstenite` (`rustls-tls-webpki-roots`) | **Bundled** Mozilla root store for the relay WebSocket |
+| `tokio-tungstenite` / `tungstenite` | 0.30.0 | `tauri-plugin-f2zmsg` | RFC 6455 WebSocket to the relay |
+
+**Purpose:** transport confidentiality to the relay and to the key-transparency
+service. This is the ordinary "HTTPS/TLS" case, with one nuance worth recording:
+the TLS *protocol* is bundled (rustls + ring), not Apple's; certificate *trust*
+is OS-supplied on the `ureq` path and bundled (webpki-roots) on the WebSocket
+path.
+
+### 3.4 At-rest key sealing — OS-supplied on iOS and Android
+
+`tauri-plugin-f2zmsg/src/custody.rs` (ADR 0016 §3, [#937](https://github.com/free2z/zuu/issues/937))
+holds one 32-byte `DeviceWrapKey` in the OS secret store:
+
+- **iOS** — Keychain via `Security.framework` (`SecItemAdd`/`SecItemCopyMatching`),
+  `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, no `SecAccessControl`,
+  `kSecAttrSynchronizable = false`. See
+  `wallet/plugins/tauri-plugin-f2zmsg/ios/Sources/F2zMsgPlugin.swift`. **No
+  bundled cipher is involved on iOS.**
+- **Android** — an `AndroidKeyStore` **AES-256-GCM** key, non-exportable,
+  StrongBox where offered with a TEE then software fallback;
+  `javax.crypto.Cipher` with `GCMParameterSpec`. See
+  `wallet/plugins/tauri-plugin-f2zmsg/android/src/main/java/F2zMsgPlugin.kt`.
+  The cipher is the platform's, not a bundled implementation.
+- **macOS / Linux / Windows** — `keyring` 3.6.3 (`apple-native`,
+  `linux-native-sync-persistent` + `crypto-rust`, `windows-native`). Not present
+  in the iOS graph.
+
+The local message store is `rusqlite`-backed
+(`rs/crates/f2z-msg-store`); the group state it holds is OpenMLS's own key
+material, sealed under the `DeviceWrapKey` above rather than under a separate
+bundled cipher.
+
+### 3.5 Not in this binary
+
+`tauri-plugin-zcash` and the entire librustzcash/Zcash proving stack are
+**absent by construction** and enforced by a build gate. e2e2z carries no
+Groth16/Halo 2 proving system, no `secp256k1`, no BIP-32/BIP-39, and no wallet
+database. Its Cargo manifest documents this as the security boundary
+([#904](https://github.com/free2z/zuu/issues/904)).
+
+## 4. Standards status of each primitive
+
+This is the hinge for Apple's middle tier — *industry-standard encryption
+implemented outside Apple's OS* requires only a French declaration where the app
+is distributed in France, with no CCATS and no Apple document upload.
+
+| Primitive | Standards body / citation | Accepted? |
+|---|---|---|
+| TLS 1.3 / 1.2 | IETF RFC 8446 / RFC 5246 | Yes |
+| ChaCha20-Poly1305 | IETF RFC 8439; in TLS RFC 7905 | Yes |
+| AES / AES-GCM (in `ring`, and Android keystore) | NIST FIPS 197; NIST SP 800-38D | Yes |
+| SHA-2 | NIST FIPS 180-4 | Yes |
+| SHA-3 / SHAKE | NIST FIPS 202 | Yes |
+| HMAC | IETF RFC 2104; NIST FIPS 198-1 | Yes |
+| HKDF | IETF RFC 5869 | Yes |
+| Ed25519 | IETF RFC 8032; NIST FIPS 186-5 | Yes |
+| X25519 | IETF RFC 7748 | Yes |
+| HPKE | IETF RFC 9180 | Yes |
+| MLS protocol | IETF RFC 9420 (architecture: RFC 9750) | Yes |
+| ML-KEM-768 | NIST FIPS 203 | Yes |
+| BLAKE2b | IETF RFC 7693 | Yes |
+| **X-Wing hybrid KEM** | IETF CFRG **Internet-Draft** `draft-connolly-cfrg-xwing-kem` — **not an RFC** | **Not yet** |
+| **The MLS ciphersuite codepoint `0x004D`** | `draft-ietf-mls-pq-ciphersuites` — **not an IANA assignment**; registered MLS suites are `0x0001`–`0x0007` | **No** |
+| BLAKE3 | Published specification, no IETF/NIST/ISO standard | No |
+
+Two of these deserve the emphasis they are given above, because they are the
+only places where "industry standard, accepted by international standards
+bodies" is genuinely arguable rather than obvious.
+
+`rs/crates/f2z-msg-mls/src/version.rs` records the codepoint problem in the
+source, states that it is a **naming** risk and not a re-key —
+[#385](https://github.com/free2z/zuu/issues/385) checked libcrux's X-Wing
+draft-06 vectors against the live draft-10 Appendix C vectors and found them
+byte-identical — and stores a `ProtocolVersion` beside every group so a
+relabel is a migration that can be written. A test asserts
+`codepoint_is_registered() == false`.
+
+## 5. Post-quantum: shipping today, not planned
+
+**This is the fact most likely to be got wrong, so it is stated plainly:
+hybrid post-quantum key establishment is in the binary that ships today.** It is
+not roadmap work and it is not behind a flag.
+
+- **Today, in the shipping binary:** X25519 + **ML-KEM-768** via X-Wing, as the
+  MLS KEM, on every group, unconditionally. `docs/e2ee/ARCHITECTURE.md` §5.2:
+  "hybrid post-quantum from day one." `libcrux-ml-kem 0.0.10` is in the iOS
+  dependency graph via `libcrux-kem` → `hpke-rs-libcrux` →
+  `openmls_libcrux_crypto` → `f2z-msg-mls` → `tauri-plugin-f2zmsg` → `e2e2z`.
+- **Not today, and listed as future work:** post-quantum *signatures*. Every
+  signature in the system — MLS leaf, identity, device, ceremony, KT log — is
+  Ed25519. `ARCHITECTURE.md` §5.5 states this as an accepted limitation and
+  §13-C lists migration (e.g. ML-DSA) as future work; the roadmap issue is
+  [#316](https://github.com/free2z/zuu/issues/316).
+
+A record that describes e2e2z as "planning" post-quantum work would be wrong in
+the direction that matters.
+
+One documentation discrepancy worth correcting somewhere: `ARCHITECTURE.md` §5.2
+describes the AEAD as "AES-128-GCM (or ChaCha20-Poly1305 where AES is not
+hardware-accelerated)". The shipping ciphersuite constant is
+ChaCha20-Poly1305 unconditionally, and `provider.rs` has a test named
+`the_ciphersuite_uses_chacha20poly1305_and_not_aes_gcm`. **The code, not the
+prose, is what this record reports.**
+
+## 6. Proposed ASC questionnaire answer — a proposal for review
+
+**Proposal.** e2e2z uses encryption; it is not limited to encryption supplied by
+Apple's OS; and the encryption it bundles is standards-track cryptography used
+for message and transport confidentiality. On Apple's three-tier table that
+places it in the **middle tier** — industry-standard encryption implemented
+outside Apple's OS — which requires a **French declaration where the app is
+distributed in France** and no CCATS and no Apple document upload. On that
+reading the current `false` may be sustainable, but **for a different reason
+than ZUULI's**, and it must be recorded as e2e2z's own basis rather than
+inherited.
+
+**Reasoning.** Every primitive that carries confidentiality in this app —
+TLS 1.3, ChaCha20-Poly1305, HPKE, X25519, ML-KEM-768, SHA-2, HKDF, Ed25519 — is
+an IETF RFC or a NIST FIPS, and the protocol wrapping them is RFC 9420. Nothing
+here is a proprietary algorithm of our own invention. The implementations are
+third-party open-source libraries (OpenMLS, libcrux, rustls/ring, RustCrypto).
+
+**The strongest counter-argument, and it is not weak.**
+
+1. **The composition is not the standard, even where the parts are.** X-Wing is
+   a CFRG Internet-Draft, not an RFC, and the MLS ciphersuite codepoint `0x004D`
+   is not an IANA assignment. A reviewer who reads "accepted as international
+   standards" strictly can say that the *KEM actually used* is a draft
+   construction at an unregistered codepoint — which is closer to Apple's third
+   tier ("not accepted as international standards") than the middle one, even
+   though X25519 and ML-KEM are each standardised. This is a legal reading
+   question about how much aggregation the phrase tolerates, and it is exactly
+   the kind of question engineering should not answer.
+2. **End-to-end encrypted messaging is the category most likely to carry
+   separate U.S. obligations.** Apple's documentation requirement and BIS's
+   reporting duties are different questions. Even if the middle tier is right
+   and `false` is right for Apple, the EAR mass-market self-classification
+   route (annual self-classification report / encryption registration) may
+   still apply. Nothing in this repository discharges that, and `false` in the
+   plist asserts nothing about it either way.
+3. **ZUULI's precedent proves only Apple's acceptance.** ZUULI has shipped 20
+   builds with `false`. That is evidence that App Store Connect accepted the
+   uploads. It is not a government classification and it is not precedent for a
+   messenger.
+4. **"Open source" does not settle it.** The messaging crates are MIT and
+   public on GitHub. Publication may bear on the analysis; it does not by itself
+   resolve the application's status.
+
+## 7. What a human still has to decide
+
+Engineering cannot close any of these. They are listed so the decision is cheap,
+not so it is skipped.
+
+1. **Is the middle tier the right tier for e2e2z?** Specifically: does X-Wing at
+   an unregistered MLS codepoint count as "industry-standard encryption" for
+   Apple's purposes, given that both of its component KEMs are standardised?
+   *(Counsel.)*
+2. **Is `false` the correct value for `ITSAppUsesNonExemptEncryption`?** Both
+   directions need a considered answer — `true` leads to a follow-up exemption
+   question that also has to be answered. *(Owner, with counsel.)*
+3. **Which EAR route applies, and does anything have to be filed?** Mass-market
+   self-classification, ECCN, annual self-classification report, encryption
+   registration. This record deliberately asserts no ECCN. *(Counsel.)*
+4. **Is France in e2e2z's intended territory availability?** **This cannot be
+   determined from the repository.** `wallet/e2e2z/release.json` and
+   `store-identity.json` carry no territory or availability field, and no
+   workflow sets one; territory availability is configured in App Store Connect
+   and is not mirrored here. If France is in scope, the French declaration
+   applies under the middle tier. *(Owner.)*
+5. **Does the answer have to hold for Google Play too?** Play asks its own
+   export-compliance questions and this record covers only the Apple side plus
+   the underlying technical facts.
+6. **Should the technical facts be re-verified before the first real upload?**
+   `dry_run: true` builds, signs and validates without uploading, so it makes no
+   declaration; only the first real upload does.
+
+Once decided, the acceptance criteria in
+[#961](https://github.com/free2z/zuu/issues/961) require `Info.ios.plist`,
+`release.json`, `release.schema.json` and the workflow assertion to agree with
+the decision, and the basis to be recorded here rather than left implicit.

--- a/wallet/free2z/docs/export-classification.md
+++ b/wallet/free2z/docs/export-classification.md
@@ -1,0 +1,217 @@
+# Export classification record — free2z (`cash.free2z.free2z`)
+
+> **Status: facts assembled. Nothing here is a determination.**
+>
+> This document is the engineering half of [#961](https://github.com/free2z/zuu/issues/961)
+> for the content surface: an inventory of the cryptography that actually ships,
+> measured from the dependency graph rather than assumed. **Corpora approves the
+> classification basis and export counsel resolves the legal points.** Every
+> proposal below is labelled as a proposal and carries its own
+> counter-argument. No value of `iosUsesNonExemptEncryption` or any CI assertion
+> about it was changed by the work that produced this file.
+>
+> Companion records: [ZUULI](../../zuuli/docs/export-classification.md),
+> [e2e2z](../../e2e2z/docs/export-classification.md).
+
+## 1. Current standing
+
+`wallet/free2z/release.json` pins `iosUsesNonExemptEncryption: false` and
+`release.schema.json` fixes it as `"const": false`. **There is no
+`Info.ios.plist` for this app yet** — `wallet/free2z/src-tauri/` contains no
+plist at all — so nothing is asserted to Apple until one is generated, and the
+first upload is the moment the declaration is made.
+
+No basis has ever been recorded for this app. The only recorded basis in the
+tree is ZUULI's, which is tied to wallet and financial-transaction
+functionality; free2z has neither.
+
+**The one thing that must not be assumed:** free2z has no wallet and no
+messaging plugin, and it is nevertheless **not** an Apple-OS-only app. It
+bundles a TLS implementation. That is the finding this record exists to make
+explicit.
+
+## 2. How this inventory was measured
+
+Measured at `origin/main` `28f09c6c`, on the iOS release target, with build
+scripts, proc-macro-only paths and dev-dependencies excluded from the shipped
+set:
+
+```
+cd wallet/free2z/src-tauri
+cargo tree --locked --edges normal --target aarch64-apple-ios --prefix none
+```
+
+258 packages resolve — the smallest of the three surfaces. The JavaScript bundle
+was checked separately: `wallet/free2z/package.json` and its lockfile contain no
+cryptographic library.
+
+## 3. What ships in the release binary
+
+### 3.1 The whole of it: one bundled TLS client
+
+| Crate | Version | Reached through | Primitive / role |
+|---|---|---|---|
+| `rustls` | 0.23.43 | `reqwest` 0.12.28 → `tauri-plugin-http` 2.6.0 | **TLS 1.2/1.3** (RFC 8446 / RFC 5246) client |
+| `ring` | 0.17.14 | `rustls`, `rustls-webpki` | rustls's default crypto provider: **AES-GCM**, **ChaCha20-Poly1305**, ECDHE (X25519, P-256/384), ECDSA and RSA signature *verification*, **SHA-2**, **HMAC/HKDF** |
+| `rustls-webpki` | 0.103.15 | `rustls` | X.509 certificate path validation |
+| `webpki-roots` | 1.0.9 | `reqwest`, `hyper-rustls` | **Bundled** Mozilla root store — trust anchors ship in the binary rather than coming from the OS |
+| `hyper-rustls` | 0.27.9 | `reqwest` | TLS glue for the HTTP client |
+| `tokio-rustls` | 0.26.5 | `reqwest`, `hyper-rustls` | Async TLS glue |
+| `subtle` | 2.6.1 | `rustls` | Constant-time comparison |
+| `zeroize` | 1.9.0 | `rustls` | Secret hygiene |
+| `getrandom` | 0.2/0.3/0.4 | various | OS CSPRNG boundary (`SecRandomCopyBytes` / `getentropy` on Apple) |
+
+The dependency edge is explicit in `wallet/free2z/src-tauri/Cargo.toml`:
+
+```toml
+tauri-plugin-http = { version = "2.5.9", default-features = false, features = [
+    "rustls-tls",
+    "http2",
+    "charset",
+    "macos-system-configuration",
+] }
+```
+
+`"rustls-tls"` is the line that puts a bundled TLS implementation in this
+binary. `default-features = false` drops only the cookie jar, for the ambient-
+authority reason the manifest documents; it does not affect the crypto.
+
+**Purpose:** transport confidentiality, and nothing else. The client's reach is
+URL-scoped by `wallet/free2z/src-tauri/capabilities/default.json` to
+`https://free2z.cash/*`, `https://*.free2z.cash/*`, `https://free2z.com/*` and
+`https://*.free2z.com/*`. free2z authenticates with a bearer token in an
+`Authorization` header; it holds no long-term key material of its own.
+
+### 3.2 Compile-time only — not in the shipped binary
+
+`sha2 0.10.9` appears in the graph solely under `tauri-codegen` →
+`tauri-macros`, a **proc-macro** that runs during compilation to hash bundled
+assets. It is not linked into the application binary. Recorded here so that a
+future reader who greps the crate list does not mistake it for shipped
+cryptography.
+
+### 3.3 Not in this binary, by construction
+
+`tauri-plugin-zcash` and `tauri-plugin-f2zmsg` are **absent and must stay
+absent** — the content surface renders third-party markup, embeds and remote
+media, so linking either would put a privileged command in the invoke handler
+that [#367](https://github.com/free2z/zuu/issues/367)'s frame confusion could
+reach. `wallet/zuuli/scripts/surface-capability-authority.mjs` enforces the
+capability half. Consequently free2z contains **no** proving system, **no**
+signing keys, **no** message encryption, **no** key derivation, and **no**
+secret store.
+
+### 3.4 Apple-OS-supplied cryptography
+
+- **All WebView traffic.** Page loads, images, video, and the
+  `@cloudflare/realtimekit` live-media SDK all run inside WKWebView and use the
+  system networking stack — including WebRTC's DTLS-SRTP for live sessions,
+  which is WebKit's implementation, not ours. free2z bundles no media or
+  WebRTC cryptography.
+- **WebCrypto.** `wallet/free2z/src/lib/oauth/protocol.ts` uses
+  `crypto.subtle.digest("SHA-256", …)` and `crypto.getRandomValues` to
+  implement **PKCE (RFC 7636)** for OAuth; `crypto.getRandomValues` and
+  `crypto.randomUUID` supply nonces and idempotency keys in
+  `features/live/membership.ts` and `features/articles/article-drafts.ts`.
+  These are WebKit's WebCrypto, i.e. the OS's.
+- **Certificate trust on the WebView path** comes from the OS trust store; on
+  the `tauri-plugin-http` path it comes from the bundled `webpki-roots`
+  instead. This asymmetry is worth recording precisely because it is the
+  difference between "OS-only" and "not OS-only".
+
+### 3.5 Copy protection
+
+None. No DRM, no licence enforcement, no anti-tamper cryptography. Article and
+media access control is server-side authorisation over TLS, not client-side
+cryptography.
+
+## 4. Standards status of each primitive
+
+Every primitive in this binary is standards-accepted; there is no draft
+construction and no unregistered codepoint anywhere in free2z.
+
+| Primitive | Standards body / citation | Accepted? |
+|---|---|---|
+| TLS 1.3 / TLS 1.2 | IETF RFC 8446 / RFC 5246 | Yes |
+| AES-GCM | NIST FIPS 197; NIST SP 800-38D | Yes |
+| ChaCha20-Poly1305 (in TLS) | IETF RFC 8439; RFC 7905 | Yes |
+| ECDHE — X25519, P-256, P-384 | IETF RFC 7748; NIST FIPS 186-5 / SP 800-56A | Yes |
+| ECDSA / RSA (verification only) | NIST FIPS 186-5; IETF RFC 8017 | Yes |
+| SHA-2 | NIST FIPS 180-4 | Yes |
+| HMAC / HKDF | IETF RFC 2104, FIPS 198-1 / RFC 5869 | Yes |
+| X.509 path validation | IETF RFC 5280 | Yes |
+| PKCE (WebCrypto path, OS-supplied) | IETF RFC 7636 | Yes |
+
+## 5. Post-quantum
+
+**None, today or planned.** No ML-KEM, no X-Wing, no hybrid key exchange, no
+post-quantum signatures anywhere in this binary. rustls 0.23 with the `ring`
+provider does not enable a hybrid group by default, and nothing in this
+manifest turns one on.
+
+This is stated explicitly because e2e2z and ZUULI both *do* ship hybrid
+post-quantum key establishment today, and a reader moving between the three
+records should not carry that across.
+
+## 6. Proposed ASC questionnaire answer — a proposal for review
+
+**Proposal.** free2z uses encryption. It is **not** limited to encryption
+supplied by Apple's OS, because `tauri-plugin-http`'s `rustls-tls` feature
+bundles a complete TLS implementation and a bundled root store. Everything it
+bundles is standards-accepted (§4) and is used exclusively for transport
+confidentiality to first-party hosts. On Apple's three-tier table that places it
+in the **middle tier** — industry-standard encryption implemented outside
+Apple's OS — which requires a **French declaration where the app is distributed
+in France**, and no CCATS and no Apple document upload. On that reading the
+pinned `false` is plausibly correct, but for a reason that has to be recorded
+rather than assumed, and the French question has to be answered before the
+first upload.
+
+**Reasoning.** This is the simplest of the three assessments by a wide margin.
+One purpose (transport), one library family (rustls + ring), zero
+non-standard constructions, zero key custody, zero at-rest encryption, zero
+post-quantum, zero proprietary algorithms.
+
+**The strongest counter-arguments.**
+
+1. **"It's only HTTPS" is a conclusion, not a fact.** The middle tier still
+   carries the French declaration obligation, and free2z's `false` was pinned
+   before anyone established that it belongs in the middle tier rather than the
+   top one. The value happens to be plausible; the process that produced it did
+   not check.
+2. **A trivially small change moves the app.** Removing `rustls-tls` in favour
+   of `native-tls` would arguably make free2z genuinely Apple-OS-only; adding
+   any client-side encryption feature would move it the other way. Nothing in
+   CI notices either. If the classification is going to depend on this one
+   Cargo feature, that dependency should be recorded where the next person
+   editing that manifest will see it.
+3. **BIS reporting is a separate question** from Apple's documentation
+   requirement, even for an app whose only cryptography is TLS.
+4. **The plist does not exist yet.** `release.json` says `false`, but the app
+   has no `Info.ios.plist`. Whatever is decided must be written into the plist
+   the generator produces, and the CI assertion for this app has to be created,
+   not merely reused from ZUULI's.
+
+## 7. What a human still has to decide
+
+1. **Is the middle tier the right tier, and is `false` the right value?**
+   *(Owner, with counsel.)*
+2. **Is France in free2z's intended territory availability?** **Not determinable
+   from the repository.** `wallet/free2z/release.json` carries no territory or
+   availability field, there is no `store-identity.json` for this app, and no
+   workflow sets one; territory availability is configured in App Store Connect.
+   If France is in scope, the French declaration applies under the middle tier.
+   *(Owner.)*
+3. **Does anything have to be filed with BIS for a transport-only app?** This
+   record deliberately asserts no ECCN. *(Counsel.)*
+4. **Should the decision be pinned to the `rustls-tls` feature in CI?** If the
+   basis is "bundled but standards-accepted transport crypto only", then a
+   future change that adds a second purpose should fail a check rather than
+   pass silently. *(Owner — engineering can implement whichever answer is
+   given.)*
+5. **Google Play's own export questions** are out of scope for this record.
+
+Once decided, `Info.ios.plist` must be created with the agreed value,
+`release.json` and `release.schema.json` must agree with it, and a bundle
+assertion equivalent to `.github/workflows/e2e2z-release.yml`'s must be added
+for this app.

--- a/wallet/zuuli/docs/export-classification.md
+++ b/wallet/zuuli/docs/export-classification.md
@@ -1,0 +1,298 @@
+# Export classification record — ZUULI (`cash.free2z.zuuli`)
+
+> **Status: facts assembled. Nothing here is a determination.**
+>
+> This document is the engineering half of [#961](https://github.com/free2z/zuu/issues/961)
+> for ZUULI: an inventory of the cryptography that actually ships, measured from
+> the dependency graph rather than assumed. **Corpora approves the
+> classification basis and export counsel resolves the legal points.** Every
+> proposal below is labelled as a proposal and carries its own
+> counter-argument. No value of `ITSAppUsesNonExemptEncryption`,
+> `iosUsesNonExemptEncryption`, or any CI assertion about them was changed by
+> the work that produced this file.
+>
+> It extends, and does not replace,
+> [`releasing.md` § Release records for cryptography](./releasing.md#release-records-for-cryptography),
+> which remains the runbook's own record of the answer given to App Store
+> Connect. Companion records:
+> [e2e2z](../../e2e2z/docs/export-classification.md),
+> [free2z](../../free2z/docs/export-classification.md).
+
+## 1. The finding that matters most
+
+ZUULI's recorded basis says its non-OS cryptography "uses published,
+non-proprietary algorithms and is **limited to its Zcash wallet and
+financial-transaction functionality**."
+
+**That second clause no longer describes the binary.** Since
+[#750](https://github.com/free2z/zuu/issues/750) (merged 2026-08-25), ZUULI
+links `tauri-plugin-f2zmsg` and the messaging-core crates, and its iOS
+dependency graph contains the complete MLS end-to-end-encrypted messaging
+engine — OpenMLS, HPKE, and X-Wing hybrid post-quantum key establishment
+(X25519 + ML-KEM-768) — identical to e2e2z's. `wallet/zuuli/release.json`
+records build 20; the messaging plugin has been in the source of every build
+from 16 onward.
+
+Two qualifications, both real:
+
+- **Most of it is unreachable from the WebView.** After
+  [#916](https://github.com/free2z/zuu/issues/916), no capability grants any
+  `f2zmsg:` permission, so the plugin's 43 commands are registered but cannot
+  be invoked from the frontend (`wallet/zuuli/src-tauri/src/lib.rs`).
+- **The enrollment trio is reachable and does real cryptography.**
+  `f2zmsg_enroll`, `f2zmsg_enrollment_status` and `f2zmsg_unenroll` are
+  app-crate commands routed by `generate_handler!`, which bypasses the
+  capability ACL. Enrollment derives the seed-based messaging key hierarchy and
+  issues a signed `DeviceCredential` — it is in ZUULI and not in e2e2z
+  precisely because it needs the wallet seed
+  ([#904](https://github.com/free2z/zuu/issues/904)).
+
+Whether "linked but mostly unreachable" changes the export answer is a legal
+question. What is not in question is that the *recorded basis* is now narrower
+than the *shipped binary*, and `releasing.md` itself sets that as the trigger
+to revisit: "Re-evaluate this declaration before shipping any proprietary or
+non-standard cryptography, or **any material change to how encryption is
+used**."
+
+## 2. How this inventory was measured
+
+Measured at `origin/main` `28f09c6c`, on the iOS release target, with build
+scripts, proc-macro-only paths and dev-dependencies excluded:
+
+```
+git submodule update --init z/zcash/librustzcash
+cd wallet/zuuli/src-tauri
+cargo tree --locked --edges normal --target aarch64-apple-ios --prefix none
+```
+
+501 packages resolve. The JavaScript bundle was checked separately:
+`wallet/zuuli/package.json` and its lockfile contain **no** cryptographic
+library. The frontend's only cryptography is WebCrypto — see §3.6.
+
+## 3. What ships in the release binary
+
+### 3.1 Zcash shielded protocol — bundled, and the largest block
+
+All reached through `tauri-plugin-zcash` → the librustzcash path dependencies in
+`z/zcash/librustzcash`.
+
+| Crate | Version | Primitive / role |
+|---|---|---|
+| `zcash_primitives`, `zcash_protocol`, `zcash_keys`, `zcash_client_backend`, `zcash_client_sqlite`, `zcash_transparent`, `pczt`, `zip321` | path deps | The protocol implementation itself |
+| `sapling-crypto` | 0.7.0 | Sapling note/spend/output circuits and key agreement |
+| `zcash_proofs` | 0.30.0 | Groth16 proving and verification, Sapling parameter loading |
+| `bellman`, `bls12_381`, `pairing`, `jubjub`, `group`, `ff` | 0.14.0 / 0.8.0 / 0.23.0 / 0.10.0 | **Groth16 zk-SNARK** over the **BLS12-381** pairing curve; Jubjub for in-circuit arithmetic |
+| `orchard` | 0.15.3 | Orchard actions, Sinsemilla and Poseidon hashes |
+| `halo2_proofs`, `halo2_gadgets`, `halo2_poseidon`, `pasta_curves` | 0.3.2 / 0.5.0 / 0.1.0 / 0.5.1 | **Halo 2** proof system over the **Pallas/Vesta** cycle |
+| `redjubjub`, `reddsa` | 0.8.0 / 0.5.2 | **RedDSA / RedJubjub / RedPallas** — re-randomisable Schnorr signatures for spend authorisation |
+| `zcash_note_encryption` | 0.4.2 | Note encryption: **ChaCha20-Poly1305** AEAD with a **BLAKE2b** KDF (ZIP 212) |
+| `chacha20poly1305`, `chacha20`, `poly1305`, `aead`, `cipher`, `universal-hash` | — | The AEAD implementation beneath it |
+| `aes`, `cbc`, `fpe` | 0.8.4 / 0.1.2 / 0.6.1 | **FF1 format-preserving encryption over AES** — Sapling diversifier derivation (ZIP 32), *not* bulk data encryption |
+| `blake2b_simd`, `blake2s_simd`, `blake2` | 1.0.4 / 1.0.4 / 0.10.6 | **BLAKE2b/BLAKE2s** — Zcash's pervasive hash and PRF construction |
+| `zcash_spec` | 0.2.1 | The BLAKE2b-based PRF/KDF constructions the protocol specifies |
+| `equihash` | 0.3.0 | Equihash proof-of-work verification |
+| `zcash_script`, `secp256k1`, `secp256k1-sys` | 0.4.5 / 0.29.1 / 0.10.1 | Transparent-pool **ECDSA over secp256k1**, consensus script verification |
+| `ripemd`, `sha1`, `sha2` | 0.1.3 & 0.2.0 / 0.10.7 & 0.11.0 / 0.10.9 & 0.11.0 | **RIPEMD-160**, **SHA-256** — transparent address and script hashing |
+| `zip32` | 0.2.1 | ZIP 32 shielded hierarchical key derivation |
+| `bip32` (free2z fork, rev `131d490e`) | 0.6.0-pre.1 | **BIP-32** transparent key derivation. The fork holds `secp256k1` at 0.29 and is documented as transient in the app manifest |
+| `bip0039`, `pbkdf2`, `password-hash` | 0.12.0 / 0.12.2 / 0.5.0 | **BIP-39** mnemonic → seed, i.e. **PBKDF2-HMAC-SHA-512** |
+| `bech32`, `f4jumble`, `zcash_address`, `zcash_encoding` | 0.11.1 / 0.1.1 / 0.13.0 / 0.4.0 | Address encoding — Bech32/Bech32m and F4Jumble. Encoding, not cryptography |
+| `secrecy`, `zeroize`, `subtle` | 0.8.0 / 1.9.0 / 2.6.1 | Secret hygiene and constant-time comparison |
+
+**Purpose:** financial-transaction confidentiality and authorisation — shielded
+note encryption, zero-knowledge proof generation and verification, spend
+authorisation signatures, and hierarchical key derivation from the user's seed.
+
+### 3.2 Messaging — bundled, and identical to e2e2z's
+
+Reached through `tauri-plugin-f2zmsg` plus the four crates ZUULI names directly
+(`f2z-msg-identity`, `f2z-kt-core`, `f2z-codec`, `f2z-msg-mls`).
+
+`openmls 0.9.0`, `openmls_libcrux_crypto 0.4.0`, `hpke-rs 0.7.0`,
+`hpke-rs-libcrux 0.7.0`, `libcrux-kem 0.0.9`, **`libcrux-ml-kem 0.0.10`**,
+`libcrux-curve25519`/`-ecdh`, `libcrux-chacha20poly1305`/`-poly1305`/`-aead`/`-aes`,
+`libcrux-sha2`/`-sha3`, `libcrux-hkdf`/`-hmac`/`-hmac-drbg`, `libcrux-ed25519`,
+`libcrux-p256`, `ed25519-dalek` 2.2.0 and 3.0.0, `curve25519-dalek` 4.1.3 and
+5.0.0, `hkdf`, `hmac`, `blake3` (via `akd_core` → `f2z-kt-core`), `tls_codec`.
+
+The ciphersuite is a single compile-time constant,
+`MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519`. **Full detail, including the
+unregistered-codepoint problem, is in
+[e2e2z's record §3.1 and §4](../../e2e2z/docs/export-classification.md#31-message-confidentiality--mls-bundled)** —
+it is not repeated here, because it is the same code.
+
+**Purpose in ZUULI specifically:** identity and device-credential issuance
+(authentication/signing) is reachable; message confidentiality is in the binary
+but not reachable from the WebView today.
+
+### 3.3 Transport — bundled TLS, three stacks
+
+| Crate | Version | Reached through | Role |
+|---|---|---|---|
+| `rustls` | 0.23.42 | `tonic` (lightwalletd gRPC), `reqwest`/`hyper-rustls` (`tauri-plugin-http`, `tauri-plugin-zcash`), `tokio-tungstenite` (relay), `ureq` (key transparency) | **TLS 1.2/1.3** client |
+| `rustls` | **0.21.12** | `minreq` → `zcash_proofs` | A **second, older** TLS stack, used to fetch Sapling proving parameters |
+| `ring` | 0.17.14 | `rustls` | rustls's default crypto provider |
+| `rustls-webpki` | 0.101.7, 0.103.13 | `rustls` | X.509 path validation |
+| `rustls-platform-verifier` | 0.7.0 | `tauri-plugin-zcash`, `ureq` | Delegates certificate trust to the **OS** trust store |
+| `webpki-roots` | 0.25.4, 0.26.11, 1.0.9 | `minreq`, `tokio-tungstenite`, `reqwest` | **Bundled** Mozilla root store on those paths |
+| `tokio-rustls`, `hyper-rustls`, `tokio-tungstenite` | — | — | TLS/WebSocket glue |
+
+**Purpose:** transport confidentiality to lightwalletd, to the free2z API, to
+the messaging relay and key-transparency service, and to the proving-parameter
+host. That three TLS client stacks and three root stores ship in one binary is
+worth recording as an inventory fact; it is a supply-chain observation, not an
+export one.
+
+### 3.4 At-rest seed custody — OS-supplied, with one bundled legacy decoder
+
+- **iOS** — Keychain via `Security.framework`, with
+  `SecAccessControlCreateWithFlags`,
+  `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, `.userPresence`, and
+  `LAContext` for Face ID (`wallet/plugins/tauri-plugin-zcash/ios/Sources/ZcashPlugin.swift`;
+  `NSFaceIDUsageDescription` is in `Info.ios.plist`). Service
+  `cash.free2z.zuuli.seed.v1`, `kSecAttrSynchronizable = false`.
+- **Android** — `AndroidKeyStore` with `setUserAuthenticationRequired(true)`.
+- **Desktop** — `keyring 3.6.3` (`apple-native`, `linux-native-sync-persistent`
+  + `crypto-rust`, `windows-native`).
+- **Messaging wrap key** — a second, deliberately unprivileged custody layer in
+  `tauri-plugin-f2zmsg/src/custody.rs`, namespace
+  `cash.free2z.zuuli.f2zmsg.wrap.v1`, with the *opposite* accessibility policy
+  (`AfterFirstUnlock`, no user presence) because background delivery has to
+  work with the screen locked.
+- **One bundled cipher, read-only.**
+  `wallet/plugins/tauri-plugin-zcash/src/wallet/keychain.rs`'s `legacy_file`
+  module decrypts a **ChaCha20-Poly1305** seed file from a removed file-based
+  fallback. It is a migration *decoder* — the module comment says "There is
+  deliberately no `store`" — and it is not `cfg`-gated, so it compiles into
+  every target including iOS.
+
+**Purpose:** at-rest key sealing. Overwhelmingly Apple-OS-supplied; the one
+bundled cipher exists only to read data written by a version that no longer
+ships.
+
+### 3.5 Copy protection
+
+None. No DRM, no licence enforcement, no anti-tamper cryptography.
+
+### 3.6 Apple-OS-supplied cryptography (not bundled)
+
+- Keychain / `Security.framework` / `LocalAuthentication`, as above.
+- Certificate trust via `security-framework` on the `rustls-platform-verifier`
+  paths.
+- **WebCrypto in the WebView**, which is WebKit's and therefore the OS's:
+  `crypto.subtle.digest("SHA-256", …)` and `crypto.getRandomValues` in
+  `wallet/zuuli/src/lib/oauth/protocol.ts` implement **PKCE (RFC 7636)** for
+  desktop and mobile OAuth, and `crypto.getRandomValues` /
+  `crypto.randomUUID` supply idempotency keys and nonces elsewhere.
+- All WebView-initiated HTTPS (page loads, media) uses the system networking
+  stack.
+
+## 4. Standards status of each primitive
+
+| Primitive | Standards body / citation | Accepted? |
+|---|---|---|
+| TLS 1.3 / 1.2 | IETF RFC 8446 / RFC 5246 | Yes |
+| AES; AES-based FF1 | NIST FIPS 197; NIST SP 800-38G | Yes |
+| ChaCha20-Poly1305 | IETF RFC 8439 | Yes |
+| SHA-2 | NIST FIPS 180-4 | Yes |
+| RIPEMD-160 | ISO/IEC 10118-3 | Yes |
+| HMAC / HKDF | IETF RFC 2104, FIPS 198-1 / RFC 5869 | Yes |
+| PBKDF2 | IETF RFC 8018; NIST SP 800-132 | Yes |
+| BLAKE2b / BLAKE2s | IETF RFC 7693 | Yes |
+| ECDSA over secp256k1 | ECDSA: NIST FIPS 186-5, ISO/IEC 14888-3. The **curve** is SEC 2 (Certicom/SECG), not a NIST curve | Partly — see below |
+| Ed25519 / X25519 | IETF RFC 8032, FIPS 186-5 / RFC 7748 | Yes |
+| HPKE | IETF RFC 9180 | Yes |
+| MLS | IETF RFC 9420 | Yes |
+| ML-KEM-768 | NIST FIPS 203 | Yes |
+| **X-Wing hybrid KEM** | IETF CFRG **Internet-Draft** — not an RFC | **Not yet** |
+| **MLS ciphersuite `0x004D`** | `draft-ietf-mls-pq-ciphersuites` — **not an IANA assignment** | **No** |
+| **Groth16 over BLS12-381** | Academic construction; BLS12-381 has only an expired CFRG draft. Specified by the **Zcash Protocol Specification** and ZIPs | **No standards body** |
+| **Halo 2 over Pallas/Vesta** | Same — open, published, non-proprietary, but no IETF/NIST/ISO standard | **No standards body** |
+| **RedDSA / RedJubjub / RedPallas** | Zcash Protocol Specification | **No standards body** |
+| **Sinsemilla, Poseidon, Equihash** | Academic / Zcash Protocol Specification | **No standards body** |
+| BIP-32 / BIP-39 / Bech32 / Bech32m | Bitcoin Improvement Proposals — open community specifications | **No standards body** |
+| BLAKE3 | Published specification, no standard | No |
+
+**This table is the sharpest thing in this document.** ZUULI's recorded basis
+claims its algorithms are "published, non-proprietary", which is true and
+verifiable. It does **not** claim they are "accepted as international
+standards", which is the phrase Apple's third tier turns on. For the Zcash
+proving stack those are genuinely different claims: Groth16, Halo 2, RedDSA,
+Sinsemilla and Poseidon are open, peer-reviewed and widely deployed, and are
+specified in a public protocol document — and none of them is an IETF, NIST or
+ISO standard. Whether "accepted by international standards bodies" covers an
+open non-proprietary specification of that kind is a legal reading, and
+engineering should not supply it.
+
+## 5. Post-quantum: shipping today, not planned
+
+Hybrid post-quantum key establishment — X25519 + **ML-KEM-768** via X-Wing — is
+in ZUULI's shipping binary today, through the messaging engine, unconditionally
+and not behind a flag. It is *reachable* only via enrollment (§1); it is
+*present* regardless.
+
+Nothing in the Zcash side is post-quantum. Every signature in either half —
+Zcash spend authorisation, MLS leaf, identity, device, KT log — remains
+classical. Post-quantum signatures are future work
+([#316](https://github.com/free2z/zuu/issues/316)).
+
+## 6. Proposed ASC questionnaire answer — a proposal for review
+
+**Proposal.** The technical facts supporting the current `false` have changed
+since it was recorded, and the basis should be **restated** rather than
+reaffirmed. The restatement engineering can support is: *ZUULI's non-OS
+cryptography uses published, non-proprietary algorithms and serves (a) its Zcash
+wallet and financial-transaction functionality and (b) an end-to-end encrypted
+messaging engine whose identity/enrollment path is reachable and whose message
+path is not exposed to the WebView in this build.* Whether that still lands on
+`false` is for Corpora and counsel.
+
+**Reasoning for `false` surviving.** Nothing proprietary or of our own invention
+ships. The transport tier is ordinary TLS. The at-rest tier is overwhelmingly
+Apple's own Keychain. The wallet tier implements a public protocol
+specification. The messaging tier is RFC 9420 with RFC-and-FIPS primitives.
+Apple's middle tier — industry-standard encryption implemented outside Apple's
+OS — requires only a French declaration where the app is distributed in France.
+
+**The strongest counter-arguments.**
+
+1. **The recorded basis is now false as written.** "Limited to its Zcash wallet
+   and financial-transaction functionality" does not describe a binary
+   containing a complete MLS messenger. If the original answer rested on an
+   EAR exemption for banking or money transactions, that reasoning does not
+   reach the messaging engine, and "it is mostly unreachable from the WebView"
+   is an argument about *exposure*, not about what the binary *contains*.
+2. **The Zcash proving stack is not "industry standard" in Apple's sense.**
+   Open and published is not the same as accepted by an international standards
+   body (§4). A strict reading could put the shielded-protocol cryptography
+   outside the middle tier — which would be the most consequential single
+   finding in this record.
+3. **BIS reporting is a separate question.** Apple's documentation requirement
+   and U.S. self-classification duties are different obligations; `false`
+   answers only the first, and both a cryptocurrency wallet and an E2EE
+   messenger are categories where the second is worth checking.
+4. **Twenty accepted builds prove Apple's acceptance, nothing more.** Not a
+   government classification, and not evidence that the basis was ever reviewed
+   against the current binary.
+
+## 7. What a human still has to decide
+
+1. **Does the recorded basis need restating now that messaging ships in
+   ZUULI?** `releasing.md`'s own re-evaluation trigger appears to have fired.
+   *(Owner, with counsel.)*
+2. **Does "published, non-proprietary" satisfy Apple's "accepted as
+   international standards" for the Zcash proving stack (Groth16/BLS12-381,
+   Halo 2/Pallas, RedDSA, Sinsemilla, Poseidon, Equihash)?** *(Counsel.)*
+3. **Does linking-but-not-exposing the MLS message path change the answer?**
+   *(Counsel.)*
+4. **Which EAR route applies, and is anything owed to BIS?** This record
+   deliberately asserts no ECCN. *(Counsel.)*
+5. **Is France in ZUULI's intended territory availability?** **Not determinable
+   from the repository** — `release.json` and `store-identity.json` carry no
+   territory field, no workflow sets one, and availability is configured in App
+   Store Connect. If France is in scope, the French declaration applies under
+   the middle tier. *(Owner.)*
+6. **Were builds 16–20 uploaded, and under the old basis?** The repository shows
+   the messaging plugin in the source of builds 16 onward; which builds actually
+   reached App Store Connect is a store-side fact this record cannot establish.
+   *(Owner.)*


### PR DESCRIPTION
Assembles the **technical facts** #961 asks for, per app. This is an inventory
and a proposal — **not a determination**, and it changes no declared value.

## Hard boundary honored

No change to `ITSAppUsesNonExemptEncryption` in any `Info.ios.plist`, to
`iosUsesNonExemptEncryption` in any `release.json`/`release.schema.json`, or to
any CI assertion about them. No ECCN is asserted anywhere. Every position is
labelled a **proposal for review** and carries its own counter-argument.
Diff is three new files, nothing else.

## What is here

`wallet/{zuuli,e2e2z,free2z}/docs/export-classification.md`, following the shape
and seriousness of `wallet/zuuli/docs/releasing.md`'s "Release records for
cryptography".

Measured from the real graph at `origin/main` `28f09c6c`, on the iOS release
target, with build scripts, proc-macro-only paths and dev-dependencies excluded:

```
cargo tree --locked --edges normal --target aarch64-apple-ios --prefix none
```

501 crates for ZUULI, 360 for e2e2z, 258 for free2z, plus the JS bundle checked
separately. For each crypto-bearing crate: the primitive, what pulls it in, the
standards citation, the purpose, and whether it is Apple-OS-supplied or bundled.

## Three findings

**1. ZUULI's recorded basis no longer describes ZUULI.** It says ZUULI's non-OS
cryptography is "limited to its Zcash wallet and financial-transaction
functionality". Since #750 (2026-08-25) ZUULI links `tauri-plugin-f2zmsg` and its
iOS graph contains the complete MLS messaging engine — OpenMLS, HPKE, X-Wing —
identical to e2e2z's. That is the source of builds 16-20. Two qualifications, both
in the record: after #916 no capability grants any `f2zmsg:` permission, so 43
plugin commands are unreachable from the WebView; but the enrollment trio is
reachable, bypasses the capability ACL by design, and issues signed
`DeviceCredential`s. `releasing.md`'s own trigger — "any material change to how
encryption is used" — appears to have fired.

**2. Hybrid post-quantum ships TODAY in ZUULI and e2e2z**, not on the roadmap.
`MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519`: X25519 + ML-KEM-768 (FIPS 203),
unconditional, non-negotiable, with a downgrade check on key packages. What *is*
roadmap (#316) is post-quantum **signatures** — everything signs Ed25519 today.
The record states both separately, because conflating them is the error #961
names.

The sharp edge: X-Wing is a CFRG **Internet-Draft**, not an RFC, and MLS
ciphersuite codepoint `0x004D` is **not an IANA assignment**
(`draft-ietf-mls-pq-ciphersuites`). Our own `version.rs` records this and a test
asserts `codepoint_is_registered() == false`. Whether a draft composition of two
standardised KEMs counts as "industry-standard encryption" for Apple's middle
tier is precisely a legal reading, and the record refuses to supply one.

**3. free2z is not Apple-OS-only.** `tauri-plugin-http`'s `rustls-tls` feature
(`wallet/free2z/src-tauri/Cargo.toml:62`) bundles rustls 0.23.43 + ring 0.17.14 +
a bundled Mozilla root store. That is its entire cryptographic content —
transport only, URL-scoped to first-party hosts, no PQ, no key custody, no
at-rest encryption, no copy protection. The `sha2` in its graph is
compile-time-only (`tauri-codegen` proc macro) and the record says so, so nobody
mistakes it later. free2z also still has **no `Info.ios.plist`**.

A fourth thing worth counsel's eye: ZUULI's basis claims its algorithms are
"published, non-proprietary", which is verifiable and true. It does **not** claim
they are "accepted as international standards", which is the phrase Apple's third
tier turns on. For Groth16/BLS12-381, Halo 2/Pallas, RedDSA, Sinsemilla, Poseidon
and Equihash those are genuinely different claims — open, peer-reviewed, widely
deployed, specified in a public protocol document, and not IETF/NIST/ISO
standards.

## Open questions for owner / counsel

Listed per app in each record's final section. The ones needing a human:

- Does ZUULI's recorded basis need restating now that messaging ships in it?
- Does "published, non-proprietary" satisfy Apple's "accepted as international
  standards" for the Zcash proving stack?
- Does X-Wing at an unregistered MLS codepoint count as industry-standard?
- Does linking-but-not-exposing the MLS message path in ZUULI change the answer?
- Which EAR route applies, and is anything owed to BIS? (Separate from Apple's
  documentation requirement; no ECCN asserted here.)
- **Is France in the intended territory availability for any of the three?**
  **Not determinable from the repository** — no `release.json`,
  `store-identity.json` or workflow carries a territory field; availability is
  configured in App Store Connect. Listed as an owner question, not guessed.
- Were ZUULI builds 16-20 actually uploaded, and under the old basis? Store-side
  fact this record cannot establish.

## Note on `releasing.md`

Deliberately untouched. Its full contents are SHA-256 pinned as a reviewed
surface by `wallet/zuuli/scripts/status-freshness.mjs`
(`RELEASING_DOCUMENT_SHA256`), so adding a cross-reference means re-pinning that
digest — an owner-reviewed surface change that belongs with the decision, not
with the fact-finding. The new ZUULI record links *to* `releasing.md` and sits
beside it.

## Verification

Docs-only; no Rust, TS or manifest changed.

- `node scripts/check-markdown-links.mjs --self-test` — 45 cases pass.
- `node scripts/check-markdown-links.mjs` — **929 links and 493 anchors across
  116 tracked documents**, all resolve (113 before this PR).
- `bash scripts/check-public-repo-boundary.sh` — clean.
- `node --test wallet/zuuli/scripts/status-freshness.node-test.mjs` — 118/118
  pass, confirming `releasing.md`'s pinned surface is intact.
- Not run: `rtl-source-policy.mjs` (needs `node_modules`, not installed) and the
  Rust matrix (nothing Rust changed). CI covers both.

Closes nothing — #961 stays open until Corpora and counsel decide.

Refs #961, #316, #750, #904, #916, #937, #385

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
