### PR TITLE
release(e2e2z): prepare internal build 0.1.0+2

### DIFF
--- a/wallet/e2e2z/release.json
+++ b/wallet/e2e2z/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.e2e2z",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 1,
+  "build": 2,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.e2e2z"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "2").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist
+++ b/wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/wallet/e2e2z/src-tauri/gen/apple/project.yml
+++ b/wallet/e2e2z/src-tauri/gen/apple/project.yml
@@ -52,7 +52,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "1"
+        CFBundleVersion: "2"
     entitlements:
       path: e2e2z_iOS/e2e2z_iOS.entitlements
     scheme:

--- a/wallet/e2e2z/src-tauri/tauri.conf.json
+++ b/wallet/e2e2z/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "1",
+      "bundleVersion": "2",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 1
+      "versionCode": 2
     }
   },
   "plugins": {


### PR DESCRIPTION
## Why `0.1.0+1` cannot be released

`.github/workflows/e2e2z-release.yml` requires a manual release's `source_sha` to be the exact commit that last modified `wallet/e2e2z/release.json`:

```bash
identity_sha=$(git log -1 --format=%H "$source_sha" -- ':(top)wallet/e2e2z/release.json')
[[ "$identity_sha" == "$source_sha" ]] || {
  echo "manual release source must be the exact commit that established this identity ($identity_sha)" >&2
```

That guard is correct and is **not** changed here: an artifact must be pinned to the commit that defined its version+build.

The problem is that the identity went stale underneath it. Build 1 was established at `bd39b14` (#909, the original scaffold), but `wallet/e2e2z/store-identity.json` did not gain its Apple fields until `0450392` (#959). So the only commit the guard will accept for `0.1.0+1` is one where `appStoreConnectRecord` is still `"missing"`, and `prepare` stops there on `scripts/store-identity.mjs --require=apple`. **`0.1.0+1` is unbuildable.** No bytes were ever published under it, so the number is spent for nothing rather than spent on a shipped artifact.

## The fix

Establish a new identity on a commit that carries both. `build` 1 → 2; `version` stays `0.1.0`. When this squash-merges, the merge commit becomes the identity commit *and* contains the recorded Apple store identity, so a TestFlight dry run can finally be pinned to it.

## Files changed, and why five and not one

`wallet/e2e2z/scripts/release-identity.mjs` checks every surface that restates the build rather than trusting it — a store upload whose internal version disagrees with the tag is unrecoverable, since Play and App Store Connect both treat a version code as spent forever. The named checks and their files:

| File | Field | Check name |
| --- | --- | --- |
| `release.json` | `build` | source of truth |
| `src-tauri/tauri.conf.json` | `bundle.iOS.bundleVersion` | `tauri iOS bundleVersion` |
| `src-tauri/tauri.conf.json` | `bundle.android.versionCode` | `tauri Android versionCode` |
| `src-tauri/gen/apple/project.yml` | `CFBundleVersion` | `Xcode bundle version` |
| `src-tauri/gen/apple/e2e2z_iOS/Info.plist` | `CFBundleVersion` | `iOS Info.plist bundle version` |
| `src-tauri/gen/android/app/build.gradle.kts` | `tauri.android.versionCode` fallback | `Gradle versionCode fallback` |

That is exactly the build-carrying subset of the nine paths ZUULI's `scripts/release-bump-content.mjs` owns. The version-carrying paths (`package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`) do not move because `0.1.0` is unchanged. e2e2z has **no `release-bump.mjs` of its own** — ZUULI's resolves its root from its own script location and hardcodes `zuuli_iOS`, so it cannot be pointed here — so these were edited by hand to the same values that script would produce, and `release-path.node-test.mjs`'s "the generated iOS project is canonical" subtest confirms the generated tree is still a normalization fixed point.

## Verified locally

- `node scripts/release-identity.mjs` → `{"applicationId":"cash.free2z.e2e2z","version":"0.1.0","build":2,"identity":"0.1.0+2","tag":"e2e2z-v0.1.0+2"}`
- `node scripts/release-identity.mjs --source-sha=<head> --require-newer-than=04503924…` → same, so both git-bound guards the workflow applies to a bump pass at this head.
- `node --test scripts/release-path.node-test.mjs` → 5/5.
- `node scripts/store-identity.mjs --self-test` passes; `--require=apple` passes at this tree (it did not at build 1's identity commit — that is the whole point).

Not verified locally: `npm ci` was not run in this worktree, so vitest / Playwright / `npm run build` were not executed. Nothing under `src/` or `tests/` is touched, and no e2e2z test pins the identity as a literal (grepped) — unlike ZUULI's `tests/about.pw.ts`, which failed the gate on exactly that at build 20 (#872). The gate covers it either way.

## `release.schema.json`

`build: 2` satisfies it (`integer`, `minimum: 1`, `maximum: 2100000000`). Worth knowing: that schema is **not machine-validated anywhere** — the `$schema` key is an editor pointer, and the constraints are re-implemented imperatively in `release-identity.mjs`. The two agree today.

## Heads-up for whoever drives the merge

`e2e2z-release.yml` triggers on `push` to `main` filtered to `paths: wallet/e2e2z/release.json`, and a push-triggered run sets `target=mobile`, `dry_run=false`. Merging this **will** fire that workflow, and `prepare` will fail on `scripts/store-identity.mjs --require=android` because `google.playConsoleListing` is still `"missing"`. Nothing is uploaded and no identity is consumed — the run stops in the first job, before anything is built — but expect one red run on `main`. The intended TestFlight path is the manual dispatch with `target=ios`, `dry_run=true`, `source_sha=<the squash-merge commit>`, `identity=0.1.0+2`.

## Out of scope, as instructed

`iosUsesNonExemptEncryption` / `ITSAppUsesNonExemptEncryption` (under owner review in #961), the workflow's immutability guard, and zuuli / free2z.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
