### PR TITLE
release(free2z): prepare internal build 0.1.0+2, and stop the push path uploading

### DIFF
--- a/.github/workflows/free2z-release.yml
+++ b/.github/workflows/free2z-release.yml
@@ -268,7 +268,36 @@ jobs:
             # nothing anyone can do about it today. Widening this to `mobile` is
             # a one-word change once google.playConsoleListing says "created".
             target=ios
-            dry_run=false
+            # THE PUSH PATH NEVER UPLOADS. Do not "fix" this back to false.
+            #
+            # Merging a release.json bump is a code-review event, not a decision
+            # to publish. Every iOS prerequisite for free2z now exists -- the
+            # free2z-app-stores environment holds a verified distribution
+            # certificate, the `free2z appstore ci` profile and the ASC key, and
+            # store-identity.mjs --require=apple passes -- so with dry_run=false
+            # a squash-merge would run straight through to
+            # `xcrun altool --upload-app` with nobody having asked for a release.
+            # e2e2z is not a precedent here: its push arm targets `mobile` and
+            # dies in this job on the missing Play listing, so it has an accident
+            # standing in for a decision. free2z has no such accident.
+            #
+            # The upload is also a legal declaration. Apple reads
+            # ITSAppUsesNonExemptEncryption out of the bundle at upload time, so
+            # shipping a build submits free2z's export-compliance answer. free2z
+            # bundles rustls/ring outside the OS, so it is not Apple-OS-only by
+            # inspection, and which answer it should give is under owner and
+            # counsel review in #961/#967. A build-number bump must not make that
+            # declaration as a side effect of being merged.
+            #
+            # dry_run=true still builds, signs, and runs `altool --validate-app`,
+            # so the push arm keeps proving the whole pipeline works on the exact
+            # commit that established the identity -- it just stops at the step
+            # that would submit. `--validate-app` is pre-flight and creates no
+            # App Store Connect build record. Releasing is then an explicit
+            # workflow_dispatch with dry_run: false, which is a human choosing to
+            # publish and to make that declaration. Flipping this line back to
+            # false removes the human from that loop entirely.
+            dry_run=true
           else
             source_sha=$INPUT_SOURCE_SHA
             target=$INPUT_TARGET

--- a/wallet/free2z/release.json
+++ b/wallet/free2z/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.free2z",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 1,
+  "build": 2,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/free2z/scripts/release-path.node-test.mjs
+++ b/wallet/free2z/scripts/release-path.node-test.mjs
@@ -84,6 +84,145 @@ test("release identity agrees across every file that restates it", () => {
   assert.equal(identity.tag, `free2z-v${identity.identity}`);
 });
 
