### PR TITLE
fix(e2e2z): render the failure instead of the skeleton, and stop losing the engine status (#973)

### DIFF
--- a/wallet/e2e2z/src/app-bootstrap.test.tsx
+++ b/wallet/e2e2z/src/app-bootstrap.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { mountApplication } from "./app-bootstrap";
+// The entry point as text. Vite's `?raw` rather than `node:fs`, because
+// `@types/node` is deliberately not in this project's `types` and widening
+// every file's ambient scope to read one file would be the larger change.
+import mainSource from "./main.tsx?raw";
+
+describe("application locale bootstrap", () => {
+  it("renders a dependency-free recovery frame when locale initialization rejects", async () => {
+    const failure = new Error("catalog chunk unavailable");
+    const rendered: string[] = [];
+    const reportError = vi.fn();
+
+    await mountApplication({
+      root: {
+        render(children) {
+          rendered.push(renderToStaticMarkup(children));
+        },
+      },
+      initializeI18n: async () => {
+        throw failure;
+      },
+      renderApplication: () => {
+        throw new Error("must not render the app after initialization fails");
+      },
+      reportError,
+    });
+
+    expect(reportError).toHaveBeenCalledWith(
+      "e2e2z locale bootstrap failed",
+      failure,
+    );
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0]).toContain('role="alert"');
+    expect(rendered[0]).toContain("Something went wrong");
+    expect(rendered[0]).toContain(
+      "e2e2z hit an unexpected error. Reloading usually fixes it.",
+    );
+    expect(rendered[0]).toContain(">Reload</button>");
+  });
+
+  // Having the recovery frame is not the same as reaching it. e2e2z shipped
+  // #973 with this whole module unused: `main.tsx` was a bare
+  // `void initializeAppI18n().then(...)`, so a rejected bootstrap produced an
+  // empty root and the tests above still passed, because they call
+  // `mountApplication` directly and never ask whether anything else does.
+  //
+  // Reading the entry point is the only way to hold that. It is a single
+  // screen with no router, so there is exactly one file to check.
+  it("is what the entry point actually mounts through", () => {
+    expect(mainSource).toContain("mountApplication");
+    expect(mainSource).toContain("<ErrorBoundary fallback={<RootFallback />}>");
+    // The shape that shipped the bug: the entry point driving the render
+    // itself, off a promise nothing was catching. It hands a root to
+    // `mountApplication` and renders nothing on its own.
+    expect(mainSource).not.toContain(").render(");
+  });
+});

