### PR TITLE
release(zuuli): prepare internal build 0.1.0+21

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 20,
+  "build": 21,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "20").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "21").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -67,7 +67,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "20"
+        CFBundleVersion: "21"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -38,14 +38,14 @@
       "infoPlist": "Info.macos.plist"
     },
     "iOS": {
-      "bundleVersion": "20",
+      "bundleVersion": "21",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 20
+      "versionCode": 21
     }
   },
   "plugins": {


### PR DESCRIPTION
## Why `0.1.0+20` can no longer ship

Build 20 was cut 2026-09-01. Everything that turned ZUULI into a wallet vault landed after it: #943 (`#904` phase 4 hardening), #913 (messaging ported out to e2e2z), #955 (vault cleanup finishing #945/#946/#916), #914 (intent-bridge authority side). `wallet/zuuli/src/features/` is now only `about auth home wallet`. The build on testers' phones still shows the old content-app surface.

`build` 20 → 21; `version` stays `0.1.0`.

## Used the bump script, not a hand edit

Unlike e2e2z and free2z (neither of which has a `release-bump.mjs` that can point at them), ZUULI owns its own tooling, so I used it as-is:

```
node scripts/release-bump.mjs --version=0.1.0 --build=21
```

`scripts/release-bump-content.mjs` names **nine** build/version-carrying paths (`releaseBumpRelativePaths`). Five actually changed in this diff — `release.json`, `src-tauri/tauri.conf.json`, `src-tauri/gen/apple/project.yml`, `src-tauri/gen/apple/zuuli_iOS/Info.plist`, `src-tauri/gen/android/app/build.gradle.kts` — because the other four (`package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`) only restate `version`, which is unchanged at `0.1.0`. This matches the same "version-carrying paths don't move" shape both prior PRs (#968, #972) documented for their five/six-file sets — ZUULI's is nine because it's the tool those PRs deliberately declined to reuse.

## Verified locally

- `node scripts/release-identity.mjs` → `{"applicationId":"cash.free2z.zuuli","channel":"internal","version":"0.1.0","build":21,"identity":"0.1.0+21","tag":"zuuli-v0.1.0+21"}` — every one of its ~100 cross-file assertions passes, including the generated-tree parity checks against `src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj` and the Android manifest, which this PR does not touch because the bump script doesn't touch them either (they carry no build number).
- `node scripts/release-identity.mjs --require-newer-than=894f4371e0a6267dc91c05841053c90d21cccbb8` (the commit that established build 20, #874) → same output, so the monotonicity guard the release workflow calls on every push passes at this head.
- `node scripts/normalize-generated-ios-project.mjs` and `node scripts/normalize-generated-android-manifest.mjs` both ran against the edited tree and produced **zero** churn — the generated Apple/Android trees are still a fixed point, so nothing here was hand-edited that the bump script's regeneration should have owned instead.
- `node scripts/check-workflow-gates.mjs` → passes (2 gates, 85 jobs, 21 workflows, 19 registered ungated).
- `bash scripts/check-public-repo-boundary.sh` → passes.
- `npm ci && npm test` → **green**: 72 vitest files, 608 Node `--test` assertions (603 pass, 5 skipped intentionally, 0 fail), and all **99 Playwright specs** pass. Playwright was run because `.pw.ts` specs assert rendered copy and vitest alone doesn't cover it (per repo memory on rebases).
  - Note: the very first `npm test` run, taken against the *uncommitted* worktree, failed exactly one Playwright assertion (`tests/about.pw.ts` — "Source commit: Unavailable in this build" instead of a real SHA). That's `scripts/build-identity.mjs`'s `checkoutIsDirty` check correctly refusing to stamp a source commit onto a dirty tree — not a regression. Re-ran after committing the bump: all 99 pass, including that one.

## The identity-literal grep (per #872)

#872 broke ZUULI's build 20 because a Playwright spec pinned the identity as a literal. Grepped the whole `wallet/zuuli` tree for `0.1.0+20`, bare `20` near `build`/`version`/`versionCode`/`bundleVersion`, and `bundleVersion` itself in `tests/` and `src/`: **no hits**. `tests/about.pw.ts` (the file #872 was about) already reads `RELEASE.version` / `RELEASE.build` straight out of `release.json` at import time rather than pinning a literal — that's the #872 fix, and it's still in place.

## What merging this will trigger — read before merging

`zuuli-release.yml` triggers on `push` to `main` filtered to `wallet/zuuli/release.json` (lines 3–8). On a push:

```
wallet/.github/workflows/zuuli-release.yml
96            if [[ "$EVENT_NAME" == push ]]; then
101             source_sha=$EVENT_SHA
102             target=mobile
103             dry_run=false
```

`should_release` is decided at lines 118–129: for a push it starts `true` and is only forced to `false` when `wallet/zuuli/release.json` **did not exist** at the pre-push commit (a from-scratch scaffold, not a bump). It already exists (this is bump #4 — builds 18/19/20 preceded it), so `should_release` stays `true`.

**Effective values: `target=mobile`, `dry_run=false`, `should_release=true`.** That's different from e2e2z/free2z, on purpose — ZUULI's push path has already fired real releases successfully at builds 18, 19, and 20 (#969 tracks this shape across all three apps). Per instructions, I did not touch this.

Concretely, merging will:
- Run `android-build` → `android-sign-upload` (gated at lines 186–189 by `target ∈ {mobile, android, all}`) and `ios-build` → `ios-sign` → `ios-verify` → `ios-upload` (gated at lines 665–668, 781, etc. by `target ∈ {mobile, ios, all}`). `linux`/`macos` jobs do **not** run — those require `target ∈ {desktop, all}` (lines 1180–1182, 1338–1340).
- Inside `android-sign-upload`, the Play Console upload (`androidpublisher.googleapis.com` edit/upload/commit, landing on the **internal** track — `tracks/internal`, line 558) sits behind `if [[ "$DRY_RUN" == false ]]` (line 517), which is true, so it **runs**.
- Inside `ios-upload`, `xcrun altool --validate-app` always runs, and `xcrun altool --upload-app` (line 1077, submitting to TestFlight) sits behind the same `if [[ "$DRY_RUN" == false ]]` (line 1074), which is true, so it **runs** too.

**In short: merging uploads build `0.1.0+21` to both App Store Connect (TestFlight) and Google Play Console (internal track). Neither store nor the workflow trigger/target/dry_run resolution was modified by this PR** — this is exactly what the task asked for ("so the vault-hardened ZUULI can ship to TestFlight and Play internal").

## Out of scope, as instructed

`ITSAppUsesNonExemptEncryption` / `iosUsesNonExemptEncryption`, any release workflow, e2e2z, free2z.


https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