+// ---------------------------------------------------------------------------
+// The push path cannot upload.
+//
+// `on: push` filtered to release.json means merging a build bump starts a
+// release run. That is wanted -- it proves the pipeline works on the exact
+// commit that established the identity, which is the one commit the manual
+// dispatch will accept. What is NOT wanted is the run finishing the job: every
+// iOS prerequisite for free2z exists, so a push arm resolving dry_run=false
+// would carry a squash-merge all the way to `xcrun altool --upload-app`, and
+// the upload submits free2z's ITSAppUsesNonExemptEncryption answer to Apple --
+// a declaration under owner and counsel review in #961/#967 that nobody has
+// approved making.
+//
+// e2e2z is not a precedent: its push arm targets `mobile` and stops in
+// `prepare` on the missing Play listing, so an accident stands in for the
+// decision. free2z has no such accident, which is why the rule is asserted here
+// rather than assumed. Three things have to hold together, so all three are
+// checked -- the trigger is the one being reasoned about, the push arm resolves
+// to dry_run=true, and dry_run=true actually withholds the store transactions.
+// ---------------------------------------------------------------------------
+
+// The `if [[ "$EVENT_NAME" == push ]]` arm of the identity step, comments and
+// blank lines removed: what the push event actually resolves to.
+function pushArmAssignments(workflow) {
+  const opener = '          if [[ "$EVENT_NAME" == push ]]; then\n';
+  const start = workflow.indexOf(opener);
+  assert.notEqual(start, -1, "the identity step no longer branches on a push event");
+  const body = workflow.slice(start + opener.length);
+  const end = body.indexOf("\n          else\n");
+  assert.notEqual(end, -1, "the push arm of the identity step has no dispatch arm after it");
+  return body
+    .slice(0, end)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+// Every region the workflow will only execute for a real release. The guard and
+// its closing `fi` are matched at their own ten-space indentation, so a `fi`
+// closing something nested inside the guard does not end the region early.
+function dryRunGuardedRegions(workflow) {
+  const opener = '          if [[ "$DRY_RUN" == false ]]; then\n';
+  const closer = "\n          fi\n";
+  const regions = [];
+  for (let from = 0; ; ) {
+    const start = workflow.indexOf(opener, from);
+    if (start === -1) break;
+    const end = workflow.indexOf(closer, start + opener.length);
+    assert.notEqual(end, -1, "a DRY_RUN guard is never closed at its own indentation");
+    regions.push(workflow.slice(start, end));
+    from = end + closer.length;
+  }
+  assert.equal(regions.length, 2, "expected exactly two guarded regions: Play upload and ASC upload");
+  return regions;
+}
+
+test("merging a release.json bump starts a run, and only a build-bump run", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  // Asserted so the rule below is known to be about a trigger that still fires
+  // on exactly this. A push arm that became unreachable would make the
+  // dry_run assertion pass while meaning nothing.
+  assert.match(
+    workflow,
+    /^on:\n {2}push:\n {4}branches: \[main\]\n {4}paths:\n {6}- wallet\/free2z\/release\.json\n {2}workflow_dispatch:$/m,
+  );
+});
+
+test("the push path builds and signs but never uploads", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  const assignments = pushArmAssignments(workflow);
+  // TestFlight-only until a Play Console listing exists; the store_records step
+  // checks `ios` for a push and the identity step refuses to disagree with it.
+  assert.ok(
+    assignments.includes("target=ios"),
+    `the push path must target ios, got: ${assignments.join(" ")}`,
+  );
+  // The rule this test exists for. Stated in both directions: the push arm sets
+  // dry_run=true, and there is no assignment anywhere in it that could set it
+  // false -- an added branch resolving to false fails here even if the line
+  // above survives.
+  assert.ok(
+    assignments.includes("dry_run=true"),
+    `the push path must resolve dry_run=true, got: ${assignments.join(" ")}`,
+  );
+  const dryRunAssignments = assignments.filter((line) => line.startsWith("dry_run="));
+  assert.deepEqual(
+    dryRunAssignments,
+    ["dry_run=true"],
+    "the push path must resolve dry_run exactly once, to true",
+  );
+  // A dispatch that forgot to say is a dispatch that did not decide to publish.
+  assert.match(
+    workflow,
+    /dry_run:\n\s+description: Build, sign, and validate without uploading to either store\n\s+required: true\n\s+default: true\n/,
+  );
+});
+
+// Whole-line comments removed, so a call site is counted and a sentence about
+// one is not. The push-path comment in this very workflow quotes
+// `xcrun altool --upload-app` to explain what it is preventing, and a scan over
+// raw text would either count that as an unguarded upload or force the file to
+// stop explaining itself. Only whole-line comments go: a `#` inside a command
+// stays, because that line is still a command.
+const withoutCommentLines = (contents) =>
+  contents
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n");
+
+test("dry_run withholds every store transaction", () => {
+  const raw = readFileSync(workflowPath, "utf8");
+  const workflow = withoutCommentLines(raw);
+  const guarded = withoutCommentLines(dryRunGuardedRegions(raw).join("\n"));
+  // What makes dry_run=true meaningful. Each command that reaches a store must
+  // appear only inside a guarded region -- counted rather than merely found, so
+  // a second unguarded call site cannot hide behind a guarded first one.
+  for (const transaction of ["xcrun altool --upload-app", "androidpublisher.googleapis.com"]) {
+    const total = workflow.split(transaction).length - 1;
+    assert.ok(total > 0, `the workflow no longer performs ${transaction}`);
+    assert.equal(
+      guarded.split(transaction).length - 1,
+      total,
+      `every ${transaction} call must sit inside an "if [[ \\"$DRY_RUN\\" == false ]]" guard`,
+    );
+  }
+  // The pre-flight that a dry run is still expected to perform. `--validate-app`
+  // creates no App Store Connect build record and makes no export-compliance
+  // declaration, so it belongs outside the guard; moving it inside would leave a
+  // dry run proving nothing about the bundle it just signed.
+  assert.ok(
+    workflow.includes("xcrun altool --validate-app"),
+    "the iOS path must still validate the signed bundle on a dry run",
+  );
+  assert.ok(
+    !guarded.includes("xcrun altool --validate-app"),
+    "bundle validation must run on a dry run, so it must not sit inside the DRY_RUN guard",
+  );
+});
+
 test("the workflow's merged-manifest permission assertion matches the committed manifest", () => {
   const workflow = readFileSync(workflowPath, "utf8");
   const manifest = readFileSync(

--- a/wallet/free2z/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/free2z/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.free2z"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "2").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/free2z/src-tauri/gen/apple/free2z_iOS/Info.plist
+++ b/wallet/free2z/src-tauri/gen/apple/free2z_iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/wallet/free2z/src-tauri/gen/apple/project.yml
+++ b/wallet/free2z/src-tauri/gen/apple/project.yml
@@ -52,7 +52,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "1"
+        CFBundleVersion: "2"
     entitlements:
       path: free2z_iOS/free2z_iOS.entitlements
     scheme:

--- a/wallet/free2z/src-tauri/tauri.conf.json
+++ b/wallet/free2z/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "1",
+      "bundleVersion": "2",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 1
+      "versionCode": 2
     }
   },
   "plugins": {


### PR DESCRIPTION
## Why `0.1.0+1` cannot be released

`.github/workflows/free2z-release.yml` requires a manual release's `source_sha` to be the exact commit that last modified `wallet/free2z/release.json`:

```bash
identity_sha=$(git log -1 --format=%H "$source_sha" -- ':(top)wallet/free2z/release.json')
[[ "$identity_sha" == "$source_sha" ]] || {
  echo "manual release source must be the exact commit that established this identity ($identity_sha)" >&2
```

That guard is correct and is **not** changed here. But free2z's identity went stale underneath it: build 1 was established at `bd39b14` (#909, the original scaffold), while the entire release pipeline, the `gen/apple` tree, `src-tauri/Info.ios.plist` and `store-identity.json` only arrived in **#963**. The only commit the guard accepts for `0.1.0+1` predates everything needed to build it. **`0.1.0+1` is unbuildable.** No bytes were ever published under it.

`build` 1 → 2; `version` stays `0.1.0`. The squash-merge commit becomes the identity commit *and* carries the pipeline, so a TestFlight dry run can finally be pinned to it.

## The six build-carrying surfaces, derived not copied

`wallet/free2z/scripts/release-identity.mjs` checks every file that restates the build rather than trusting it, and it runs inside the required `gate` (zuuli.yml's `surfaces` job runs free2z's `npm test`, which runs `release-path.node-test.mjs`, which runs the identity checker). I read its assertions and moved exactly what it names:

| File | Field | Check name in `release-identity.mjs` |
| --- | --- | --- |
| `release.json` | `build` | source of truth |
| `src-tauri/tauri.conf.json` | `bundle.iOS.bundleVersion` | `tauri iOS bundleVersion` |
| `src-tauri/tauri.conf.json` | `bundle.android.versionCode` | `tauri Android versionCode` |
| `src-tauri/gen/apple/project.yml` | `CFBundleVersion` | `Xcode bundle version` |
| `src-tauri/gen/apple/free2z_iOS/Info.plist` | `CFBundleVersion` | `iOS Info.plist bundle version` |
| `src-tauri/gen/android/app/build.gradle.kts` | `tauri.android.versionCode` fallback | `Gradle versionCode fallback` |

It matches e2e2z's set, but that was confirmed, not assumed: I grepped the whole tree and verified `free2z.xcodeproj/project.pbxproj` and `AndroidManifest.xml` restate **no** build number (no `CURRENT_PROJECT_VERSION`, no `versionCode`). Version-carrying paths (`package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`) do not move because `0.1.0` is unchanged.

### Hand-edited, and why that is the correct choice

free2z has no `release-bump.mjs`; ZUULI's resolves its root from its own script location and hardcodes `zuuli_iOS`, so it cannot be pointed here. The generated trees' fixed-point property is preserved and **proved**, not assumed: `normalize-generated-ios-project.mjs` and `normalize-generated-android-manifest.mjs` were both run against the edited tree and produced **zero** churn, so the `git diff --exit-code` the release path runs after each mobile build still holds. Neither normalizer derives the build number — they canonicalize xcodegen's quoting, plist terminators and the deep-link URL type — so a hand edit to the value Tauri would itself emit from `tauri.conf.json` is exactly right.

## The push path could have uploaded to TestFlight — that is fixed here

**This is the part worth reviewing.** `on: push` is filtered to `wallet/free2z/release.json`, so merging a build bump starts a release run. e2e2z survives its equivalent by accident: its push arm targets `mobile` and dies in `prepare` on the missing Play listing. **free2z has no such accident.** Its push arm targets `ios`, and I verified every iOS prerequisite now passes:

```
$ node scripts/store-identity.mjs --require=apple   # exit 0 — record created, profile recorded
$ node scripts/store-identity.mjs --require=android # exit 78 — Play listing missing
```

With `dry_run=false`, merging this PR would have run straight through to `xcrun altool --upload-app`.

That is not acceptable, and not only operationally. **The upload is a legal declaration**: Apple reads `ITSAppUsesNonExemptEncryption` out of the bundle at upload time, so shipping a build submits free2z's export-compliance answer. free2z bundles rustls/ring outside Apple's OS, so it is not Apple-OS-only by inspection, and which answer it should give is under owner and counsel review in **#961/#967**. A build-number bump must not make that declaration as a side effect of being merged.

So the push arm now resolves **`dry_run=true`**, with the trigger and `target=ios` unchanged, and the comment at that line extended to record why so the next reader does not "fix" it back. This keeps the push run genuinely useful — it still builds, signs, and runs `altool --validate-app` on the exact commit that established the identity, which is the one commit the manual dispatch will accept — while stopping at the step that submits. `--validate-app` is pre-flight and creates no App Store Connect build record.

Bundled with the bump rather than split: separately, whichever merged first would either be a no-op or the very upload being prevented. Together they are safe in any order.

### Three new tests, each mutation-tested (#969)

`scripts/release-path.node-test.mjs` gains the assertions #969 asks for, so this cannot drift back unnoticed:

1. the `push` trigger is still `main` + `wallet/free2z/release.json` — so the rule below is known to be about a trigger that still fires;
2. the push arm resolves `target=ios` and `dry_run=true`, asserted in both directions (`dry_run` is assigned **exactly once**, to `true`), plus the dispatch input still defaults to `true`;
3. every store transaction — `xcrun altool --upload-app` and `androidpublisher.googleapis.com` — appears **only** inside an `if [[ "$DRY_RUN" == false ]]` guard, counted rather than merely found, while `--validate-app` must stay *outside* it.

A guard that never fires is not a guard, so each was proved to fail on the change it forbids:

| Mutation | Result |
| --- | --- |
| push arm → `dry_run=false` | ✗ fails — `must resolve dry_run=true` |
| push arm → `target=mobile` | ✗ fails — `must target ios` |
| iOS upload's guard → `if true` | ✗ fails — `expected exactly two guarded regions` |
| second, unguarded `--upload-app` call site | ✗ fails — `must sit inside an "if [[ \"$DRY_RUN\" == false ]]" guard` |
| dispatch `dry_run` default → `false` | ✗ fails |
| workflow restored | ✓ 9/9 pass |

Test 3 also caught real brittleness in its first draft: the new push-path comment *quotes* `xcrun altool --upload-app` to explain what it prevents, which a raw-text scan counted as an unguarded upload. Whole-line comments are now stripped before counting, so a call site is counted and a sentence about one is not — the file can keep explaining itself.

## What merging this will trigger

A `free2z / protected release` run on `main`, resolving **`target=ios`, `dry_run=true`**, `should_release=true`. It will build and sign the iOS bundle, verify the attestation, run `altool --validate-app`, and **stop there — no upload, no App Store Connect build record, no export-compliance declaration.** No Android job runs (`target=ios`). The identity guards were checked against this exact head: `--require-newer-than=1efc3818…` passes (2 > 1), so it should go green rather than red.

## Verified locally

- `node scripts/release-identity.mjs` → `{"applicationId":"cash.free2z.free2z","version":"0.1.0","build":2,"identity":"0.1.0+2","tag":"free2z-v0.1.0+2"}`
- `node scripts/release-identity.mjs --require-newer-than=1efc3818586de77e8a6a3b259f2ed5b408a841d8` → same, so the monotonicity guard passes at this head.
- `npm ci && npm run typecheck && npm run typecheck:tests && npm test` → **green**: vitest, `ui-copy-truncation.node-test.mjs`, `release-path.node-test.mjs` (9/9), and **92 Playwright tests** passed. Playwright was run because `.pw.ts` specs assert rendered copy and vitest alone is not enough.
- Both normalizers run against the edited tree → zero churn.
- `node scripts/store-identity.mjs --self-test` passes; `--require=apple` exits 0 and `--require=android` exits 78, which is what establishes the risk this PR closes.
- `node scripts/check-workflow-gates.mjs` → passes (2 gates, 85 jobs, 21 workflows).
- `bash scripts/check-public-repo-boundary.sh` → passes.

Not verified locally: no mobile build was run, so the `git diff --exit-code` fixed-point check was exercised through the normalizers rather than through a real `tauri ios build` / `tauri android build`. That check runs in the release workflow on the merge.

## Out of scope, as instructed

`iosUsesNonExemptEncryption` / `ITSAppUsesNonExemptEncryption` (#961/#967), the workflow's immutability guard, `store-identity.json`'s `google` block (recording one would arm the hazard in #969), and zuuli / e2e2z.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