--- a/wallet/e2e2z/src/app-bootstrap.tsx
+++ b/wallet/e2e2z/src/app-bootstrap.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react";
+import type { i18n } from "i18next";
+import { initializeAppI18n } from "./i18n";
+
+interface RootRenderer {
+  render(children: ReactNode): void;
+}
+
+interface MountApplicationDependencies {
+  root: RootRenderer;
+  initializeI18n?: typeof initializeAppI18n;
+  renderApplication: (instance: i18n) => ReactNode;
+  reportError?: (message: string, error: unknown) => void;
+}
+
+/**
+ * Minimal, dependency-free fallback shown only if the ENTIRE app throws during
+ * render or locale bootstrap. The literal English copy is intentional: this
+ * frame must remain mountable when catalog loading or i18next initialization
+ * itself is the failing subsystem.
+ */
+export function RootFallback() {
+  return (
+    <div
+      className="app-crash-frame"
+      role="alert"
+      style={{
+        boxSizing: "border-box",
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1rem",
+        paddingBlockStart: "calc(2rem + var(--safe-area-top))",
+        paddingBlockEnd: "calc(2rem + var(--safe-area-bottom))",
+        paddingInlineStart: "calc(2rem + var(--safe-area-inline-start))",
+        paddingInlineEnd: "calc(2rem + var(--safe-area-inline-end))",
+        background: "#121212",
+        color: "#f5f5f5",
+        fontFamily: "system-ui, sans-serif",
+        textAlign: "center",
+      }}
+    >
+      <h1 style={{ fontSize: "1.25rem", fontWeight: 600 }}>
+        Something went wrong
+      </h1>
+      <p style={{ maxWidth: "28rem", color: "#a3a3a3" }}>
+        e2e2z hit an unexpected error. Reloading usually fixes it.
+      </p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        style={{
+          minWidth: "44px",
+          minHeight: "44px",
+          padding: "0.5rem 1rem",
+          borderRadius: "0.75rem",
+          border: "1px solid #2b2b2b",
+          background: "#9f78d9",
+          color: "#141414",
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        Reload
+      </button>
+    </div>
+  );
+}
+
+/** Mount the localized app, retaining a visible recovery path if it fails. */
+export async function mountApplication({
+  root,
+  initializeI18n = initializeAppI18n,
+  renderApplication,
+  reportError = console.error,
+}: MountApplicationDependencies): Promise<void> {
+  try {
+    const instance = await initializeI18n();
+    root.render(renderApplication(instance));
+  } catch (error) {
+    reportError("e2e2z locale bootstrap failed", error);
+    root.render(<RootFallback />);
+  }
+}

--- a/wallet/e2e2z/src/components/common/ErrorBoundary.tsx
+++ b/wallet/e2e2z/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,94 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Rendered instead of `children` once a descendant throws during render.
+   * A function form receives the caught error so callers can degrade
+   * gracefully (e.g. show the raw text of a comment that failed to render).
+   */
+  fallback: ReactNode | ((error: Error) => ReactNode);
+  /**
+   * When any value in this array changes (shallow compare), the boundary
+   * clears its error and retries rendering `children`. Pass the untrusted
+   * content here so a fresh/edited body gets another render attempt instead of
+   * being pinned to the fallback forever.
+   */
+  resetKeys?: unknown[];
+  /** Optional hook for logging/telemetry. Never used to re-throw. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+function keysChanged(a: unknown[] | undefined, b: unknown[] | undefined): boolean {
+  if (a === b) return false;
+  if (!a || !b || a.length !== b.length) return true;
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return true;
+  }
+  return false;
+}
+
+/**
+ * Class error boundary — the ONLY React primitive that can stop a render-time
+ * throw from unmounting the whole root.
+ *
+ * A port of ZUULI's, kept byte-comparable apart from this comment: e2e2z is its
+ * own Vite project with its own `package.json`, so the two apps share source by
+ * copy, exactly as `app-bootstrap.tsx` and `document-direction.ts` already do.
+ *
+ * Here it is used at the app root (`main.tsx`), so a crash anywhere in the
+ * subtree degrades to a small recovery card instead of a permanent white
+ * screen. That matters more in this app than in the other two: e2e2z renders a
+ * single screen and has nothing to navigate to, so a subtree that unmounts the
+ * root leaves nothing at all — which is the family #973 belongs to. `#973`'s
+ * own fix handles *rejections*; React only invokes a boundary for a throw
+ * during render or lifecycle, and the two together are what make "the app
+ * always shows something" true rather than aspirational.
+ *
+ * ZUULI additionally wraps untrusted markdown bodies in one. e2e2z renders no
+ * untrusted markdown, so that use has not come with it.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+    // Dev breadcrumb only; production must never surface a crash to the user.
+    const isDev = Boolean(
+      (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV,
+    );
+    if (isDev) {
+      // eslint-disable-next-line no-console
+      console.error("ErrorBoundary caught a render error:", error, info);
+    }
+  }
+
+  componentDidUpdate(prev: ErrorBoundaryProps) {
+    if (this.state.error && keysChanged(prev.resetKeys, this.props.resetKeys)) {
+      this.setState({ error: null });
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      const { fallback } = this.props;
+      return typeof fallback === "function"
+        ? fallback(this.state.error)
+        : fallback;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/wallet/e2e2z/src/features/messages/index.enrollment-gap.test.tsx
+++ b/wallet/e2e2z/src/features/messages/index.enrollment-gap.test.tsx
@@ -151,33 +151,119 @@ describe("the messages screen without enrollment authority", () => {
   });
 
   it("does not turn a different failure into the enrollment gap", async () => {
-    // Only the typed refusal takes the gap path. Anything else keeps
-    // propagating, exactly as it did before the gap existed — a `catch` that
-    // swallowed every rejection would hide a broken plugin behind a tidy
-    // screen that says the wrong thing about why.
+    // Only the typed refusal takes the gap path. Anything else is a real
+    // failure and must keep its own identity — a `catch` that swallowed every
+    // rejection would hide a broken plugin behind a tidy screen saying the
+    // wrong thing about why.
+    //
+    // This assertion used to be "an unhandled rejection escaped to the host",
+    // which passed while #973 was live and was in fact a description of it.
+    // What must actually hold is that the failure is *rendered*.
     controls.getEnrollmentStatus.mockRejectedValue(
       new Error("engine-not-running"),
     );
-    const rejections: unknown[] = [];
-    const absorb = (reason: unknown) => rejections.push(reason);
-    // `@types/node` is not in this project's `types`, and adding it to run one
-    // assertion would widen every file's ambient scope.
-    const host = (globalThis as unknown as {
-      process: {
-        on(event: string, listener: (reason: unknown) => void): void;
-        off(event: string, listener: (reason: unknown) => void): void;
-      };
-    }).process;
-    host.on("unhandledRejection", absorb);
-    try {
-      await act(async () => root.render(<MessagesFeature />));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    } finally {
-      host.off("unhandledRejection", absorb);
-    }
+
+    await act(async () => root.render(<MessagesFeature />));
+
     expect(container.textContent).not.toContain(
       "Enrollment happens in the wallet app",
     );
-    expect(rejections.map(String).join(" ")).toContain("engine-not-running");
+    expect(container.querySelector("[data-messages-failure]")).not.toBe(null);
+    expect(container.querySelector("[data-messages-loading]")).toBe(null);
+    expect(container.textContent).toContain("f2zmsg_enrollment_status");
+    expect(container.textContent).toContain("engine-not-running");
+  });
+
+  // #973, at the seam it actually broke. `get_device_info` reads the stored
+  // device identity and answers §8 `not-enrolled` when there is none, and this
+  // app can never install one (#905, blocked on #461) — so this is not an edge
+  // case, it is the only answer a packaged e2e2z ever gets, and the version of
+  // this file that shipped mocked a `DeviceInfo` a real build cannot produce.
+  it("renders the gap when device info refuses the way the plugin really does", async () => {
+    controls.getDeviceInfo.mockRejectedValue("not-enrolled");
+
+    await act(async () => root.render(<MessagesFeature />));
+
+    expect(container.querySelector("[data-messages-loading]")).toBe(null);
+    expect(container.textContent).toContain(
+      "Enrollment happens in the wallet app",
+    );
+    // The engine status survived a sibling's rejection — the whole reason for
+    // `allSettled`. Under `Promise.all` this answer was thrown away.
+    expect(container.textContent).toContain("Witnesses");
+    // A standing condition is not a fault, and must not be dressed as one.
+    expect(container.querySelector("[data-messages-failure]")).toBe(null);
+    expect(container.textContent).not.toContain("not-enrolled");
+  });
+
+  it("names a device-info failure that is not the standing refusal", async () => {
+    // `durability-unavailable`: the store would not open. That is a real fault
+    // and worth saying, but it must not cost the user the rest of the screen.
+    controls.getDeviceInfo.mockRejectedValue("durability-unavailable");
+
+    await act(async () => root.render(<MessagesFeature />));
+
+    expect(container.querySelector("[data-messages-loading]")).toBe(null);
+    expect(container.textContent).toContain("get_device_info");
+    expect(container.textContent).toContain("durability-unavailable");
+    // Non-blocking: the gap and the engine summary are both still there.
+    expect(container.querySelector("[data-messages-failure]")).toBe(null);
+    expect(container.textContent).toContain(
+      "Enrollment happens in the wallet app",
+    );
+    expect(container.textContent).toContain("Witnesses");
+  });
+
+  it("names a failing engine status instead of sitting on the skeleton", async () => {
+    // The engine status is the one read with no substitute, so unlike the
+    // others its refusal takes the screen — but it takes it to something that
+    // says which call failed and what the engine said.
+    controls.getEngineStatus.mockRejectedValue("durability-unavailable");
+
+    await act(async () => root.render(<MessagesFeature />));
+
+    expect(container.querySelector("[data-messages-loading]")).toBe(null);
+    expect(container.querySelector("[data-messages-failure]")).not.toBe(null);
+    expect(container.textContent).toContain("get_engine_status");
+    expect(container.textContent).toContain("durability-unavailable");
+    expect(container.textContent).not.toContain(
+      "Enrollment happens in the wallet app",
+    );
+  });
+
+  it("recovers when a retry succeeds", async () => {
+    controls.getEngineStatus.mockRejectedValueOnce("relay-unreachable");
+
+    await act(async () => root.render(<MessagesFeature />));
+    expect(container.querySelector("[data-messages-failure]")).not.toBe(null);
+
+    const retry = container.querySelector(
+      '[aria-label="Read the messaging engine again"]',
+    ) as HTMLElement | null;
+    expect(retry).not.toBe(null);
+
+    await act(async () => {
+      retry?.dispatchEvent(new window.Event("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector("[data-messages-failure]")).toBe(null);
+    expect(container.textContent).toContain(
+      "Enrollment happens in the wallet app",
+    );
+  });
+
+  // The backstop, proved rather than assumed. `reconcile` is written to end in
+  // a rendered state on its own; if a future edit makes it throw before it can,
+  // the effect that drives it must still not strand anyone.
+  it("renders a failure when the whole read throws unexpectedly", async () => {
+    controls.getEngineStatus.mockImplementation(() => {
+      throw new Error("the bridge module blew up");
+    });
+
+    await act(async () => root.render(<MessagesFeature />));
+
+    expect(container.querySelector("[data-messages-loading]")).toBe(null);
+    expect(container.querySelector("[data-messages-failure]")).not.toBe(null);
+    expect(container.textContent).toContain("the bridge module blew up");
   });
 });

--- a/wallet/e2e2z/src/features/messages/index.tsx
+++ b/wallet/e2e2z/src/features/messages/index.tsx
@@ -5,13 +5,50 @@
 // seed, so `enrollment.getEnrollmentStatus()` refuses rather than answering,
 // and that refusal gets its own rendered state instead of an unhandled
 // rejection that would leave the page on its loading skeleton forever.
+//
+// # #973 — the header above was right, and applied to one call in three
+//
+// The first packaged build of this app never left its skeleton on a real
+// device, and the reason was structural rather than exotic. `reconcile` read
+// three things through one `Promise.all`, and only the enrollment call carried
+// the protection this header describes. Any rejection from the other two took
+// the whole read down, the `void reconcile()` that started it swallowed the
+// rejection, `status` stayed `null`, and the gate below rendered a skeleton
+// forever with nothing said to the user.
+//
+// What was actually rejecting is `get_device_info`, and it rejects on **every**
+// e2e2z install rather than occasionally. `Engine::device_info` reads the
+// stored device identity and answers §8 `not-enrolled` when there is none; the
+// only writer of that record is `Engine::install_identity`, whose only
+// production caller is ZUULI's app crate. This app holds no seed and has no
+// transport for the `issue-device-credential` intent (#905, blocked on #461),
+// so it never installs an identity and never can, today. The refusal is
+// permanent and by construction — which is exactly why the app was unusable on
+// the first device it ever ran on, and exactly why every test passed: they all
+// mocked a `DeviceInfo` that a packaged build cannot produce.
+//
+// So two things changed, and the second is the more important one:
+//
+//   1. **`Promise.allSettled`, judged per call.** The three reads are not
+//      equals. The engine status has no substitute — every branch below reads
+//      it — so its rejection is a rendered failure. The enrollment refusal is a
+//      designed state. Device info is supplementary, its only consumer is the
+//      already-conditional `<BrowserGuarantee>`, and losing it must not cost
+//      the user a working engine summary.
+//   2. **Nothing here can end in an unrendered state.** `not-enrolled` from
+//      device info reads as the enrollment gap, because that is what it means
+//      and it is true. Every other refusal is named on screen, with the wire
+//      command that produced it, because the cost of #973 was not the outage —
+//      it was that a device could not tell anyone which of three calls failed.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  AlertTriangle,
   KeyRound,
   Loader2,
   Play,
   Power,
+  RotateCw,
   ShieldAlert,
   ShieldCheck,
   Wallet,
@@ -26,13 +63,14 @@ import {
   messaging,
 } from "../../lib/messaging/bridge";
 import { listenMessaging } from "../../lib/messaging/events";
-import type {
-  Conversation,
-  DeviceInfo,
-  EngineState,
-  EngineStatus,
-  EnrollmentStatus,
-  IneligibilityReason,
+import {
+  ErrorCodeSchema,
+  type Conversation,
+  type DeviceInfo,
+  type EngineState,
+  type EngineStatus,
+  type EnrollmentStatus,
+  type IneligibilityReason,
 } from "../../lib/messaging/types";
 import { BrowserGuarantee } from "./BrowserGuarantee";
 import { FirstContact } from "./FirstContact";
@@ -65,6 +103,84 @@ const INELIGIBILITY_COPY: Record<IneligibilityReason, string> = {
 /** A running state, in §6.1's sense: degraded still sends and receives. */
 function isRunning(state: EngineState): boolean {
   return state === "running" || state === "degraded";
+}
+
+/**
+ * A rejected bridge call, as something the screen can render.
+ *
+ * `call` is the **wire** command name rather than a friendly label, and that is
+ * deliberate: it is the string a bug report has to carry, and #973 cost a
+ * TestFlight build and a device precisely because the screen could not say
+ * which of three calls had failed.
+ */
+interface CallFailure {
+  call: string;
+  detail: string;
+}
+
+/**
+ * The text of a rejection, whatever shape it arrived in.
+ *
+ * `tauri-plugin-f2zmsg` serializes every error as the **bare** §8 `ErrorCode`
+ * and nothing else (`error.rs`: `serializer.serialize_str(self.code.as_str())`),
+ * so a real `invoke` rejection is a `string`, not an `Error`. A formatter that
+ * only understood `Error` would render `[object Object]` for every genuine
+ * backend failure while looking perfectly correct against the fakes in the
+ * tests — the same shape of blind spot that let #973 ship.
+ *
+ * Unlike `FirstContact`'s `refusalCode`, an unrecognized cause is **not**
+ * flattened to `internal` here. This is the surface of last resort, and
+ * collapsing the one piece of evidence it exists to show would defeat it.
+ */
+function failureDetail(cause: unknown): string {
+  const code = ErrorCodeSchema.safeParse(cause);
+  if (code.success) return code.data;
+  if (cause instanceof Error && cause.message !== "") return cause.message;
+  if (typeof cause === "string" && cause.trim() !== "") return cause.trim();
+  return String(cause);
+}
+
+/**
+ * §8 `not-enrolled`, which for **this** app is a standing condition, not a
+ * fault.
+ *
+ * `Engine::device_info` answers it whenever no device identity is installed,
+ * and installing one is the wallet authority's job (#905, blocked on #461). So
+ * e2e2z gets this answer on every install, indefinitely — it has to read as the
+ * enrollment gap, which is true, rather than as an error, which is not.
+ */
+function isNotEnrolled(cause: unknown): boolean {
+  return failureDetail(cause) === "not-enrolled";
+}
+
+/**
+ * The reads that failed while the rest of the screen still works.
+ *
+ * Separate from the blocking failure state on purpose: taking a whole surface
+ * away because one supplementary call refused is the `Promise.all` mistake in
+ * a different costume.
+ */
+function DegradedReads({ failures }: { failures: CallFailure[] }) {
+  if (failures.length === 0) return null;
+  return (
+    <Callout
+      tone="warning"
+      icon={ShieldAlert}
+      title="Part of this screen could not be read"
+    >
+      <p>
+        Everything else below is current. What did not come back, and what the
+        engine said about it:
+      </p>
+      <ul className="mt-2 space-y-1">
+        {failures.map((failure) => (
+          <li key={failure.call} className="mono-id break-words">
+            {failure.call} — {failure.detail}
+          </li>
+        ))}
+      </ul>
+    </Callout>
+  );
 }
 
 function EngineSummary({ status }: { status: EngineStatus }) {
@@ -111,27 +227,99 @@ export default function MessagesFeature() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [enrollmentGap, setEnrollmentGap] = useState(false);
+  const [failure, setFailure] = useState<CallFailure | null>(null);
+  const [degraded, setDegraded] = useState<CallFailure[]>([]);
+  const [actionFailure, setActionFailure] = useState<CallFailure | null>(null);
+  const [listenFailure, setListenFailure] = useState<CallFailure | null>(null);
   const reconcileGeneration = useRef(0);
 
+  /**
+   * Read everything the screen needs, and **end in a rendered state whatever
+   * happens** (#973 — see the file header).
+   *
+   * `allSettled` rather than `all` because the three reads are not equals, and
+   * treating them as equals is what broke: a failed device-info read threw away
+   * a perfectly good engine status, and there was nowhere for the rejection to
+   * go.
+   */
   const reconcile = useCallback(async () => {
     const generation = ++reconcileGeneration.current;
-    const [engine, enrollmentState, deviceInfo] = await Promise.all([
-      messaging.getEngineStatus(),
-      // The one call this app cannot make. A refusal is a state to render, not
-      // an error to swallow: anything else here reads as "not enrolled yet",
-      // which is a different and untrue thing.
-      enrollment.getEnrollmentStatus().catch((cause: unknown) => {
-        if (isEnrollmentUnavailable(cause)) return null;
-        throw cause;
-      }),
-      messaging.getDeviceInfo(),
-    ]);
-    const nextConversations = enrollmentState?.enrolled
-      ? (await messaging.listConversations()).conversations
-      : [];
-    if (generation !== reconcileGeneration.current) return;
+    const superseded = () => generation !== reconcileGeneration.current;
 
-    setStatus(engine);
+    const [engineResult, enrollmentResult, deviceResult] =
+      await Promise.allSettled([
+        messaging.getEngineStatus(),
+        // The one call this app cannot make. A refusal is a state to render,
+        // not an error to swallow: anything else here reads as "not enrolled
+        // yet", which is a different and untrue thing.
+        enrollment.getEnrollmentStatus(),
+        messaging.getDeviceInfo(),
+      ]);
+
+    // The one answer with no substitute — every branch below reads `status`.
+    // The plugin answers this even when its store failed to open (it reports
+    // §6.1 `faulted` with a code rather than refusing, #753), so a rejection
+    // here means the IPC surface itself is unreachable and naming it is all
+    // that is left to do.
+    if (engineResult.status === "rejected") {
+      if (superseded()) return;
+      setFailure({
+        call: "get_engine_status",
+        detail: failureDetail(engineResult.reason),
+      });
+      return;
+    }
+
+    // The typed refusal is the enrollment gap. Anything else is a real failure
+    // and is now rendered: it used to propagate out of `reconcile` and die in
+    // the `void` at the call site, which is the permanent skeleton by a second
+    // route.
+    let enrollmentState: EnrollmentStatus | null = null;
+    if (enrollmentResult.status === "rejected") {
+      if (!isEnrollmentUnavailable(enrollmentResult.reason)) {
+        if (superseded()) return;
+        setFailure({
+          call: "f2zmsg_enrollment_status",
+          detail: failureDetail(enrollmentResult.reason),
+        });
+        return;
+      }
+    } else {
+      enrollmentState = enrollmentResult.value;
+    }
+
+    // Supplementary. `not-enrolled` is this app's permanent answer and is
+    // absorbed in silence, because the enrollment gap below already says what
+    // it means, in words, and says it better. Anything else is worth naming
+    // but must not take the screen down, since everything else on it works.
+    const nextDegraded: CallFailure[] = [];
+    let deviceInfo: DeviceInfo | null = null;
+    if (deviceResult.status === "fulfilled") {
+      deviceInfo = deviceResult.value;
+    } else if (!isNotEnrolled(deviceResult.reason)) {
+      nextDegraded.push({
+        call: "get_device_info",
+        detail: failureDetail(deviceResult.reason),
+      });
+    }
+
+    let nextConversations: Conversation[] = [];
+    if (enrollmentState?.enrolled) {
+      try {
+        nextConversations = (await messaging.listConversations()).conversations;
+      } catch (cause) {
+        nextDegraded.push({
+          call: "list_conversations",
+          detail: failureDetail(cause),
+        });
+      }
+    }
+
+    if (superseded()) return;
+
+    setFailure(null);
+    setDegraded(nextDegraded);
+    setStatus(engineResult.value);
     setEnrolled(enrollmentState);
     setEnrollmentGap(enrollmentState === null);
     setDevice(deviceInfo);
@@ -146,14 +334,39 @@ export default function MessagesFeature() {
     );
   }, []);
 
+  /**
+   * The only way this screen starts a reconcile.
+   *
+   * A bare `void reconcile()` is what shipped #973, so every call site in this
+   * file now goes through here. `reconcile` is written to end in a rendered
+   * state on its own; this is the backstop for the day an edit makes it throw
+   * anyway, and it costs three lines to make that unable to strand anyone.
+   *
+   * **The returned promise cannot reject**, which is what makes `void
+   * refresh()` a safe thing to write at the call sites that do not need to
+   * wait, and lets `run` await the re-read before it clears its spinner.
+   *
+   * The one remaining reference to `reconcile` itself is `FirstContact`'s
+   * `onStateChanged`, which awaits it inside its own `try`/`catch` and has its
+   * own rendered error for it. It stays on `reconcile` deliberately: handing it
+   * a promise that never rejects would silently retire that branch.
+   */
+  const refresh = useCallback(
+    (): Promise<void> =>
+      reconcile().catch((cause: unknown) => {
+        setFailure({ call: "reconcile", detail: failureDetail(cause) });
+      }),
+    [reconcile],
+  );
+
   const selected =
     conversations?.find(
       (conversation) => conversation.conversationId === selectedId,
     ) ?? null;
 
   useEffect(() => {
-    void reconcile();
-  }, [reconcile]);
+    void refresh();
+  }, [refresh]);
 
   // Events may be coalesced and may be missed, so they are a signal to re-read
   // rather than a state feed (§5.2). Window focus is the other re-read point.
@@ -163,13 +376,26 @@ export default function MessagesFeature() {
 
     void listenMessaging("f2zmsg://engine-state", (payload) => {
       setStatus(payload);
-      if (isRunning(payload.state)) void reconcile();
-    }).then((fn) => {
-      if (cancelled) fn();
-      else unlisten = fn;
-    });
+      if (isRunning(payload.state)) void refresh();
+    })
+      .then((fn) => {
+        if (cancelled) fn();
+        else unlisten = fn;
+      })
+      // Losing the event subscription is survivable — focus still re-reads —
+      // but it must not be invisible, and it must never reach the window as an
+      // unhandled rejection. It gets its own state rather than joining
+      // `degraded`, which every reconcile replaces: this failure happened once,
+      // outside any reconcile, and stays true until the effect is torn down.
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        setListenFailure({
+          call: "listen f2zmsg://engine-state",
+          detail: failureDetail(cause),
+        });
+      });
 
-    const onFocus = () => void reconcile();
+    const onFocus = () => void refresh();
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onFocus);
 
@@ -179,19 +405,34 @@ export default function MessagesFeature() {
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onFocus);
     };
-  }, [reconcile]);
+  }, [refresh]);
 
+  /**
+   * Run something the user asked for, then re-read.
+   *
+   * `call` is its wire name for the same reason `CallFailure` carries one. The
+   * failure is kept out of the blocking state deliberately: a start that
+   * refused should say so *next to* the screen the user is looking at, not
+   * replace it — the surface was fine a moment ago and still is.
+   */
   const run = useCallback(
-    async (action: () => Promise<unknown>) => {
+    async (call: string, action: () => Promise<unknown>) => {
       setBusy(true);
+      setActionFailure(null);
       try {
         await action();
-        await reconcile();
+      } catch (cause) {
+        setActionFailure({ call, detail: failureDetail(cause) });
       } finally {
+        // Even a failed action can have moved the engine, so the re-read is
+        // unconditional, and it is awaited so the spinner outlasts it the way
+        // it always did. `refresh` owns its own rejection, so this cannot
+        // throw out of the `finally`.
+        await refresh();
         setBusy(false);
       }
     },
-    [reconcile],
+    [refresh],
   );
 
   const selectConversation = useCallback((conversation: Conversation) => {
@@ -204,9 +445,51 @@ export default function MessagesFeature() {
     setSelectedId(conversation.conversationId);
   }, []);
 
+  // Reconcile replaces `degraded` wholesale; the listen failure is outside that
+  // cycle, so the two are joined only here, where they are rendered.
+  const reads = listenFailure ? [...degraded, listenFailure] : degraded;
+
+  // Before the skeleton, always. A screen that cannot read the engine has to
+  // say which call refused and what it said — the outage is survivable, being
+  // unable to name it is what made #973 a device-only mystery.
+  if (failure) {
+    return (
+      <div className="animate-slide-up space-y-6" data-messages-failure>
+        <PageHeader
+          title="Messages"
+          description="End-to-end encrypted messaging."
+        />
+
+        <Callout
+          tone="destructive"
+          icon={AlertTriangle}
+          title="Messaging could not be read"
+        >
+          <p>
+            The engine did not answer{" "}
+            <span className="mono-id">{failure.call}</span>, so there is nothing
+            here this screen can honestly show yet. Your conversations and your
+            keys are untouched: this is a read that did not come back, not data
+            that was lost.
+          </p>
+          <p className="mono-id mt-2 break-words">{failure.detail}</p>
+          <Button
+            variant="outline"
+            className="mt-3"
+            onClick={refresh}
+            aria-label="Read the messaging engine again"
+          >
+            <RotateCw className="size-4" aria-hidden />
+            Try again
+          </Button>
+        </Callout>
+      </div>
+    );
+  }
+
   if (!status || (!enrolled && !enrollmentGap)) {
     return (
-      <div className="animate-slide-up space-y-6">
+      <div className="animate-slide-up space-y-6" data-messages-loading>
         <PageHeader
           title="Messages"
           description="End-to-end encrypted messaging."
@@ -228,6 +511,8 @@ export default function MessagesFeature() {
           title="Messages"
           description="End-to-end encrypted messaging."
         />
+
+        <DegradedReads failures={reads} />
 
         {device && <BrowserGuarantee device={device} />}
 
@@ -251,6 +536,7 @@ export default function MessagesFeature() {
 
   const { eligibility } = enrolled;
   const candidate = eligibility.candidate;
+  const running = isRunning(status.state);
 
   return (
     <div className="animate-slide-up space-y-6">
@@ -260,33 +546,48 @@ export default function MessagesFeature() {
         actions={
           enrolled.enrolled ? (
             <Button
-              variant={isRunning(status.state) ? "outline" : "default"}
+              variant={running ? "outline" : "default"}
               disabled={busy}
               onClick={() =>
                 void run(
-                  isRunning(status.state)
-                    ? messaging.stopEngine
-                    : messaging.startEngine,
+                  running ? "stop_engine" : "start_engine",
+                  running ? messaging.stopEngine : messaging.startEngine,
                 )
               }
               aria-label={
-                isRunning(status.state)
+                running
                   ? "Stop the messaging engine"
                   : "Start the messaging engine"
               }
             >
               {busy ? (
                 <Loader2 className="size-4 animate-spin" aria-hidden />
-              ) : isRunning(status.state) ? (
+              ) : running ? (
                 <Power className="size-4" aria-hidden />
               ) : (
                 <Play className="size-4" aria-hidden />
               )}
-              {isRunning(status.state) ? "Stop" : "Start"}
+              {running ? "Stop" : "Start"}
             </Button>
           ) : null
         }
       />
+
+      {actionFailure && (
+        <Callout
+          tone="destructive"
+          icon={AlertTriangle}
+          title="That did not go through"
+        >
+          <p>
+            <span className="mono-id">{actionFailure.call}</span> was refused,
+            and nothing about your conversations changed. What the engine said:
+          </p>
+          <p className="mono-id mt-2 break-words">{actionFailure.detail}</p>
+        </Callout>
+      )}
+
+      <DegradedReads failures={reads} />
 
       {device && <BrowserGuarantee device={device} />}
 
@@ -332,7 +633,9 @@ export default function MessagesFeature() {
           <p className="mono-id text-lg text-foreground">@{candidate}</p>
           <Button
             disabled={busy}
-            onClick={() => void run(() => enrollment.enroll(candidate))}
+            onClick={() =>
+              void run("f2zmsg_enroll", () => enrollment.enroll(candidate))
+            }
             aria-label={`Claim the handle ${candidate}`}
           >
             {busy && <Loader2 className="size-4 animate-spin" aria-hidden />}
@@ -351,7 +654,7 @@ export default function MessagesFeature() {
 
       {enrolled.enrolled && enrolled.mergedAtEpoch !== null && (
         <FirstContact
-          engineRunning={isRunning(status.state)}
+          engineRunning={running}
           witnessThresholdMet={status.witnessThresholdMet}
           onConversation={selectConversation}
           onStateChanged={reconcile}

--- a/wallet/e2e2z/src/index.css
+++ b/wallet/e2e2z/src/index.css
@@ -165,6 +165,17 @@
   }
 
   /*
+   * The root crash frame, from `app-bootstrap.tsx`. Everything else about that
+   * frame is inline style on purpose — it has to mount when the stylesheet or
+   * the locale kernel is the thing that failed — but a viewport height cannot
+   * be written inline and still get the `dvh` fallback, so it lives here.
+   */
+  .app-crash-frame {
+    height: 100vh;
+    height: 100dvh;
+  }
+
+  /*
    * Amounts and counts are the instrument readout: Plex Mono, fixed-width
    * figures, tightened tracking, so a number updating in place never reflows
    * the line around it.

--- a/wallet/e2e2z/src/main.tsx
+++ b/wallet/e2e2z/src/main.tsx
@@ -1,8 +1,28 @@
+// The e2e2z entry point.
+//
+// This used to be a bare `void initializeAppI18n().then(render)` — no `.catch`,
+// no boundary, no fallback — while ZUULI and free2z both mounted through
+// `mountApplication` inside an `ErrorBoundary`. It diverged when messaging was
+// moved out in #904 phase 3, and #973 is why that divergence is closed rather
+// than noted: the app shipped a build that rendered nothing but a loading
+// skeleton, and the two failures it could not report were the same failure
+// twice. A rejected locale bootstrap left an empty `<div id="root">` with the
+// rejection swallowed by the `void`; a rejected bridge read left a permanent
+// skeleton with the rejection swallowed by another `void`.
+//
+// Between them, `mountApplication` and the boundary cover both React exits:
+// `mountApplication` catches a bootstrap **rejection** and renders
+// `RootFallback`, and the boundary catches a render-time **throw** anywhere in
+// the subtree. That matters more here than in the other two apps, because this
+// one is a single screen with nowhere to navigate — a subtree that unmounts the
+// root leaves the user with nothing and no way back.
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
 import App from "./App";
-import { initializeAppI18n } from "./i18n";
+import { mountApplication, RootFallback } from "./app-bootstrap";
+import { ErrorBoundary } from "./components/common/ErrorBoundary";
 import { installDocumentDirection } from "./lib/document-direction";
 import "./index.css";
 
@@ -14,12 +34,16 @@ if (!container) throw new Error("the application root element is missing");
 // lang>`; the observer installed here derives `dir` from it thereafter.
 installDocumentDirection();
 
-void initializeAppI18n().then((i18n) => {
-  ReactDOM.createRoot(container).render(
+void mountApplication({
+  root: ReactDOM.createRoot(container),
+  renderApplication: (i18n) => (
     <React.StrictMode>
       <I18nextProvider i18n={i18n}>
-        <App />
+        {/* Top-level boundary: no subtree can ever unmount the root. */}
+        <ErrorBoundary fallback={<RootFallback />}>
+          <App />
+        </ErrorBoundary>
       </I18nextProvider>
-    </React.StrictMode>,
-  );
+    </React.StrictMode>
+  ),
 });

--- a/wallet/e2e2z/tests/enrollment-gap.pw.ts
+++ b/wallet/e2e2z/tests/enrollment-gap.pw.ts
@@ -16,6 +16,23 @@
 //   4. The enrollment commands are never invoked at all — the refusal is a
 //      designed boundary in `bridge.ts`, not a "command not found" that
 //      happened to look like one.
+//
+// # Why this file shipped #973 anyway
+//
+// It used to stub `plugin:f2zmsg|get_device_info` with a `DeviceInfo`, which is
+// a shape a packaged e2e2z **cannot ever produce**. `Engine::device_info`
+// (`engine.rs`) reads the stored identity and answers §8 `not-enrolled` when
+// there is none, and the only writer of that record is `install_identity`,
+// whose only production caller is ZUULI's app crate. e2e2z holds no seed and
+// has no transport for the `issue-device-credential` intent (#905, blocked on
+// #461), so it never installs one and `get_device_info` rejects on every
+// install, forever. `engine_lifecycle.rs`'s
+// `an_unenrolled_engine_refuses_to_start_and_says_which_way_to_go` already
+// asserts exactly that on the Rust side.
+//
+// So the stub now refuses the way the plugin really refuses. That is the whole
+// reproduction: with it, the pre-fix screen sits on its skeleton the way the
+// TestFlight build did on the device.
 
 import { expect, test } from "@playwright/test";
 
@@ -32,17 +49,15 @@ const ENGINE_STATUS = {
   lastError: null,
 };
 
-// `platform` still reads `zuuli-desktop`: it is the plugin's own enum, declared
-// in CLIENT-CONTRACT.md §3.1 and in `models.rs`. Renaming it is a contract
-// change, not part of moving a screen.
-const DEVICE_INFO = {
-  deviceId: "device-e2e2z",
-  deviceFingerprint: "AAAA BBBB CCCC DDDD",
-  identityFingerprint: "EEEE FFFF 0000 1111",
-  createdAt: 0,
-  platform: "zuuli-desktop",
-  durability: "durable",
-};
+/**
+ * What `get_device_info` answers on a device that has never enrolled: the bare
+ * §8 code, because `tauri-plugin-f2zmsg`'s `Error` serializes as
+ * `serializer.serialize_str(self.code.as_str())` and nothing else.
+ *
+ * This is not a pessimistic choice. It is the *only* answer a packaged e2e2z
+ * can get — see the file header.
+ */
+const NOT_ENROLLED = "not-enrolled";
 
 /** The port the second `webServer` in playwright.config.ts serves. */
 function unmockedBaseUrl(baseURL: string | undefined): string {
@@ -54,7 +69,7 @@ function unmockedBaseUrl(baseURL: string | undefined): string {
 test.describe("enrollment gap", () => {
   test("fails closed and names the wallet app", async ({ page, baseURL }) => {
     await page.addInitScript(
-      ({ status, device }) => {
+      ({ status, notEnrolled }) => {
         const invoked: string[] = [];
         let nextCallback = 1;
         (window as unknown as { __E2E2Z_INVOKED__: string[] }).__E2E2Z_INVOKED__ =
@@ -81,7 +96,10 @@ test.describe("enrollment gap", () => {
           async invoke(cmd: string) {
             invoked.push(cmd);
             if (cmd === "plugin:f2zmsg|get_engine_status") return status;
-            if (cmd === "plugin:f2zmsg|get_device_info") return device;
+            // The real refusal, as a bare code string — see the file header.
+            // Tauri rejects an `invoke` with the serialized error, and this
+            // plugin's serialized error *is* the code.
+            if (cmd === "plugin:f2zmsg|get_device_info") throw notEnrolled;
             if (cmd === "plugin:event|listen") return nextCallback++;
             if (cmd === "plugin:event|unlisten") return null;
             // Everything else answers the way a Tauri host answers a command
@@ -90,7 +108,7 @@ test.describe("enrollment gap", () => {
           },
         };
       },
-      { status: ENGINE_STATUS, device: DEVICE_INFO },
+      { status: ENGINE_STATUS, notEnrolled: NOT_ENROLLED },
     );
 
     await page.goto(unmockedBaseUrl(baseURL));
@@ -101,6 +119,17 @@ test.describe("enrollment gap", () => {
     await expect(
       page.getByText("Enrollment happens in the wallet app"),
     ).toBeVisible();
+
+    // #973 itself: the skeleton must be gone. Asserting the gap copy alone was
+    // not enough, because the skeleton renders the same `PageHeader` above it —
+    // a stranded screen still passes a "heading is visible" check.
+    await expect(page.locator("[data-messages-loading]")).toHaveCount(0);
+
+    // And a refusal that is the *expected* standing state must not be dressed
+    // up as a fault. `get_device_info` answering `not-enrolled` is what this
+    // app is, not something that broke.
+    await expect(page.locator("[data-messages-failure]")).toHaveCount(0);
+    await expect(page.getByText("not-enrolled")).toHaveCount(0);
 
     // Nothing that reads as enrolled.
     await expect(page.getByText("Handle active")).toHaveCount(0);
@@ -125,5 +154,48 @@ test.describe("enrollment gap", () => {
     expect(
       invoked.filter((cmd) => cmd.startsWith("f2zmsg_")),
     ).toEqual([]);
+  });
+
+  // The other half of #973. `get_device_info` refusing is a standing state, so
+  // the screen absorbs it; `get_engine_status` refusing is a real fault, and
+  // the screen has to *say so*. Both must clear the skeleton — that is the
+  // property the shipped build lacked, and neither branch of it was tested.
+  test("names a failing engine status instead of sitting on the skeleton", async ({
+    page,
+    baseURL,
+  }) => {
+    await page.addInitScript(() => {
+      let nextCallback = 1;
+      (
+        window as unknown as { __TAURI_INTERNALS__: Record<string, unknown> }
+      ).__TAURI_INTERNALS__ = {
+        transformCallback: () => nextCallback++,
+        unregisterCallback: () => undefined,
+        async invoke(cmd: string) {
+          if (cmd === "plugin:event|listen") return nextCallback++;
+          if (cmd === "plugin:event|unlisten") return null;
+          // §8 `durability-unavailable`: the messaging store would not open, so
+          // even the status command — the one that answers a *faulted* engine
+          // rather than refusing — cannot be reached. A device with a full or
+          // read-only data directory reaches this.
+          throw "durability-unavailable";
+        },
+      };
+    });
+
+    await page.goto(unmockedBaseUrl(baseURL));
+
+    await expect(page.locator("[data-messages-failure]")).toBeVisible();
+    await expect(page.locator("[data-messages-loading]")).toHaveCount(0);
+    // Naming the call and the code is the point: "something went wrong" would
+    // have left this bug exactly as hard to diagnose as it was.
+    await expect(page.getByText("get_engine_status")).toBeVisible();
+    await expect(page.getByText("durability-unavailable")).toBeVisible();
+
+    // And it must not be mistaken for the enrollment gap, which says something
+    // specific and true that this situation does not support.
+    await expect(
+      page.getByText("Enrollment happens in the wallet app"),
+    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes #973.

## Root cause, with the evidence

The rejecting call is **`get_device_info`**, and it rejects on **every** e2e2z install rather than occasionally.

- `Engine::device_info` (`wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs:513`) reads the stored device identity and answers §8 `not-enrolled` when there is none.
- The only writer of that record is `Engine::install_identity`; its only production caller is `wallet/zuuli/src-tauri/src/messaging.rs:191` — ZUULI's app crate.
- e2e2z holds no seed and has no transport for the `issue-device-credential` intent (#905, blocked on #461). It never installs an identity and cannot today.

So `get_device_info` refuses permanently and by construction. `reconcile` read three things through one `Promise.all` with only the enrollment call guarded, so that refusal took the whole read down; the `void reconcile()` swallowed it; `status` stayed `null`; `if (!status || (!enrolled && !enrollmentGap))` rendered the skeleton forever.

**This is measured, not reasoned:**

1. `wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs` already asserts it — `an_unenrolled_engine_refuses_to_start_and_says_which_way_to_go` checks `engine.device_info()` errors `ErrorCode::NotEnrolled` on a fresh engine. Run here: `test result: ok. 1 passed`.
2. `tests/enrollment-gap.pw.ts` — the spec whose entire purpose is to model *"the default build, the one a packaged e2e2z ships"* — stubbed `plugin:f2zmsg|get_device_info` with a `DeviceInfo`, a shape a packaged build cannot produce. Making that stub refuse the way the plugin really refuses reproduces the device symptom exactly: **the enrollment gap copy never renders**, the page sits on its skeleton.

That is also the full answer to "why was this never caught": every test mocked the one response that can never occur.

## What changed

**1. `Promise.allSettled`, judged per call.** The three reads are not equals, and treating them as equals is half the defect — a failed device-info read threw away a perfectly good engine status.

| call | on rejection |
|---|---|
| `get_engine_status` | **blocking** — no substitute, every branch reads it. Rendered failure naming the command and the code, with a retry. |
| `f2zmsg_enrollment_status` | typed refusal → the designed enrollment gap. Anything else → blocking failure (this used to escape as an unhandled rejection). |
| `get_device_info` | `not-enrolled` → **absorbed**; the enrollment gap already says what it means, in words. Anything else → non-blocking notice. |
| `list_conversations` | non-blocking notice. |

`not-enrolled` from device info is deliberately *not* an error state. It is this app's standing, correct condition, and the existing "Enrollment happens in the wallet app" copy is the right thing to show — per the issue's own reading.

**2. No call site reaches `reconcile` bare.** `refresh` is the single entry point and its promise cannot reject. The effect, the `engine-state` listener, window focus and `run` all go through it; a `listenMessaging` rejection and a refused user action now surface too, instead of being swallowed by a `void`. (`FirstContact`'s `onStateChanged` keeps `reconcile` on purpose — it catches and renders its own error, and handing it a never-rejecting promise would silently retire that branch.)

**3. e2e2z adopts the shared bootstrap.** `main.tsx` was `void initializeAppI18n().then(...)` with no `.catch()`, no boundary, no fallback — the same silent-rejection family, and it meant an i18n failure would have produced an empty root just as quietly. It now mounts through `mountApplication` inside `ErrorBoundary`/`RootFallback`, matching ZUULI and free2z. `app-bootstrap.tsx` and `ErrorBoundary.tsx` are ported the way this tree already shares source between the three apps (by copy — each is its own Vite project).

## Tests

Six vitest cases in `index.enrollment-gap.test.tsx` **fail against the old component and pass against the new one** — verified by restoring the pre-fix `index.tsx` and re-running: `6 failed | 3 passed`, then `9 passed`. They cover the real device refusal, a non-standing device-info failure, a failing engine status, a failing enrollment status, retry recovery, and the `refresh` backstop.

The one test that previously *asserted the defect* — "an unhandled rejection escaped to the host" — is rewritten. Its intent (don't mistake a different failure for the gap) was right; its mechanism was a description of #973.

Two Playwright cases in `enrollment-gap.pw.ts` run against the non-mock build: the reproduction above, and a rejecting engine status rendering a named failure. Both failed before this change.

`app-bootstrap.test.tsx` additionally reads `main.tsx` and asserts it mounts through `mountApplication` inside the boundary — having a recovery frame is not the same as reaching it, which is exactly how this shipped.

## free2z — checked, and clean

free2z has no equivalent. Every async-in-`useEffect` site routes through `hooks/useAsync.ts` (which is catch-complete) or a fully try/caught callee, and every skeleton gate is conjoined with `!error` and followed by a rendered `if (!x)` fallback — the third rail e2e2z lacked. `wallet/zuuli/` is clean too.

One latent invariant worth a separate issue, not fixed here: `App.tsx:200` (`void bootstrapSession()`), `Comments/index.tsx:56`, `creator/index.tsx:405` and `useMediaPreflight.ts:186` use the bare `void asyncFn()` form and are safe only because their callees happen to be exhaustively try/caught today. Nothing enforces that.

## Verified

`npm ci`, `npm run typecheck`, `npm run typecheck:tests`, `npm test` (vitest 228 + node 13 + Playwright 5), `npm run build` — all green in `wallet/e2e2z`. Plus the Rust `engine_lifecycle` test above. `release.json` is untouched.

**Not verified:** anything requiring the physical device or a packaged iOS build. The reproduction is a browser run against the default (non-mock) frontend with an IPC stub matched to the plugin's real serialized refusal, corroborated by the plugin's own Rust test — not an iOS Simulator console capture.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
