### PR TITLE
feat(diagnostics): private, local-first error capture in all three surfaces; screen in e2e2z (#973)

### DIFF
--- a/wallet/e2e2z/src/App.tsx
+++ b/wallet/e2e2z/src/App.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import DiagnosticsFeature from "./features/diagnostics";
 import MessagesFeature from "./features/messages";
 
 /**
@@ -18,6 +19,13 @@ export default function App() {
           {t("app.name")} — {t("app.tagline")}
         </p>
         <MessagesFeature />
+        {/*
+          Collapsed to a single button until asked for. Every tester here is a
+          collaborator, so the failures the app recorded should be one tap away
+          rather than behind a build flag — but a messenger's default view is
+          its conversation, not its instrumentation.
+        */}
+        <DiagnosticsFeature />
       </main>
     </div>
   );

--- a/wallet/e2e2z/src/app-bootstrap.test.tsx
+++ b/wallet/e2e2z/src/app-bootstrap.test.tsx
@@ -48,9 +48,18 @@ describe("application locale bootstrap", () => {
   //
   // Reading the entry point is the only way to hold that. It is a single
   // screen with no router, so there is exactly one file to check.
+  //
+  // Matched as a pattern rather than as one literal line because the boundary
+  // now also carries an `onError` that reports into the diagnostics buffer, so
+  // the tag spans several lines. The pattern still requires the same two things
+  // the literal did — a boundary, with `RootFallback` as its fallback — and
+  // additionally tolerates no gap between them, so it cannot be satisfied by a
+  // boundary in one place and a stray `RootFallback` in another.
   it("is what the entry point actually mounts through", () => {
     expect(mainSource).toContain("mountApplication");
-    expect(mainSource).toContain("<ErrorBoundary fallback={<RootFallback />}>");
+    expect(mainSource).toMatch(
+      /<ErrorBoundary[^>]*\bfallback=\{<RootFallback \/>\}/u,
+    );
     // The shape that shipped the bug: the entry point driving the render
     // itself, off a promise nothing was catching. It hands a root to
     // `mountApplication` and renders nothing on its own.

--- a/wallet/e2e2z/src/features/diagnostics/index.tsx
+++ b/wallet/e2e2z/src/features/diagnostics/index.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useState } from "react";
+import {
+  type DiagnosticEvent,
+  type DiagnosticsStore,
+  renderDiagnosticsReport,
+} from "@free2z/wallet-shared";
+import { Button } from "../../components/ui/button";
+import { diagnostics as appDiagnostics } from "../../lib/diagnostics";
+
+/**
+ * What the app can tell you about its own failures.
+ *
+ * ## Why this screen exists
+ *
+ * `0.1.0 (2)` shipped to TestFlight and hung on a loading skeleton (#973).
+ * Nothing was written down, nothing was shown, and the only way to learn
+ * anything was to reproduce it on a machine with a debugger attached — which
+ * the tester holding the phone does not have. A failure the user can read is
+ * the difference between a bug report and "it does not work".
+ *
+ * ## Why the sharing is manual
+ *
+ * Because this is an end-to-end encrypted messenger, and a messenger that
+ * uploads anything about a session in the background has given away the thing
+ * it sells. There is no upload path in this feature or anywhere below it. The
+ * buffer is on the device; the report is text; the user copies it if and when
+ * they want to, into an issue they can read first.
+ */
+
+function shortTime(at: number): string {
+  if (!Number.isFinite(at) || at <= 0) return "unknown";
+  try {
+    return new Date(at).toISOString().replace("T", " ").replace(/\.\d+Z$/u, "");
+  } catch {
+    return "unknown";
+  }
+}
+
+function EventRow({ event }: { event: DiagnosticEvent }) {
+  return (
+    <li className="rounded-md border border-border bg-card p-3">
+      <p className="eyebrow text-muted-foreground">
+        {event.kind} — {shortTime(event.at)}
+      </p>
+      <p className="mt-1 text-sm font-medium text-foreground">
+        {event.name || "Error"}
+      </p>
+      {event.message ? (
+        <p className="mt-1 break-words text-sm text-muted-foreground">
+          {event.message}
+        </p>
+      ) : null}
+      {event.frames.length > 0 ? (
+        <pre className="mt-2 overflow-x-auto rounded bg-secondary p-2 text-xs text-muted-foreground">
+          {event.frames
+            .map((frame) =>
+              frame.fn
+                ? `at ${frame.fn} (${frame.source}:${frame.line}:${frame.column})`
+                : `at ${frame.source}:${frame.line}:${frame.column}`,
+            )
+            .join("\n")}
+        </pre>
+      ) : null}
+      {event.breadcrumbs.length > 0 ? (
+        <p className="mt-2 break-words text-xs text-muted-foreground">
+          {event.breadcrumbs
+            .map((crumb) => `${crumb.category}/${crumb.code}`)
+            .join(" -> ")}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
+interface DiagnosticsFeatureProps {
+  /** Injectable so a test drives a store it controls. */
+  store?: DiagnosticsStore;
+}
+
+export default function DiagnosticsFeature({
+  store = appDiagnostics,
+}: DiagnosticsFeatureProps) {
+  const [copied, setCopied] = useState(false);
+  const [open, setOpen] = useState(false);
+  // The buffer is a mutable ring rather than immutable state, so a render is
+  // asked for explicitly after an action that changes it.
+  const [, setRevision] = useState(0);
+  const events = store.events();
+  const environment = store.environment;
+
+  // Rendered when an action asks for it rather than on every render: this panel
+  // lives in `App`, so it re-renders with the whole messaging screen, and
+  // formatting forty records each time to produce a string nobody read is work
+  // the screen it sits under should not pay for.
+  const copy = useCallback(() => {
+    void (async () => {
+      try {
+        await navigator.clipboard.writeText(renderDiagnosticsReport(store));
+        setCopied(true);
+      } catch {
+        // A WebView can refuse clipboard access. The report is on screen in
+        // full below, so a failed copy still leaves the user able to select it.
+        setCopied(false);
+      }
+    })();
+  }, [store]);
+
+  const share = useCallback(() => {
+    void (async () => {
+      const report = renderDiagnosticsReport(store);
+      try {
+        const shareTo = (
+          navigator as Navigator & {
+            share?: (data: { title: string; text: string }) => Promise<void>;
+          }
+        ).share;
+        if (shareTo) {
+          await shareTo.call(navigator, {
+            title: "e2e2z diagnostics",
+            text: report,
+          });
+          return;
+        }
+      } catch {
+        // A dismissed share sheet rejects. That is a choice, not a failure.
+        return;
+      }
+      await navigator.clipboard.writeText(report).catch(() => undefined);
+      setCopied(true);
+    })();
+  }, [store]);
+
+  const clear = useCallback(() => {
+    store.clear();
+    setCopied(false);
+    setRevision((value) => value + 1);
+  }, [store]);
+
+  if (!open) {
+    return (
+      <section className="mt-10 border-t border-border pt-6">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => setOpen(true)}
+          data-diagnostics-open
+        >
+          Diagnostics{events.length > 0 ? ` (${events.length})` : ""}
+        </Button>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="diagnostics-heading"
+      className="mt-10 border-t border-border pt-6"
+      data-diagnostics-panel
+    >
+      <h2
+        id="diagnostics-heading"
+        className="text-lg font-semibold text-foreground"
+      >
+        Diagnostics
+      </h2>
+      <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+        Recorded on this device only. Nothing is sent anywhere. Copy the report
+        into a GitHub issue if you want us to see it.
+      </p>
+
+      <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
+        <div>
+          <dt className="eyebrow text-muted-foreground">App</dt>
+          <dd className="text-foreground">{environment.app}</dd>
+        </div>
+        <div>
+          <dt className="eyebrow text-muted-foreground">Build</dt>
+          <dd className="mono-id text-foreground">
+            {environment.version} ({environment.build})
+          </dd>
+        </div>
+        <div>
+          <dt className="eyebrow text-muted-foreground">Platform</dt>
+          <dd className="text-foreground">
+            {environment.platform} {environment.platformVersion}
+          </dd>
+        </div>
+        <div>
+          <dt className="eyebrow text-muted-foreground">Engine</dt>
+          <dd className="text-foreground">{environment.engine}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button type="button" size="sm" onClick={copy}>
+          {copied ? "Copied" : "Copy report"}
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={share}>
+          Share report
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={clear}>
+          Clear
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => setOpen(false)}
+        >
+          Hide
+        </Button>
+      </div>
+
+      {events.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground" data-diagnostics-empty>
+          No failures have been recorded on this device.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-3" data-diagnostics-events>
+          {[...events].reverse().map((event, index) => (
+            <EventRow key={`${event.at}-${index}`} event={event} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/wallet/e2e2z/src/lib/diagnostics.capture.test.tsx
+++ b/wallet/e2e2z/src/lib/diagnostics.capture.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+import { StrictMode, act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type DiagnosticsPersistence,
+  DiagnosticsStore,
+  bootstrapReporter,
+  boundaryReporter,
+  createEnvironment,
+  installGlobalDiagnostics,
+  localStoragePersistence,
+  renderDiagnosticsReport,
+} from "@free2z/wallet-shared";
+import { ErrorBoundary } from "../components/common/ErrorBoundary";
+import { mountApplication, RootFallback } from "../app-bootstrap";
+
+/**
+ * That the three ways this app can fail each leave a record.
+ *
+ * The one that matters is the rejection. #973 was not an exotic bug: a promise
+ * rejected, a `void` discarded it, and the process had no listener — so the app
+ * hung on a skeleton and produced no evidence at all. These tests are the proof
+ * that the listener now exists and writes something a person can read.
+ */
+
+const ENVIRONMENT = createEnvironment({
+  app: "e2e2z",
+  version: "0.1.0",
+  build: "2",
+  userAgent:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+});
+
+function newStore(persistence: DiagnosticsPersistence | null = null) {
+  return new DiagnosticsStore({ environment: ENVIRONMENT, persistence });
+}
+
+let uninstall: (() => void) | null = null;
+
+afterEach(() => {
+  uninstall?.();
+  uninstall = null;
+  vi.restoreAllMocks();
+});
+
+describe("a rejected promise produces a record", () => {
+  it("captures the reason an unhandled rejection carried", () => {
+    const store = newStore();
+    uninstall = installGlobalDiagnostics(store, window);
+
+    const event = new Event("unhandledrejection");
+    Object.defineProperty(event, "reason", {
+      value: new Error("getEngineStatus is not a function"),
+    });
+    window.dispatchEvent(event);
+
+    expect(store.events()).toHaveLength(1);
+    expect(store.events()[0]?.kind).toBe("unhandled-rejection");
+    expect(store.events()[0]?.name).toBe("Error");
+    expect(store.events()[0]?.message).toBe(
+      "getEngineStatus is not a function",
+    );
+  });
+
+  it("stops capturing once uninstalled", () => {
+    const store = newStore();
+    installGlobalDiagnostics(store, window)();
+    const event = new Event("unhandledrejection");
+    Object.defineProperty(event, "reason", { value: new Error("late") });
+    window.dispatchEvent(event);
+    expect(store.events()).toHaveLength(0);
+  });
+});
+
+describe("an uncaught error produces a record", () => {
+  it("prefers the thrown error over the event's own message", () => {
+    const store = newStore();
+    uninstall = installGlobalDiagnostics(store, window);
+
+    const event = new Event("error");
+    Object.defineProperty(event, "error", {
+      value: new TypeError("cannot read properties of undefined"),
+    });
+    Object.defineProperty(event, "message", { value: "Script error." });
+    window.dispatchEvent(event);
+
+    expect(store.events()[0]?.kind).toBe("uncaught-error");
+    expect(store.events()[0]?.name).toBe("TypeError");
+  });
+
+  it("still records a cross-origin script error, which carries no error", () => {
+    const store = newStore();
+    uninstall = installGlobalDiagnostics(store, window);
+    const event = new Event("error");
+    Object.defineProperty(event, "message", { value: "Script error." });
+    window.dispatchEvent(event);
+    expect(store.events()[0]?.name).toBe("ErrorEvent");
+  });
+});
+
+describe("a render throw produces a record", () => {
+  it("is captured by the root boundary rather than only degraded", () => {
+    const store = newStore();
+    const container = document.createElement("div");
+    document.body.append(container);
+    // React logs the caught error; the test is about the record, not the noise.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    function Exploding(): JSX.Element {
+      throw new Error("the transcript could not render");
+    }
+
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <StrictMode>
+          <ErrorBoundary
+            fallback={<p>fallback</p>}
+            onError={boundaryReporter(store)}
+          >
+            <Exploding />
+          </ErrorBoundary>
+        </StrictMode>,
+      );
+    });
+
+    expect(container.textContent).toContain("fallback");
+    expect(store.events()).toHaveLength(1);
+    expect(store.events()[0]?.kind).toBe("render-error");
+    expect(store.events()[0]?.message).toBe(
+      "the transcript could not render",
+    );
+    act(() => root.unmount());
+    container.remove();
+  });
+});
+
+describe("a bootstrap failure produces a record", () => {
+  it("records why the recovery frame is on screen", async () => {
+    const store = newStore();
+    const rendered: string[] = [];
+
+    await mountApplication({
+      root: {
+        render(children) {
+          rendered.push(renderToStaticMarkup(children));
+        },
+      },
+      initializeI18n: async () => {
+        throw new Error("catalog chunk unavailable");
+      },
+      renderApplication: () => <p>never</p>,
+      reportError: bootstrapReporter(store),
+    });
+
+    expect(rendered[0]).toContain("Something went wrong");
+    expect(store.events()[0]?.kind).toBe("bootstrap-error");
+    expect(store.events()[0]?.message).toBe("catalog chunk unavailable");
+  });
+
+  it("still renders the recovery frame it always did", () => {
+    expect(renderToStaticMarkup(<RootFallback />)).toContain('role="alert"');
+  });
+});
+
+describe("the buffer is bounded and survives a restart", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("keeps the newest events and drops the oldest", () => {
+    const store = new DiagnosticsStore({
+      environment: ENVIRONMENT,
+      persistence: null,
+      eventCapacity: 3,
+    });
+    for (const index of [1, 2, 3, 4, 5]) {
+      store.record("reported-error", new Error(`failure ${index}`));
+    }
+    expect(store.events()).toHaveLength(3);
+    expect(store.events()[0]?.message).toBe("failure 3");
+    expect(store.events()[2]?.message).toBe("failure 5");
+  });
+
+  it("reads back what the previous run wrote", () => {
+    const first = newStore(localStoragePersistence(window.localStorage));
+    first.breadcrumb("messaging", "engine-status-requested");
+    first.record("unhandled-rejection", new Error("engine unreachable"));
+
+    const second = newStore(localStoragePersistence(window.localStorage));
+    expect(second.events()).toHaveLength(1);
+    expect(second.events()[0]?.message).toBe("engine unreachable");
+    expect(second.events()[0]?.breadcrumbs[0]?.code).toBe(
+      "engine-status-requested",
+    );
+  });
+
+  it("ignores a buffer another surface wrote", () => {
+    const zuuli = new DiagnosticsStore({
+      environment: createEnvironment({
+        app: "zuuli",
+        version: "0.1.0",
+        build: "20",
+        userAgent: "",
+      }),
+      persistence: localStoragePersistence(window.localStorage),
+    });
+    zuuli.record("reported-error", new Error("not this app"));
+
+    const mine = newStore(localStoragePersistence(window.localStorage));
+    expect(mine.events()).toHaveLength(0);
+  });
+
+  it("captures in memory when storage is unavailable", () => {
+    const throwing = {
+      getItem() {
+        throw new Error("blocked");
+      },
+      setItem() {
+        throw new Error("blocked");
+      },
+      removeItem() {
+        throw new Error("blocked");
+      },
+    };
+    const store = newStore(localStoragePersistence(throwing));
+    expect(() =>
+      store.record("reported-error", new Error("still recorded")),
+    ).not.toThrow();
+    expect(store.events()).toHaveLength(1);
+  });
+});
+
+describe("the exported report", () => {
+  it("names the build and the failure and says nothing left the device", () => {
+    const store = newStore();
+    store.breadcrumb("lifecycle", "app-start");
+    store.record("unhandled-rejection", new Error("engine unreachable"));
+    const report = renderDiagnosticsReport(store, { at: 1_757_000_000_000 });
+
+    expect(report).toContain("### Diagnostics report");
+    expect(report).toContain("| app | e2e2z |");
+    expect(report).toContain("| version | 0.1.0 (2) |");
+    expect(report).toContain("| platform | ios 18.0 |");
+    expect(report).toContain("| engine | webkit |");
+    expect(report).toContain("unhandled-rejection");
+    expect(report).toContain("engine unreachable");
+    expect(report).toContain("lifecycle/app-start");
+    expect(report).toContain("nothing here left the device");
+  });
+
+  it("says so plainly when there is nothing to report", () => {
+    expect(renderDiagnosticsReport(newStore())).toContain(
+      "No failures have been recorded on this device.",
+    );
+  });
+});

--- a/wallet/e2e2z/src/lib/diagnostics.redaction.test.ts
+++ b/wallet/e2e2z/src/lib/diagnostics.redaction.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+  DiagnosticsStore,
+  PASSTHROUGH_SCRUBBER,
+  createDiagnosticEvent,
+  createEnvironment,
+  scrubText,
+} from "@free2z/wallet-shared";
+
+/**
+ * The redaction control.
+ *
+ * Every case below feeds secret-shaped material through the real capture path
+ * and asserts the store holds none of it. On its own that proves nothing — an
+ * assertion that a string is absent passes trivially if the string was never
+ * there — so each case is paired with the same assertion run against
+ * `PASSTHROUGH_SCRUBBER`, which must find the secret. If a change ever makes
+ * redaction a no-op, the second half of every pair keeps passing and the first
+ * half starts failing. If a change ever makes these inputs stop reaching the
+ * capture path at all, the second half fails and says so.
+ */
+
+const ENVIRONMENT = createEnvironment({
+  app: "e2e2z",
+  version: "0.1.0",
+  build: "2",
+  userAgent:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15",
+});
+
+/**
+ * Secret-shaped, not secret. Every value here is synthetic and is the shape of
+ * a thing that must never be captured, which is the property under test.
+ */
+const SECRETS = {
+  mnemonic:
+    "abandon ability able about above absent absorb abstract absurd abuse access accident",
+  unifiedAddress:
+    "u1l8xunezsvhq8fgzfl7404m450nwnd76zshscn6nfys7vyz2ywyh4cc5daaq0c7q2su5lqfh23sp7fkyy6c76ryxtnvhg9pt7fw7g6vwzrl2j7fkyy6c76ryxt",
+  saplingAddress:
+    "zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9slya",
+  transparentAddress: "t1KsPtV3rncjW3ULQJqLcCrRpDzHWaeuMhg",
+  spendingKey:
+    "secret-extended-key-main1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4nnkzqrpqxs9nywzn2nnkzqrpqxs9",
+  viewingKey:
+    "uview1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4nnkzqrpqxs9nywzn2nnkzqrpqxs9zarvary0",
+  devicePrivateKey: "MC4CAQAwBQYDK2VwBCIEIH3JbxKQpBqMi2wEyLQvKV5Y7hZ9nRQaXcTfPmLdWgZ0",
+  authToken:
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+  handle: "@skylar",
+  amount: "0.04213500",
+} as const;
+
+/**
+ * The one class token analysis cannot remove.
+ *
+ * A memo and an error message are the same thing to a tokenizer: short English
+ * words, ordinary punctuation, no digits, no encoding. A rule that removed this
+ * would remove "could not read the file at path" with it, and a diagnostics
+ * screen that cannot say what went wrong is not worth shipping. See rule 3 in
+ * `redact.ts`.
+ */
+const PROSE = "dinner at the place we talked about, bring the blue folder";
+
+function storeWith(error: unknown): DiagnosticsStore {
+  const store = new DiagnosticsStore({
+    environment: ENVIRONMENT,
+    persistence: null,
+    now: () => 1_757_000_000_000,
+  });
+  store.breadcrumb("messaging", "engine-status-requested");
+  store.record("unhandled-rejection", error);
+  return store;
+}
+
+function captured(error: unknown): string {
+  return JSON.stringify(storeWith(error).events());
+}
+
+function unredacted(error: unknown): string {
+  return JSON.stringify(
+    createDiagnosticEvent(
+      {
+        at: 1_757_000_000_000,
+        kind: "unhandled-rejection",
+        error,
+        breadcrumbs: [],
+      },
+      PASSTHROUGH_SCRUBBER,
+    ),
+  );
+}
+
+describe("secret-shaped material cannot reach the buffer", () => {
+  for (const [label, secret] of Object.entries(SECRETS)) {
+    describe(label, () => {
+      const thrown = new Error(`the operation failed for ${secret}`);
+      thrown.stack = `Error: the operation failed for ${secret}\n    at reconcile (https://tauri.localhost/assets/index-a1b2c3d4.js:1024:15)`;
+
+      it("is absent from every field the store keeps", () => {
+        expect(captured(thrown)).not.toContain(secret);
+      });
+
+      it("would be present without redaction, so the assertion is real", () => {
+        expect(unredacted(thrown)).toContain(secret);
+      });
+    });
+  }
+});
+
+describe("the shapes secrets take", () => {
+  it("collapses a recovery phrase rather than keeping it word by word", () => {
+    // Each word passes the token allow-list on its own; the run is what gives
+    // a mnemonic away, and the run is what is removed.
+    expect(scrubText(SECRETS.mnemonic)).toBe("[redacted:word-run]");
+  });
+
+  it("keeps a short lowercase run, so ordinary messages survive", () => {
+    expect(scrubText("could not read the file at path")).toBe(
+      "could not read the file at path",
+    );
+  });
+
+  it("drops an amount whatever its magnitude", () => {
+    expect(scrubText("balance is 0.04213500 after the send")).not.toContain(
+      "0.04213500",
+    );
+    expect(scrubText("sent 12.5")).not.toContain("12.5");
+    expect(scrubText("sent 4210000")).not.toContain("4210000");
+  });
+
+  it("drops a handle", () => {
+    expect(scrubText("no route to @skylar")).toBe(
+      "no route to [redacted:handle]",
+    );
+  });
+
+  it("drops a URL and an absolute path", () => {
+    expect(scrubText("GET https://relay.example.com/queue/7 failed")).not.toContain(
+      "relay.example.com",
+    );
+    expect(
+      scrubText("open /Users/someone/Library/Application failed"),
+    ).not.toContain("someone");
+  });
+
+  it("drops non-Latin text, which is where message plaintext lives", () => {
+    expect(scrubText("failed to send привет мир")).toBe(
+      "failed to send [redacted:value] [redacted:value]",
+    );
+  });
+
+  it("bounds prose rather than claiming to remove it", () => {
+    // Stated as a test so the limit is recorded where someone will read it,
+    // and so a future change that widens the cap has to change this number.
+    const scrubbed = scrubText(`the send failed: ${PROSE}`);
+    expect(scrubbed).toContain("the place we talked");
+    expect(scrubbed.length).toBeLessThanOrEqual(250);
+  });
+
+  it("caps how much prose can transit at all", () => {
+    const prose = Array.from({ length: 200 }, (_, index) =>
+      index % 2 === 0 ? "Word" : "text",
+    ).join(" ");
+    const scrubbed = scrubText(prose);
+    expect(scrubbed.length).toBeLessThanOrEqual(250);
+    expect(scrubbed.endsWith("[…]")).toBe(true);
+  });
+
+  it("keeps the parts of an error that make it diagnosable", () => {
+    expect(
+      scrubText("TypeError: undefined is not a function (getEngineStatus)"),
+    ).toBe("TypeError: undefined is not a function (getEngineStatus)");
+  });
+});
+
+describe("a thrown object is described, never serialized", () => {
+  it("records the type and nothing else", () => {
+    const walletState = {
+      seed: SECRETS.mnemonic,
+      address: SECRETS.unifiedAddress,
+      toString() {
+        return `${this.seed} ${this.address}`;
+      },
+    };
+    const serialized = captured(walletState);
+    expect(serialized).not.toContain(SECRETS.mnemonic);
+    expect(serialized).not.toContain(SECRETS.unifiedAddress);
+    expect(serialized).toContain('"name":"Object"');
+  });
+
+  it("would be present without redaction, so the assertion is real", () => {
+    // The passthrough scrubber still refuses to call `toString` — describing a
+    // non-Error by type is a structural decision in `record.ts`, not a
+    // redaction step — so the control here is that the message is empty rather
+    // than that it leaks.
+    expect(unredacted({ seed: SECRETS.mnemonic })).toContain('"message":""');
+  });
+});
+
+describe("the buffer is scrubbed again on the way out of storage", () => {
+  it("refuses text a tampered payload put there", () => {
+    let written = "";
+    const persistence = {
+      read: () =>
+        JSON.stringify({
+          v: 1,
+          environment: ENVIRONMENT,
+          events: [
+            {
+              at: 1,
+              kind: "uncaught-error",
+              name: "Error",
+              message: `leaked ${SECRETS.unifiedAddress}`,
+              frames: [],
+              breadcrumbs: [{ at: 1, category: "wallet", code: "not-a-code" }],
+            },
+          ],
+        }),
+      write: (value: string) => {
+        written = value;
+      },
+      clear: () => {},
+    };
+    const store = new DiagnosticsStore({
+      environment: ENVIRONMENT,
+      persistence,
+    });
+    expect(JSON.stringify(store.events())).not.toContain(
+      SECRETS.unifiedAddress,
+    );
+    // The breadcrumb code is not in the vocabulary, so it is dropped rather
+    // than rendered.
+    expect(JSON.stringify(store.events())).not.toContain("not-a-code");
+    store.record("reported-error", new Error("later"));
+    expect(written).not.toContain(SECRETS.unifiedAddress);
+  });
+});

--- a/wallet/e2e2z/src/lib/diagnostics.ts
+++ b/wallet/e2e2z/src/lib/diagnostics.ts
@@ -1,0 +1,57 @@
+import {
+  DiagnosticsStore,
+  createEnvironment,
+  localStoragePersistence,
+} from "@free2z/wallet-shared";
+import release from "../../release.json";
+
+/**
+ * This surface's diagnostics buffer.
+ *
+ * One per process, created before anything else runs so the handlers installed
+ * in `main.tsx` have somewhere to write from the first tick. The behaviour is
+ * entirely `@free2z/wallet-shared`'s — this file only says which app this is,
+ * which build, and where the buffer survives a restart.
+ *
+ * ## Why e2e2z is the first surface to get a screen
+ *
+ * Because it is the one that shipped. `0.1.0 (2)` went to TestFlight, hung on
+ * a loading skeleton, and left the tester and us with no way to learn why
+ * (#973): the rejection that caused it was discarded by a `void`, and nothing
+ * in the process was listening. Capture is installed in all three surfaces;
+ * the screen exists here first because here it has a failure to explain.
+ */
+
+function storage() {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    // Reading `localStorage` itself throws when a WebView blocks site data.
+    return null;
+  }
+}
+
+function userAgent(): string {
+  try {
+    return typeof navigator === "undefined" ? "" : navigator.userAgent;
+  } catch {
+    return "";
+  }
+}
+
+/** Build the store. Exported for tests; the app uses {@link diagnostics}. */
+export function createDiagnosticsStore(): DiagnosticsStore {
+  const local = storage();
+  return new DiagnosticsStore({
+    environment: createEnvironment({
+      app: "e2e2z",
+      version: release.version,
+      build: String(release.build),
+      userAgent: userAgent(),
+    }),
+    persistence: local ? localStoragePersistence(local) : null,
+  });
+}
+
+/** The process-wide buffer. */
+export const diagnostics = createDiagnosticsStore();

--- a/wallet/e2e2z/src/main.tsx
+++ b/wallet/e2e2z/src/main.tsx
@@ -16,13 +16,25 @@
 // the subtree. That matters more here than in the other two apps, because this
 // one is a single screen with nowhere to navigate — a subtree that unmounts the
 // root leaves the user with nothing and no way back.
+//
+// Both of those exits now also *record* what happened, and
+// `installGlobalDiagnostics` covers the third — a throw or rejection that
+// reaches the event loop with no React frame on the stack at all. Rendering a
+// recovery card says the app failed; the diagnostics buffer is what lets
+// someone holding the phone say why.
 
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
+import {
+  bootstrapReporter,
+  boundaryReporter,
+  installGlobalDiagnostics,
+} from "@free2z/wallet-shared";
 import App from "./App";
 import { mountApplication, RootFallback } from "./app-bootstrap";
 import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { diagnostics } from "./lib/diagnostics";
 import { installDocumentDirection } from "./lib/document-direction";
 import "./index.css";
 
@@ -34,16 +46,28 @@ if (!container) throw new Error("the application root element is missing");
 // lang>`; the observer installed here derives `dir` from it thereafter.
 installDocumentDirection();
 
+// Before the first `await`, so a rejection during locale bootstrap reaches a
+// listener rather than nobody.
+installGlobalDiagnostics(diagnostics, window);
+diagnostics.breadcrumb("lifecycle", "app-start");
+
 void mountApplication({
   root: ReactDOM.createRoot(container),
-  renderApplication: (i18n) => (
-    <React.StrictMode>
-      <I18nextProvider i18n={i18n}>
-        {/* Top-level boundary: no subtree can ever unmount the root. */}
-        <ErrorBoundary fallback={<RootFallback />}>
-          <App />
-        </ErrorBoundary>
-      </I18nextProvider>
-    </React.StrictMode>
-  ),
+  reportError: bootstrapReporter(diagnostics),
+  renderApplication: (i18n) => {
+    diagnostics.breadcrumb("lifecycle", "locale-ready");
+    return (
+      <React.StrictMode>
+        <I18nextProvider i18n={i18n}>
+          {/* Top-level boundary: no subtree can ever unmount the root. */}
+          <ErrorBoundary
+            fallback={<RootFallback />}
+            onError={boundaryReporter(diagnostics)}
+          >
+            <App />
+          </ErrorBoundary>
+        </I18nextProvider>
+      </React.StrictMode>
+    );
+  },
 });

--- a/wallet/e2e2z/tests/diagnostics.pw.ts
+++ b/wallet/e2e2z/tests/diagnostics.pw.ts
@@ -1,0 +1,94 @@
+// Diagnostics capture, in a real browser.
+//
+// The vitest suite dispatches a synthetic `unhandledrejection` event, because
+// jsdom does not raise one for an actually-rejected promise. That proves the
+// listener is wired; it does not prove the engine ever calls it. #973 shipped
+// precisely because every test passed against a mocked bridge while the real
+// one rejected on a device, so the capture path is proven here against a real
+// engine raising a real rejection from a real `void promise`.
+
+import { expect, test } from "@playwright/test";
+
+test.describe("diagnostics", () => {
+  test("records a promise nobody handled and shows it to the user", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // The exact shape of #973: a promise is started, its rejection is
+    // discarded by `void`, and nothing in the app awaits it.
+    await page.evaluate(() => {
+      void Promise.reject(new Error("getEngineStatus is not a function"));
+    });
+    // The engine raises `unhandledrejection` on a later turn of the microtask
+    // queue, so the assertion below is what waits for it rather than a sleep.
+
+    await page.getByRole("button", { name: /^Diagnostics/ }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Diagnostics", level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("getEngineStatus is not a function"),
+    ).toBeVisible();
+    await expect(page.getByText("unhandled-rejection")).toBeVisible();
+  });
+
+  test("survives a reload, because a crash report the user lost is no report", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      void Promise.reject(new Error("engine unreachable"));
+    });
+    await page.getByRole("button", { name: /^Diagnostics/ }).click();
+    await expect(page.getByText("engine unreachable")).toBeVisible();
+
+    await page.reload();
+    await page.getByRole("button", { name: /^Diagnostics/ }).click();
+    await expect(page.getByText("engine unreachable")).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear" }).click();
+    await expect(
+      page.getByText("No failures have been recorded on this device."),
+    ).toBeVisible();
+  });
+
+  test("says what it knows about the build, and that nothing was sent", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: /^Diagnostics/ }).click();
+
+    await expect(
+      page.getByText(
+        "Recorded on this device only. Nothing is sent anywhere. Copy the report into a GitHub issue if you want us to see it.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByText("Engine", { exact: true }).last()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy report" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Share report" })).toBeVisible();
+  });
+
+  test("captures no network request of any kind", async ({ page }) => {
+    // The whole product claim is that this never phones home. A promise not to
+    // is worth less than a browser watching every request the page makes.
+    const external: string[] = [];
+    page.on("request", (request) => {
+      const url = request.url();
+      // Anything not served by this app's own dev server is, by definition,
+      // this page reaching outside the device.
+      if (!url.startsWith("http://127.0.0.1:")) external.push(url);
+    });
+
+    await page.goto("/");
+    await page.evaluate(() => {
+      void Promise.reject(new Error("engine unreachable"));
+    });
+    await page.getByRole("button", { name: /^Diagnostics/ }).click();
+    await expect(page.getByText("engine unreachable")).toBeVisible();
+    await page.getByRole("button", { name: "Share report" }).click();
+
+    expect(external).toEqual([]);
+  });
+});

--- a/wallet/free2z/src/lib/diagnostics.test.ts
+++ b/wallet/free2z/src/lib/diagnostics.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { renderDiagnosticsReport } from "@free2z/wallet-shared";
+import release from "../../release.json";
+import { createDiagnosticsStore } from "./diagnostics";
+
+/**
+ * That the content surface's buffer is this app's, and that capture here
+ * brought no native authority with it.
+ *
+ * The redaction rules themselves are proven in the shared package's own suite;
+ * what has to be proven here is that free2z is wired to them and names its own
+ * build. That this surface gained no native command along the way is asserted
+ * where it can actually be enforced — `no_invoke_handler_is_registered` in
+ * `src-tauri/src/lib.rs`.
+ */
+describe("the content surface's diagnostics buffer", () => {
+  it("identifies itself as free2z and carries this build", () => {
+    const store = createDiagnosticsStore();
+    expect(store.environment.app).toBe("free2z");
+    expect(store.environment.version).toBe(release.version);
+    expect(store.environment.build).toBe(String(release.build));
+  });
+
+  it("records a failure and redacts what an article URL would carry", () => {
+    const store = createDiagnosticsStore();
+    store.breadcrumb("navigation", "route-enter");
+    store.record(
+      "unhandled-rejection",
+      new Error("failed to load https://free2z.cash/creator/someone/article"),
+    );
+
+    const report = renderDiagnosticsReport(store);
+    expect(report).toContain("failed to load");
+    expect(report).not.toContain("free2z.cash");
+    expect(report).not.toContain("someone");
+  });
+});

--- a/wallet/free2z/src/lib/diagnostics.ts
+++ b/wallet/free2z/src/lib/diagnostics.ts
@@ -1,0 +1,60 @@
+import {
+  DiagnosticsStore,
+  createEnvironment,
+  localStoragePersistence,
+} from "@free2z/wallet-shared";
+import release from "../../release.json";
+
+/**
+ * The content surface's diagnostics buffer.
+ *
+ * ## Why this surface takes no native crash channel with it
+ *
+ * `src-tauri/src/lib.rs` registers no `invoke_handler` at all, and a unit test
+ * fails the build if one appears: under the Wry frame-confusion defect (#367) a
+ * remote subframe in this process resolves as the trusted main window, so the
+ * property that keeps this surface safe is that there is no command to reach.
+ * A `diagnostics_native_records` command would be a command, and this is
+ * exactly the surface where third-party content is rendered. So capture here is
+ * the renderer's own — the WebView's errors and rejections — and the native
+ * half of the design (a Rust panic hook) is deliberately not wired in until
+ * there is a channel that does not cost this property. See the pull request.
+ *
+ * There is no diagnostics screen here yet either; it belongs on a route, next
+ * to a nav entry and inside `tests/viewport.pw.ts`'s route audit, which is its
+ * own change.
+ */
+
+function storage() {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    // Reading `localStorage` itself throws when a WebView blocks site data.
+    return null;
+  }
+}
+
+function userAgent(): string {
+  try {
+    return typeof navigator === "undefined" ? "" : navigator.userAgent;
+  } catch {
+    return "";
+  }
+}
+
+/** Build the store. Exported for tests; the app uses {@link diagnostics}. */
+export function createDiagnosticsStore(): DiagnosticsStore {
+  const local = storage();
+  return new DiagnosticsStore({
+    environment: createEnvironment({
+      app: "free2z",
+      version: release.version,
+      build: String(release.build),
+      userAgent: userAgent(),
+    }),
+    persistence: local ? localStoragePersistence(local) : null,
+  });
+}
+
+/** The process-wide buffer. */
+export const diagnostics = createDiagnosticsStore();

--- a/wallet/free2z/src/main.tsx
+++ b/wallet/free2z/src/main.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
+import {
+  bootstrapReporter,
+  boundaryReporter,
+  installGlobalDiagnostics,
+} from "@free2z/wallet-shared";
 import App from "./App";
 import { mountApplication, RootFallback } from "./app-bootstrap";
 import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { diagnostics } from "./lib/diagnostics";
 import { installDocumentDirection } from "./lib/document-direction";
 import "./index.css";
 
@@ -12,13 +18,23 @@ import "./index.css";
 // lang>`; the observer installed here derives `dir` from it thereafter.
 installDocumentDirection();
 
+// Before the first `await`, so a rejection during locale bootstrap reaches a
+// listener rather than nobody. A `void promise` whose rejection no handler ever
+// observes is how #973 shipped a build that hung with nothing written down.
+installGlobalDiagnostics(diagnostics, window);
+diagnostics.breadcrumb("lifecycle", "app-start");
+
 void mountApplication({
   root: ReactDOM.createRoot(document.getElementById("root")!),
+  reportError: bootstrapReporter(diagnostics),
   renderApplication: (i18n) => (
     <React.StrictMode>
       <I18nextProvider i18n={i18n}>
         {/* Top-level boundary: no subtree can ever unmount the root. */}
-        <ErrorBoundary fallback={<RootFallback />}>
+        <ErrorBoundary
+          fallback={<RootFallback />}
+          onError={boundaryReporter(diagnostics)}
+        >
           <App />
         </ErrorBoundary>
       </I18nextProvider>

--- a/wallet/shared/src/diagnostics/capture.ts
+++ b/wallet/shared/src/diagnostics/capture.ts
@@ -1,0 +1,135 @@
+import type { DiagnosticsStore } from "./store";
+
+/**
+ * The window-shaped surface the installer needs.
+ *
+ * Narrowed to what is used so a test can pass an `EventTarget` and so nothing
+ * here can reach for a global by accident.
+ */
+export interface DiagnosticsGlobalTarget {
+  addEventListener(
+    type: string,
+    listener: (event: Event) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: (event: Event) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+interface ErrorEventLike {
+  readonly error?: unknown;
+  readonly message?: unknown;
+}
+
+interface RejectionEventLike {
+  readonly reason?: unknown;
+}
+
+/**
+ * Recover the thrown value from an `error` event.
+ *
+ * `event.error` is absent for a cross-origin script error, where the engine
+ * gives only `"Script error."`. Recording that is still worth doing — it says a
+ * script failed and which breadcrumbs preceded it — so a stand-in is
+ * synthesized rather than the event being dropped.
+ */
+function errorFromEvent(event: Event): unknown {
+  const candidate = event as unknown as ErrorEventLike;
+  if (candidate.error !== undefined && candidate.error !== null) {
+    return candidate.error;
+  }
+  const message =
+    typeof candidate.message === "string" ? candidate.message : "";
+  return { name: "ErrorEvent", message };
+}
+
+function reasonFromEvent(event: Event): unknown {
+  const candidate = event as unknown as RejectionEventLike;
+  return candidate.reason;
+}
+
+/**
+ * Install the two handlers that would have made #973 a report instead of a
+ * permanent skeleton.
+ *
+ * `unhandledrejection` is the one that matters here: the TestFlight build hung
+ * because `void reconcile()` discarded a rejection, and nothing in the process
+ * was listening for the rejections that `void` throws away. A boundary catches
+ * render throws and a `.catch()` catches a specific call; this catches the ones
+ * nobody wrote a handler for, which is the class that reaches users.
+ *
+ * The handlers never call `preventDefault()`. Recording a failure must not
+ * change whether the engine reports it, or a console that would have shown the
+ * cause goes quiet in exchange for a buffer entry.
+ *
+ * @returns a function that removes both handlers.
+ */
+export function installGlobalDiagnostics(
+  store: DiagnosticsStore,
+  target: DiagnosticsGlobalTarget,
+): () => void {
+  const onError = (event: Event) => {
+    // A handler that throws while handling a throw is an unbounded loop, and
+    // this one runs inside the engine's own error path. It swallows.
+    try {
+      store.record("uncaught-error", errorFromEvent(event));
+    } catch {
+      /* nothing here can be reported anywhere */
+    }
+  };
+
+  const onRejection = (event: Event) => {
+    try {
+      store.record("unhandled-rejection", reasonFromEvent(event));
+    } catch {
+      /* as above */
+    }
+  };
+
+  target.addEventListener("error", onError);
+  target.addEventListener("unhandledrejection", onRejection);
+
+  return () => {
+    target.removeEventListener("error", onError);
+    target.removeEventListener("unhandledrejection", onRejection);
+  };
+}
+
+/**
+ * The `onError` an app's root `ErrorBoundary` should be given.
+ *
+ * React does not route render throws through `window.onerror`, so a boundary
+ * that only renders a fallback leaves no record of why the fallback appeared.
+ */
+export function boundaryReporter(
+  store: DiagnosticsStore,
+): (error: unknown) => void {
+  return (error: unknown) => {
+    try {
+      store.record("render-error", error);
+    } catch {
+      /* see installGlobalDiagnostics */
+    }
+  };
+}
+
+/**
+ * The `reportError` an app's `mountApplication` should be given.
+ *
+ * Bootstrap failures happen before any UI exists, so this is the only path that
+ * can explain a `RootFallback`.
+ */
+export function bootstrapReporter(
+  store: DiagnosticsStore,
+): (message: string, error: unknown) => void {
+  return (_message: string, error: unknown) => {
+    try {
+      store.record("bootstrap-error", error);
+    } catch {
+      /* see installGlobalDiagnostics */
+    }
+  };
+}

--- a/wallet/shared/src/diagnostics/environment.ts
+++ b/wallet/shared/src/diagnostics/environment.ts
@@ -1,0 +1,164 @@
+import {
+  type DiagnosticApp,
+  type EngineFamily,
+  type PlatformFamily,
+  isDiagnosticApp,
+  isEngineFamily,
+  isPlatformFamily,
+} from "./vocabulary";
+
+/**
+ * What a report says about the device, and nothing more.
+ *
+ * A `navigator.userAgent` is a long free-text field, and the reason not to keep
+ * one is not only that it fingerprints: a free-text field is somewhere a value
+ * can hide. So the string is read once, mapped onto the closed families in
+ * `vocabulary.ts` plus a two-part version, and then discarded. What is left
+ * answers "which OS, which engine, which build" — the questions a bug report
+ * actually needs — and cannot answer anything else.
+ */
+export interface DiagnosticsEnvironment {
+  /** Which of the three surfaces produced the record. */
+  readonly app: DiagnosticApp;
+  /** The app's marketing version, e.g. `0.1.0`. */
+  readonly version: string;
+  /** The store build number, e.g. `2`. */
+  readonly build: string;
+  /** The OS family, or `unknown`. */
+  readonly platform: PlatformFamily;
+  /** `major.minor` at most, or `unknown`. */
+  readonly platformVersion: string;
+  /** The rendering engine family, or `unknown`. */
+  readonly engine: EngineFamily;
+}
+
+const VERSION = /^\d{1,4}(?:\.\d{1,4}){0,3}(?:[-+][A-Za-z0-9.]{1,24})?$/u;
+const BUILD = /^\d{1,9}$/u;
+
+/** `unknown` is the value every field falls back to; it is never a guess. */
+export const UNKNOWN = "unknown" as const;
+
+function safeVersion(value: string): string {
+  return VERSION.test(value) ? value : UNKNOWN;
+}
+
+function safeBuild(value: string): string {
+  return BUILD.test(value) ? value : UNKNOWN;
+}
+
+function twoPart(major: string | undefined, minor: string | undefined): string {
+  if (!major) return UNKNOWN;
+  const head = Number.parseInt(major, 10);
+  if (!Number.isFinite(head)) return UNKNOWN;
+  const tail = minor === undefined ? undefined : Number.parseInt(minor, 10);
+  return tail === undefined || !Number.isFinite(tail)
+    ? String(head)
+    : `${head}.${tail}`;
+}
+
+interface DeviceDescription {
+  readonly platform: PlatformFamily;
+  readonly platformVersion: string;
+  readonly engine: EngineFamily;
+}
+
+/**
+ * Map a user agent onto the closed device vocabulary.
+ *
+ * Order matters twice. Chromium's user agent contains `AppleWebKit`, so the
+ * engine test looks for Chrome first. iPadOS reports itself as a Macintosh, and
+ * we do not try to undo that — a wrong `ipados` guess is worse than an honest
+ * `macos`, because a reader would trust it.
+ */
+export function describePlatform(userAgent: string): DeviceDescription {
+  const agent = typeof userAgent === "string" ? userAgent : "";
+
+  let platform: PlatformFamily = UNKNOWN;
+  let platformVersion: string = UNKNOWN;
+
+  const android = /Android (\d{1,3})(?:\.(\d{1,3}))?/u.exec(agent);
+  const appleOs = /OS (\d{1,3})[._](\d{1,3})/u.exec(agent);
+  const macOs = /Mac OS X (\d{1,3})[._](\d{1,3})/u.exec(agent);
+  const windows = /Windows NT (\d{1,3})(?:\.(\d{1,3}))?/u.exec(agent);
+
+  if (android) {
+    platform = "android";
+    platformVersion = twoPart(android[1], android[2]);
+  } else if (/iPad/u.test(agent)) {
+    platform = "ipados";
+    platformVersion = twoPart(appleOs?.[1], appleOs?.[2]);
+  } else if (/iPhone|iPod/u.test(agent)) {
+    platform = "ios";
+    platformVersion = twoPart(appleOs?.[1], appleOs?.[2]);
+  } else if (/Macintosh|Mac OS X/u.test(agent)) {
+    platform = "macos";
+    platformVersion = twoPart(macOs?.[1], macOs?.[2]);
+  } else if (windows) {
+    platform = "windows";
+    platformVersion = twoPart(windows[1], windows[2]);
+  } else if (/Linux|X11|CrOS/u.test(agent)) {
+    platform = "linux";
+  }
+
+  let engine: EngineFamily = UNKNOWN;
+  if (/Chrome\/|Chromium\/|Edg\//u.test(agent)) engine = "blink";
+  else if (/AppleWebKit/u.test(agent)) engine = "webkit";
+  else if (/Gecko\/|Firefox\//u.test(agent)) engine = "gecko";
+
+  return { platform, platformVersion, engine };
+}
+
+/** What an app tells the diagnostics store about itself. */
+export interface EnvironmentInput {
+  /** Which surface this is. Anything else is refused, not coerced. */
+  readonly app: DiagnosticApp;
+  /** Usually `release.json`'s `version`. */
+  readonly version: string;
+  /** Usually `release.json`'s `build`. */
+  readonly build: string;
+  /** Usually `navigator.userAgent`; only its families are kept. */
+  readonly userAgent: string;
+}
+
+/**
+ * Build the environment block, refusing anything that is not the shape it
+ * claims. An app that passes a version string from somewhere unexpected gets
+ * `unknown` rather than having that string appear in every exported report.
+ */
+export function createEnvironment(
+  input: EnvironmentInput,
+): DiagnosticsEnvironment {
+  const device = describePlatform(input.userAgent);
+  return Object.freeze({
+    app: input.app,
+    version: safeVersion(input.version),
+    build: safeBuild(input.build),
+    platform: device.platform,
+    platformVersion: device.platformVersion,
+    engine: device.engine,
+  });
+}
+
+/** Re-validate an environment block read back from storage. */
+export function reviveEnvironment(value: unknown): DiagnosticsEnvironment | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isDiagnosticApp(candidate.app)) return null;
+  if (!isPlatformFamily(candidate.platform)) return null;
+  if (!isEngineFamily(candidate.engine)) return null;
+  const version =
+    typeof candidate.version === "string" ? candidate.version : UNKNOWN;
+  const build = typeof candidate.build === "string" ? candidate.build : UNKNOWN;
+  const platformVersion =
+    typeof candidate.platformVersion === "string"
+      ? candidate.platformVersion
+      : UNKNOWN;
+  return Object.freeze({
+    app: candidate.app,
+    version: safeVersion(version),
+    build: safeBuild(build),
+    platform: candidate.platform,
+    platformVersion: VERSION.test(platformVersion) ? platformVersion : UNKNOWN,
+    engine: candidate.engine,
+  });
+}

--- a/wallet/shared/src/diagnostics/index.ts
+++ b/wallet/shared/src/diagnostics/index.ts
@@ -1,0 +1,126 @@
+/**
+ * Private, local-first error capture for the three surfaces.
+ *
+ * ## The shape of it
+ *
+ * ```
+ *  window "error"  ─┐
+ *  "unhandledrejection" ─┤
+ *  ErrorBoundary onError ─┼─► redact.ts ─► DiagnosticsStore ─► diagnostics screen
+ *  mountApplication      ─┤    (allow-list)   (bounded ring,      (read / copy /
+ *  reportError           ─┘                    localStorage)       share by hand)
+ * ```
+ *
+ * ## What it deliberately is not
+ *
+ * There is no upload, no endpoint, no queue, no retry, no SDK and no sampling.
+ * Not because a content-security policy would block one — it would, and that is
+ * a symptom rather than the reason — but because a wallet and an end-to-end
+ * encrypted messenger cannot ship a process that sends anything about a user's
+ * session anywhere without the user doing it. The buffer is local; the user
+ * reads it and decides.
+ *
+ * ## Where the privacy guarantee actually lives
+ *
+ * Not in a filter over the export. In two structural places:
+ *
+ * - `vocabulary.ts` closes every field a caller controls. A breadcrumb takes no
+ *   string argument at all, so no call site can attach a handle, an address, an
+ *   amount or a message body to one.
+ * - `redact.ts` runs at `record()` time on the only three strings that are left
+ *   — an error's name, message and stack — and keeps a token only if it matches
+ *   a shape known to be safe. The buffer therefore never holds an unredacted
+ *   value, so no export path can leak one by forgetting to filter.
+ *
+ * `record.ts` exports `PASSTHROUGH_SCRUBBER` so a test can prove that the
+ * assertion "the secret is absent" would fail without redaction. A redaction
+ * test that passes against an unredacted implementation is decoration.
+ */
+
+export {
+  BREADCRUMB_CATEGORIES,
+  BREADCRUMB_CODES,
+  DIAGNOSTIC_APPS,
+  DIAGNOSTIC_KINDS,
+  ENGINE_FAMILIES,
+  PLATFORM_FAMILIES,
+  isBreadcrumbCategory,
+  isBreadcrumbCode,
+  isDiagnosticApp,
+  isDiagnosticKind,
+  isEngineFamily,
+  isPlatformFamily,
+} from "./vocabulary";
+export type {
+  BreadcrumbCategory,
+  BreadcrumbCode,
+  DiagnosticApp,
+  DiagnosticKind,
+  EngineFamily,
+  PlatformFamily,
+} from "./vocabulary";
+
+export {
+  MAX_MESSAGE_CHARACTERS,
+  MAX_MESSAGE_TOKENS,
+  MAX_STACK_FRAMES,
+  REDACTION_CLASSES,
+  TRUNCATION_MARK,
+  WORD_RUN_LIMIT,
+  redactionMark,
+  scrubIdentifier,
+  scrubSource,
+  scrubStack,
+  scrubText,
+} from "./redact";
+export type { DiagnosticFrame, RedactionClass } from "./redact";
+
+export {
+  UNKNOWN,
+  createEnvironment,
+  describePlatform,
+  reviveEnvironment,
+} from "./environment";
+export type {
+  DiagnosticsEnvironment,
+  EnvironmentInput,
+} from "./environment";
+
+export {
+  PASSTHROUGH_SCRUBBER,
+  STRICT_SCRUBBER,
+  createBreadcrumb,
+  createDiagnosticEvent,
+  reviveDiagnosticEvent,
+} from "./record";
+export type {
+  DiagnosticBreadcrumb,
+  DiagnosticEvent,
+  DiagnosticEventInput,
+  DiagnosticScrubber,
+} from "./record";
+
+export {
+  BREADCRUMBS_PER_EVENT,
+  DEFAULT_BREADCRUMB_CAPACITY,
+  DEFAULT_EVENT_CAPACITY,
+  DIAGNOSTICS_SCHEMA_VERSION,
+  DIAGNOSTICS_STORAGE_KEY,
+  DiagnosticsStore,
+  MAX_PERSISTED_CHARACTERS,
+  localStoragePersistence,
+} from "./store";
+export type {
+  DiagnosticsPersistence,
+  DiagnosticsStoreOptions,
+} from "./store";
+
+export {
+  bootstrapReporter,
+  boundaryReporter,
+  installGlobalDiagnostics,
+} from "./capture";
+export type { DiagnosticsGlobalTarget } from "./capture";
+
+export { REPORT_TITLE, renderDiagnosticsReport } from "./report";
+export type { ReportOptions } from "./report";

--- a/wallet/shared/src/diagnostics/record.ts
+++ b/wallet/shared/src/diagnostics/record.ts
@@ -1,0 +1,223 @@
+import {
+  type DiagnosticFrame,
+  scrubIdentifier,
+  scrubStack,
+  scrubText,
+} from "./redact";
+import {
+  type BreadcrumbCategory,
+  type BreadcrumbCode,
+  type DiagnosticKind,
+  isBreadcrumbCategory,
+  isBreadcrumbCode,
+  isDiagnosticKind,
+} from "./vocabulary";
+
+/** A step the app took, drawn entirely from the closed vocabulary. */
+export interface DiagnosticBreadcrumb {
+  /** Epoch milliseconds. */
+  readonly at: number;
+  readonly category: BreadcrumbCategory;
+  readonly code: BreadcrumbCode;
+}
+
+/** One captured failure. Every field here has already been through redaction. */
+export interface DiagnosticEvent {
+  /** Epoch milliseconds. */
+  readonly at: number;
+  /** Which capture path produced it. */
+  readonly kind: DiagnosticKind;
+  /** The error's constructor name, scrubbed. */
+  readonly name: string;
+  /** The error's message, scrubbed. */
+  readonly message: string;
+  /** Stack frames reduced to function, file name, line and column. */
+  readonly frames: readonly DiagnosticFrame[];
+  /** What the app was doing, most recent last. */
+  readonly breadcrumbs: readonly DiagnosticBreadcrumb[];
+}
+
+/**
+ * The three redaction functions, as an injectable seam.
+ *
+ * This exists for one reason: a test that asserts a secret is absent from the
+ * store proves nothing unless the same assertion would fail without redaction.
+ * Passing {@link PASSTHROUGH_SCRUBBER} to {@link createDiagnosticEvent} gives a
+ * test the negative control it needs. Nothing in the shipping path takes a
+ * scrubber — {@link DiagnosticsStore} always uses {@link STRICT_SCRUBBER} — so
+ * no caller can weaken the store by configuring it.
+ */
+export interface DiagnosticScrubber {
+  readonly text: (value: string) => string;
+  readonly identifier: (value: string) => string;
+  readonly stack: (value: string) => DiagnosticFrame[];
+}
+
+/** The redaction the shipping path always uses. */
+export const STRICT_SCRUBBER: DiagnosticScrubber = Object.freeze({
+  text: scrubText,
+  identifier: scrubIdentifier,
+  stack: scrubStack,
+});
+
+/**
+ * No redaction at all — the negative control, and the only thing in this
+ * package that would leak. It is never reachable from a store.
+ */
+export const PASSTHROUGH_SCRUBBER: DiagnosticScrubber = Object.freeze({
+  text: (value: string) => value,
+  identifier: (value: string) => value,
+  stack: (value: string) =>
+    value.split("\n").map((line) => ({
+      fn: line,
+      source: line,
+      line: 0,
+      column: 0,
+    })),
+});
+
+interface ErrorLike {
+  readonly name: string;
+  readonly message: string;
+  readonly stack?: string;
+}
+
+function asErrorLike(value: unknown): ErrorLike | null {
+  if (value instanceof Error) return value;
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.name !== "string") return null;
+  if (typeof candidate.message !== "string") return null;
+  return {
+    name: candidate.name,
+    message: candidate.message,
+    stack: typeof candidate.stack === "string" ? candidate.stack : undefined,
+  };
+}
+
+/**
+ * Describe a thrown value that is not an `Error`.
+ *
+ * Deliberately by type only. `String(value)` on an arbitrary object runs its
+ * `toString`, and in this codebase the objects being thrown around are wallet
+ * state, engine status and message envelopes — exactly the things a diagnostics
+ * buffer must never serialize. A record saying "an object was thrown" is less
+ * informative and is the only version that is safe by construction.
+ */
+function describeNonError(value: unknown): ErrorLike {
+  if (typeof value === "string") {
+    return { name: "String", message: value };
+  }
+  if (value === null) return { name: "Null", message: "" };
+  if (Array.isArray(value)) return { name: "Array", message: "" };
+  const kind = typeof value;
+  const name = kind.charAt(0).toUpperCase() + kind.slice(1);
+  return { name, message: "" };
+}
+
+/** What a caller hands {@link createDiagnosticEvent}. */
+export interface DiagnosticEventInput {
+  /** Epoch milliseconds. */
+  readonly at: number;
+  readonly kind: DiagnosticKind;
+  /** Whatever was thrown or rejected with. */
+  readonly error: unknown;
+  readonly breadcrumbs: readonly DiagnosticBreadcrumb[];
+}
+
+/**
+ * Turn a thrown value into a record.
+ *
+ * Redaction happens here, at construction, so there is no moment at which an
+ * unredacted `DiagnosticEvent` exists to be stored, rendered or copied by
+ * mistake. Export paths are pure reads of already-redacted values.
+ */
+export function createDiagnosticEvent(
+  input: DiagnosticEventInput,
+  scrub: DiagnosticScrubber = STRICT_SCRUBBER,
+): DiagnosticEvent {
+  const source = asErrorLike(input.error) ?? describeNonError(input.error);
+  return Object.freeze({
+    at: Number.isFinite(input.at) ? Math.trunc(input.at) : 0,
+    kind: isDiagnosticKind(input.kind) ? input.kind : "reported-error",
+    name: scrub.identifier(source.name),
+    message: scrub.text(source.message),
+    frames: Object.freeze(source.stack ? scrub.stack(source.stack) : []),
+    breadcrumbs: Object.freeze([...input.breadcrumbs]),
+  });
+}
+
+function reviveFrame(value: unknown): DiagnosticFrame | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.fn !== "string") return null;
+  if (typeof candidate.source !== "string") return null;
+  return {
+    fn: scrubIdentifier(candidate.fn),
+    source: scrubText(candidate.source),
+    line: typeof candidate.line === "number" ? Math.trunc(candidate.line) : 0,
+    column:
+      typeof candidate.column === "number" ? Math.trunc(candidate.column) : 0,
+  };
+}
+
+function reviveBreadcrumb(value: unknown): DiagnosticBreadcrumb | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isBreadcrumbCategory(candidate.category)) return null;
+  if (!isBreadcrumbCode(candidate.code)) return null;
+  return {
+    at: typeof candidate.at === "number" ? Math.trunc(candidate.at) : 0,
+    category: candidate.category,
+    code: candidate.code,
+  };
+}
+
+/**
+ * Re-validate a record read back from storage.
+ *
+ * Persisted JSON is not the same trust level as a value this process just
+ * built: the key is same-origin, but it is still writable by anything running
+ * in the page, and the report renders whatever comes back. So the vocabulary is
+ * re-checked and the text is scrubbed a second time on the way out. Redaction
+ * is idempotent, so this costs a pass and closes the gap.
+ */
+export function reviveDiagnosticEvent(value: unknown): DiagnosticEvent | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isDiagnosticKind(candidate.kind)) return null;
+  const frames = Array.isArray(candidate.frames)
+    ? candidate.frames.map(reviveFrame).filter((f): f is DiagnosticFrame => !!f)
+    : [];
+  const breadcrumbs = Array.isArray(candidate.breadcrumbs)
+    ? candidate.breadcrumbs
+        .map(reviveBreadcrumb)
+        .filter((c): c is DiagnosticBreadcrumb => !!c)
+    : [];
+  return Object.freeze({
+    at: typeof candidate.at === "number" ? Math.trunc(candidate.at) : 0,
+    kind: candidate.kind,
+    name: scrubIdentifier(
+      typeof candidate.name === "string" ? candidate.name : "",
+    ),
+    message: scrubText(
+      typeof candidate.message === "string" ? candidate.message : "",
+    ),
+    frames: Object.freeze(frames),
+    breadcrumbs: Object.freeze(breadcrumbs),
+  });
+}
+
+/** Build a breadcrumb, refusing anything outside the vocabulary. */
+export function createBreadcrumb(
+  at: number,
+  category: BreadcrumbCategory,
+  code: BreadcrumbCode,
+): DiagnosticBreadcrumb | null {
+  if (!isBreadcrumbCategory(category) || !isBreadcrumbCode(code)) return null;
+  return Object.freeze({
+    at: Number.isFinite(at) ? Math.trunc(at) : 0,
+    category,
+    code,
+  });
+}

--- a/wallet/shared/src/diagnostics/redact.ts
+++ b/wallet/shared/src/diagnostics/redact.ts
@@ -1,0 +1,362 @@
+/**
+ * The only place free-form text is allowed to become a diagnostic field.
+ *
+ * ## The shape of the problem
+ *
+ * `vocabulary.ts` closes every field a caller controls, so three strings are
+ * left that nobody can close: an `Error`'s `name`, its `message`, and its
+ * `stack`. Those come from the engine, from a library, or from a `throw new
+ * Error(...)` somebody wrote — and a message is one template literal away from
+ * carrying an address, a handle, a memo or an amount.
+ *
+ * ## Deny-listing is the weak form
+ *
+ * A regex that removes the secrets it recognises is only ever as good as its
+ * last update, and it fails open: the shape it has not met survives. This
+ * module inverts that. **A token is dropped unless it matches a shape known to
+ * be safe**, so an unfamiliar shape fails closed and becomes
+ * `[redacted:<class>]` — a label describing the shape, never the value.
+ *
+ * `wallet/zuuli/src/lib/feedback.ts` keeps the complementary deny-list, and it
+ * is right where it sits: that scrubber reviews prose a human typed on purpose,
+ * where removing everything unrecognised would remove the report. Here nothing
+ * was typed on purpose, so nothing unrecognised is worth keeping.
+ *
+ * ## The three rules
+ *
+ * 1. **Token allow-list.** Words, small numbers and code identifiers survive.
+ *    Anything long, anything encoded, anything with a digit in it past a few
+ *    characters, anything with a path, host, `@` or non-Latin letter does not.
+ *    That covers addresses, keys, tokens, ids, amounts and file paths by shape
+ *    rather than by name.
+ * 2. **Word-run collapse.** A recovery phrase is short lowercase dictionary
+ *    words and passes rule 1 word by word. So a run of
+ *    {@link WORD_RUN_LIMIT} or more consecutive bare lowercase 3–8 letter
+ *    words collapses whole. Real error messages break such a run within a few
+ *    words on punctuation, capitals, or a longer word; a twelve-word mnemonic
+ *    never does.
+ * 3. **Volume caps, and the one limit worth stating plainly.** Message
+ *    plaintext and memos are prose, and prose is genuinely indistinguishable
+ *    from an English error message token by token — "bring the blue folder"
+ *    and "could not read the file" have the same shape, the same word lengths
+ *    and the same punctuation. No token rule separates them, and a rule
+ *    aggressive enough to remove one removes the other, which would leave the
+ *    diagnostics screen unable to say anything.
+ *
+ *    So rule 3 does not claim to eliminate prose. It **bounds** it —
+ *    {@link MAX_MESSAGE_TOKENS} tokens and {@link MAX_MESSAGE_CHARACTERS}
+ *    characters, both set to what an error message needs and no more.
+ *
+ *    The control that does eliminate it is upstream and structural: nothing in
+ *    this codebase interpolates a memo or a message body into an `Error`, and
+ *    `record.ts` refuses to serialize a thrown object at all, so a state blob
+ *    carrying a body cannot be stringified into a record either. If a call
+ *    site ever writes ``new Error(`failed to send ${body}`)``, redaction is not
+ *    what should stop it — review is.
+ *
+ * ## Where this runs
+ *
+ * At `record()` time, before anything is placed in the ring buffer — never at
+ * export time. The buffer therefore cannot hold an unredacted value at all,
+ * which removes the whole class of bug where one export path forgot to filter.
+ */
+
+/** The shape a dropped token had, which is all a reader learns about it. */
+export const REDACTION_CLASSES = [
+  "number",
+  "handle",
+  "url",
+  "path",
+  "address",
+  "encoded",
+  "word-run",
+  "source",
+  "name",
+  "value",
+] as const;
+
+/** One of {@link REDACTION_CLASSES}. */
+export type RedactionClass = (typeof REDACTION_CLASSES)[number];
+
+/** Consecutive bare lowercase 3–8 letter words that collapse as a run. */
+export const WORD_RUN_LIMIT = 8;
+
+/** Most tokens a scrubbed message may keep. */
+export const MAX_MESSAGE_TOKENS = 32;
+
+/**
+ * Most characters a scrubbed message may keep.
+ *
+ * Set by what an error message needs rather than by what is convenient: the
+ * longest real messages in this codebase are well under this, and every
+ * character of headroom above that is headroom prose can occupy. See rule 3.
+ */
+export const MAX_MESSAGE_CHARACTERS = 240;
+
+/**
+ * Most characters read from any single input before scrubbing begins.
+ *
+ * Far above what an error message is, and far below what a runaway one could
+ * be. The output caps below do the shaping; this one exists only so the work
+ * done to get there stays bounded.
+ */
+export const MAX_INPUT_CHARACTERS = 8_192;
+
+/** Most stack frames a record keeps. */
+export const MAX_STACK_FRAMES = 12;
+
+/** Most lines of a stack searched for those frames. */
+export const MAX_STACK_LINES_EXAMINED = 64;
+
+/** Longest line searched; a real frame is far shorter than this. */
+export const MAX_STACK_LINE_LENGTH = 1_024;
+
+/** Appended when a cap truncated the text. */
+export const TRUNCATION_MARK = "[…]";
+
+/** The placeholder a dropped token becomes. */
+export function redactionMark(kind: RedactionClass): string {
+  return `[redacted:${kind}]`;
+}
+
+// Control characters, invisible formatting and bidi overrides are stripped
+// before anything is classified: a right-to-left override inside a token can
+// make a rendered report say something other than what it holds, and the repo
+// already treats bidi in source and copy as a policy matter.
+const DISCARDED_CHARACTERS =
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u180e\u200b-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u206f\ufeff\ufff9-\ufffb]/gu;
+
+const LEADING_WRAPPERS = /^[([{"'`\u00ab\u2039\u201c\u2018]+/u;
+const TRAILING_WRAPPERS =
+  /[)\]}"'`\u00bb\u203a\u201d\u2019.,;:!?]+$/u;
+
+const WORD = /^[A-Za-z][A-Za-z'\u2019-]{0,23}$/u;
+const BARE_LOWERCASE_WORD = /^[a-z]{3,8}$/u;
+const SMALL_NUMBER = /^\d{1,3}$/u;
+const LINE_AND_COLUMN = /^\d{1,5}:\d{1,5}$/u;
+const CODE_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*(?:[.#][A-Za-z0-9_$]+)*$/u;
+const PUNCTUATION_ONLY = /^[^\p{L}\p{N}]{1,3}$/u;
+const QUANTITY = /^[\d][\d.,]*$/u;
+const BECH32_LIKE = /^[A-Za-z]{1,14}1[02-9ac-hj-np-z]{8,}$/u;
+const BASE64_LIKE = /^[A-Za-z0-9+/_-]{16,}={0,2}$/u;
+
+/** Longest token kept verbatim; anything longer is an encoded value by size. */
+const MAX_TOKEN_LENGTH = 24;
+
+/**
+ * A digit is the tell. Identifiers, addresses, keys, hashes, tokens, amounts
+ * and record ids all carry them; the English words an error message is made of
+ * mostly do not. So a token that mixes digits into more than a few characters
+ * is treated as a value rather than as prose.
+ */
+const MAX_LENGTH_WITH_DIGITS = 7;
+
+function classify(core: string): RedactionClass {
+  if (core.includes("@")) return "handle";
+  if (core.includes("://") || core.startsWith("www.")) return "url";
+  if (core.includes("/") || core.includes("\\")) return "path";
+  if (BECH32_LIKE.test(core)) return "address";
+  if (QUANTITY.test(core)) return "number";
+  if (BASE64_LIKE.test(core)) return "encoded";
+  return "value";
+}
+
+function isSafeCore(core: string): boolean {
+  if (core.length === 0) return false;
+  if (core.length > MAX_TOKEN_LENGTH) return false;
+  if (PUNCTUATION_ONLY.test(core)) return true;
+  if (BECH32_LIKE.test(core)) return false;
+  if (/\d/u.test(core)) {
+    // `1.5`, `0.00123` and `9,000` are quantities whatever their length, and a
+    // transaction amount is exactly that shape.
+    if (/[.,]/u.test(core) && QUANTITY.test(core)) return false;
+    if (LINE_AND_COLUMN.test(core)) return true;
+    if (SMALL_NUMBER.test(core)) return true;
+    if (core.length > MAX_LENGTH_WITH_DIGITS) return false;
+  }
+  if (WORD.test(core)) return true;
+  return CODE_IDENTIFIER.test(core);
+}
+
+interface ClassifiedToken {
+  readonly text: string;
+  readonly runnable: boolean;
+}
+
+function scrubToken(token: string): ClassifiedToken {
+  const core = token
+    .replace(LEADING_WRAPPERS, "")
+    .replace(TRAILING_WRAPPERS, "");
+  // Stripping the wrappers off a token that was only punctuation leaves
+  // nothing. A bare comma is not a value, so it survives as itself rather than
+  // becoming a redaction mark that would make the sentence unreadable.
+  if (core.length === 0) {
+    return PUNCTUATION_ONLY.test(token)
+      ? { text: token, runnable: false }
+      : { text: redactionMark(classify(token)), runnable: false };
+  }
+  if (!isSafeCore(core)) {
+    return { text: redactionMark(classify(core)), runnable: false };
+  }
+  return {
+    text: token,
+    runnable: core === token && BARE_LOWERCASE_WORD.test(token),
+  };
+}
+
+function collapseWordRuns(tokens: readonly ClassifiedToken[]): string[] {
+  const output: string[] = [];
+  let run: string[] = [];
+  const flush = () => {
+    if (run.length >= WORD_RUN_LIMIT) output.push(redactionMark("word-run"));
+    else output.push(...run);
+    run = [];
+  };
+  for (const token of tokens) {
+    if (token.runnable) run.push(token.text);
+    else {
+      flush();
+      output.push(token.text);
+    }
+  }
+  flush();
+  return output;
+}
+
+function normalize(value: string): string {
+  // Cut before normalizing, not after. `normalize` and the classifier both walk
+  // the whole string, and this runs inside the engine's error path — a
+  // pathological message must not turn capturing a crash into the crash.
+  let text = value.length > MAX_INPUT_CHARACTERS
+    ? value.slice(0, MAX_INPUT_CHARACTERS)
+    : value;
+  try {
+    text = text.normalize("NFKC");
+  } catch {
+    // A lone surrogate makes `normalize` throw. The unnormalized text is still
+    // scrubbed by the same rules, so there is nothing to recover from.
+  }
+  return text.replace(DISCARDED_CHARACTERS, " ").replace(/\s+/gu, " ").trim();
+}
+
+/**
+ * Reduce free-form text to the tokens proven safe to keep.
+ *
+ * Whitespace collapses to single spaces, so the result is always one line: a
+ * ring-buffer record is a row, not a document, and a multi-line value in a
+ * markdown table is a rendering bug waiting to happen.
+ */
+export function scrubText(value: string): string {
+  const normalized = normalize(value);
+  if (normalized.length === 0) return "";
+  const tokens = normalized.split(" ").filter((token) => token.length > 0);
+  let truncated = tokens.length > MAX_MESSAGE_TOKENS;
+  const scrubbed = collapseWordRuns(
+    tokens.slice(0, MAX_MESSAGE_TOKENS).map(scrubToken),
+  );
+  // The character cap is applied token by token rather than by slicing the
+  // joined string, so a redaction mark is never cut in half into something that
+  // reads like a value.
+  const kept: string[] = [];
+  let length = 0;
+  for (const token of scrubbed) {
+    const next = length === 0 ? token.length : length + 1 + token.length;
+    if (next > MAX_MESSAGE_CHARACTERS) {
+      truncated = true;
+      break;
+    }
+    kept.push(token);
+    length = next;
+  }
+  const text = kept.join(" ");
+  return truncated ? `${text} ${TRUNCATION_MARK}`.trim() : text;
+}
+
+const SAFE_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$.<>[\]]{0,63}$/u;
+
+/**
+ * Keep a symbol name — an `Error` subclass, a stack frame's function — only if
+ * it looks like one. A name is code the build wrote, but `new Error()` lets a
+ * caller set `name` to anything, so it is checked rather than trusted.
+ */
+export function scrubIdentifier(value: string): string {
+  const trimmed = normalize(value);
+  if (trimmed.length === 0) return "";
+  if (!SAFE_IDENTIFIER.test(trimmed)) return redactionMark("name");
+  if (/\d/u.test(trimmed) && trimmed.length > MAX_TOKEN_LENGTH) {
+    return redactionMark("name");
+  }
+  return trimmed;
+}
+
+const SAFE_SOURCE_NAME = /^[A-Za-z0-9._-]{1,64}$/u;
+
+/**
+ * Reduce a stack frame's source to a bare file name.
+ *
+ * The full URL is dropped rather than kept: on desktop it is an absolute
+ * `file://` path that names the account, and a `blob:` or `data:` URL can carry
+ * the module's own text. A hashed bundle name identifies the build, which is
+ * the part worth having.
+ */
+export function scrubSource(value: string): string {
+  const normalized = normalize(value);
+  if (normalized.length === 0) return "";
+  const withoutQuery = normalized.split(/[?#]/u, 1)[0] ?? "";
+  const segments = withoutQuery.split(/[/\\]/u);
+  const name = segments[segments.length - 1] ?? "";
+  return SAFE_SOURCE_NAME.test(name) ? name : redactionMark("source");
+}
+
+/** One line of a stack, reduced to the parts that are code rather than data. */
+export interface DiagnosticFrame {
+  /** The function name, scrubbed, or `""` when the engine gave none. */
+  readonly fn: string;
+  /** The bare source file name, scrubbed. */
+  readonly source: string;
+  /** 1-based line, or 0 when the engine gave none. */
+  readonly line: number;
+  /** 1-based column, or 0 when the engine gave none. */
+  readonly column: number;
+}
+
+// V8: "    at fn (url:line:col)" or "    at url:line:col".
+const V8_FRAME = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?\s*$/u;
+// JavaScriptCore and SpiderMonkey: "fn@url:line:col". This is the shape iOS
+// gives us, which is the platform #973 was reported from.
+const AT_FRAME = /^(.*?)@(.+?):(\d+):(\d+)$/u;
+
+function parseFrame(line: string): DiagnosticFrame | null {
+  const match = V8_FRAME.exec(line) ?? AT_FRAME.exec(line);
+  if (!match) return null;
+  const [, fn, source, lineNumber, column] = match;
+  return {
+    fn: scrubIdentifier(fn ?? ""),
+    source: scrubSource(source ?? ""),
+    line: Number.parseInt(lineNumber ?? "0", 10) || 0,
+    column: Number.parseInt(column ?? "0", 10) || 0,
+  };
+}
+
+/**
+ * Parse a stack into frames, dropping every line that is not one.
+ *
+ * A stack's first line repeats the message on V8 and is absent on WebKit, and
+ * an unparsed line is text of unknown provenance. Both are discarded rather
+ * than scrubbed and kept: the message is already a field of its own, and a line
+ * that does not parse as a frame is not evidence worth the risk.
+ */
+export function scrubStack(stack: string): DiagnosticFrame[] {
+  const frames: DiagnosticFrame[] = [];
+  // Both frame patterns are lazy and would backtrack over a long line that is
+  // not a frame at all. Twelve frames is what a record keeps, so the search for
+  // them is bounded too rather than running the width of an arbitrary string.
+  const lines = stack.split("\n", MAX_STACK_LINES_EXAMINED);
+  for (const line of lines) {
+    if (frames.length >= MAX_STACK_FRAMES) break;
+    if (line.length > MAX_STACK_LINE_LENGTH) continue;
+    const frame = parseFrame(line);
+    if (frame) frames.push(frame);
+  }
+  return frames;
+}

--- a/wallet/shared/src/diagnostics/report.ts
+++ b/wallet/shared/src/diagnostics/report.ts
@@ -1,0 +1,122 @@
+import type { DiagnosticsEnvironment } from "./environment";
+import type { DiagnosticBreadcrumb, DiagnosticEvent } from "./record";
+import type { DiagnosticsStore } from "./store";
+
+/**
+ * Render the buffer as markdown a tester can paste into an issue.
+ *
+ * ## Why markdown, and why the user does the pasting
+ *
+ * Every TestFlight tester here is a collaborator, and the useful destination
+ * for what they hit is `github.com/free2z/zuu/issues`. So the export is shaped
+ * for that: a table for the environment, a fenced block per event, and no
+ * upload of any kind. The user reads it, then chooses to share it. Nothing in
+ * this package can send it anywhere — there is no request code in the module
+ * graph to send it with.
+ *
+ * ## What this function may and may not do
+ *
+ * It may format. It may not redact. Every string it prints has already been
+ * through `redact.ts` on the way into the store, which is what makes "did the
+ * export forget to filter?" a question with no answer to get wrong. If a change
+ * here ever needs a redaction call, the redaction is in the wrong place.
+ */
+
+/** Characters that would break out of the markdown structure around them. */
+function forMarkdown(value: string): string {
+  return value.replace(/[`|]/gu, "'");
+}
+
+function timestamp(at: number): string {
+  if (!Number.isFinite(at) || at <= 0) return "unknown";
+  try {
+    return new Date(at).toISOString().replace(/\.\d{3}Z$/u, "Z");
+  } catch {
+    return "unknown";
+  }
+}
+
+function renderEnvironment(environment: DiagnosticsEnvironment): string[] {
+  return [
+    "| field | value |",
+    "| --- | --- |",
+    `| app | ${environment.app} |`,
+    `| version | ${environment.version} (${environment.build}) |`,
+    `| platform | ${environment.platform} ${environment.platformVersion} |`,
+    `| engine | ${environment.engine} |`,
+  ];
+}
+
+function renderBreadcrumbs(trail: readonly DiagnosticBreadcrumb[]): string {
+  if (trail.length === 0) return "_no breadcrumbs_";
+  return trail.map((crumb) => `${crumb.category}/${crumb.code}`).join(" -> ");
+}
+
+function renderEvent(event: DiagnosticEvent, index: number): string[] {
+  const lines: string[] = [
+    `#### ${index}. ${event.kind} at ${timestamp(event.at)}`,
+    "",
+    `**${forMarkdown(event.name || "Error")}** ${forMarkdown(event.message)}`.trim(),
+    "",
+  ];
+  if (event.frames.length > 0) {
+    lines.push("```");
+    for (const frame of event.frames) {
+      const where = `${frame.source}:${frame.line}:${frame.column}`;
+      lines.push(frame.fn ? `at ${frame.fn} (${where})` : `at ${where}`);
+    }
+    lines.push("```", "");
+  }
+  lines.push(`breadcrumbs: ${forMarkdown(renderBreadcrumbs(event.breadcrumbs))}`, "");
+  return lines;
+}
+
+/** Extra context the diagnostics screen knows and the store does not. */
+export interface ReportOptions {
+  /**
+   * When the report was produced. Passed in rather than read from `Date.now()`
+   * so a test and a screenshot are reproducible.
+   */
+  readonly at?: number;
+}
+
+/**
+ * The heading the export opens with, which is also what the screen shows as a
+ * title so the two are never out of step.
+ */
+export const REPORT_TITLE = "Diagnostics report";
+
+/** Format the whole buffer. */
+export function renderDiagnosticsReport(
+  store: DiagnosticsStore,
+  options: ReportOptions = {},
+): string {
+  const events = store.events();
+  const lines: string[] = [
+    `### ${REPORT_TITLE}`,
+    "",
+    ...renderEnvironment(store.environment),
+    `| captured | ${timestamp(options.at ?? Date.now())} |`,
+    `| events | ${events.length} |`,
+    "",
+  ];
+
+  if (events.length === 0) {
+    lines.push("No failures have been recorded on this device.", "");
+  } else {
+    // Newest first: the failure a tester is reporting is the one that just
+    // happened, and it should not be below thirty-nine older ones.
+    const newestFirst = [...events].reverse();
+    newestFirst.forEach((event, index) => {
+      lines.push(...renderEvent(event, index + 1));
+    });
+  }
+
+  lines.push(
+    "_Captured locally by the app. Values that were not recognised as safe to",
+    "keep appear as `[redacted:...]`; nothing here left the device until this",
+    "report was shared by hand._",
+  );
+
+  return lines.join("\n");
+}

--- a/wallet/shared/src/diagnostics/store.ts
+++ b/wallet/shared/src/diagnostics/store.ts
@@ -1,0 +1,257 @@
+import {
+  type DiagnosticsEnvironment,
+  reviveEnvironment,
+} from "./environment";
+import {
+  type DiagnosticBreadcrumb,
+  type DiagnosticEvent,
+  createBreadcrumb,
+  createDiagnosticEvent,
+  reviveDiagnosticEvent,
+} from "./record";
+import type {
+  BreadcrumbCategory,
+  BreadcrumbCode,
+  DiagnosticKind,
+} from "./vocabulary";
+
+/** Bumped when the persisted shape changes; older payloads are discarded. */
+export const DIAGNOSTICS_SCHEMA_VERSION = 1;
+
+/** The storage key all three surfaces use. Each has its own origin. */
+export const DIAGNOSTICS_STORAGE_KEY = "free2z.diagnostics.v1";
+
+/** Events kept before the oldest is dropped. */
+export const DEFAULT_EVENT_CAPACITY = 40;
+
+/** Breadcrumbs kept before the oldest is dropped. */
+export const DEFAULT_BREADCRUMB_CAPACITY = 24;
+
+/** Breadcrumbs attached to each event. */
+export const BREADCRUMBS_PER_EVENT = 12;
+
+/**
+ * Ceiling on the serialized buffer.
+ *
+ * A diagnostics buffer that can grow is a diagnostics buffer that can fill a
+ * user's storage quota and take the app down with it — which would be a worse
+ * bug than the one it exists to report. Events are dropped oldest-first until
+ * the payload fits.
+ */
+export const MAX_PERSISTED_CHARACTERS = 48_000;
+
+/**
+ * Where the buffer survives a restart.
+ *
+ * An injectable port rather than a direct `localStorage` reference: the store
+ * is constructed in `main.tsx` before anything else runs, and it must work in a
+ * private window, under a storage-blocking setting, and in a Node test — all
+ * three of which make `window.localStorage` throw on access rather than return
+ * null.
+ */
+export interface DiagnosticsPersistence {
+  read(): string | null;
+  write(serialized: string): void;
+  clear(): void;
+}
+
+type MinimalStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * A persistence port over `localStorage` that never throws.
+ *
+ * Every method is wrapped: a store that cannot persist still captures in
+ * memory, and losing the buffer is always better than the diagnostics
+ * subsystem becoming the crash.
+ */
+export function localStoragePersistence(
+  storage: MinimalStorage,
+  key: string = DIAGNOSTICS_STORAGE_KEY,
+): DiagnosticsPersistence {
+  return {
+    read() {
+      try {
+        return storage.getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    write(serialized: string) {
+      try {
+        storage.setItem(key, serialized);
+      } catch {
+        // Quota, private mode, or a blocked origin. Nothing to do and nothing
+        // worth reporting: reporting it here would recurse into this store.
+      }
+    },
+    clear() {
+      try {
+        storage.removeItem(key);
+      } catch {
+        // As above.
+      }
+    },
+  };
+}
+
+/** How a {@link DiagnosticsStore} is configured. */
+export interface DiagnosticsStoreOptions {
+  readonly environment: DiagnosticsEnvironment;
+  readonly persistence?: DiagnosticsPersistence | null;
+  readonly eventCapacity?: number;
+  readonly breadcrumbCapacity?: number;
+  readonly now?: () => number;
+}
+
+interface PersistedShape {
+  readonly v: number;
+  readonly environment: unknown;
+  readonly events: unknown;
+}
+
+function positiveCapacity(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const rounded = Math.trunc(value);
+  return rounded > 0 ? rounded : fallback;
+}
+
+/**
+ * A bounded, local, restart-surviving record of what went wrong.
+ *
+ * Three properties, in the order they matter:
+ *
+ * 1. **It is local.** There is no upload, no endpoint, no queue and no retry.
+ *    Nothing in this file knows how to make a network request. The user reads
+ *    the buffer on the diagnostics screen and decides, by hand, whether to
+ *    share it.
+ * 2. **It is redacted on the way in.** `record()` builds the event through
+ *    `createDiagnosticEvent`, which redacts before returning, so no unredacted
+ *    value is ever held. There is nothing for an export path to forget.
+ * 3. **It is bounded.** Events, breadcrumbs and serialized size all have
+ *    ceilings, so a crash loop degrades to a full ring rather than to a filled
+ *    storage quota.
+ */
+export class DiagnosticsStore {
+  readonly environment: DiagnosticsEnvironment;
+
+  private readonly persistence: DiagnosticsPersistence | null;
+  private readonly eventCapacity: number;
+  private readonly breadcrumbCapacity: number;
+  private readonly clock: () => number;
+  private storedEvents: DiagnosticEvent[] = [];
+  private trail: DiagnosticBreadcrumb[] = [];
+
+  constructor(options: DiagnosticsStoreOptions) {
+    this.environment = options.environment;
+    this.persistence = options.persistence ?? null;
+    this.eventCapacity = positiveCapacity(
+      options.eventCapacity,
+      DEFAULT_EVENT_CAPACITY,
+    );
+    this.breadcrumbCapacity = positiveCapacity(
+      options.breadcrumbCapacity,
+      DEFAULT_BREADCRUMB_CAPACITY,
+    );
+    this.clock = options.now ?? (() => Date.now());
+    this.storedEvents = this.load();
+  }
+
+  /**
+   * Note what the app is doing.
+   *
+   * Takes no free-form argument by design — see `vocabulary.ts`. A call site
+   * cannot attach a handle, an address or a body to a breadcrumb, because
+   * there is nowhere to put one.
+   */
+  breadcrumb(category: BreadcrumbCategory, code: BreadcrumbCode): void {
+    const crumb = createBreadcrumb(this.clock(), category, code);
+    if (!crumb) return;
+    this.trail.push(crumb);
+    if (this.trail.length > this.breadcrumbCapacity) {
+      this.trail = this.trail.slice(-this.breadcrumbCapacity);
+    }
+  }
+
+  /** Capture a failure. Returns the redacted record that was stored. */
+  record(kind: DiagnosticKind, error: unknown): DiagnosticEvent {
+    const event = createDiagnosticEvent({
+      at: this.clock(),
+      kind,
+      error,
+      breadcrumbs: this.trail.slice(-BREADCRUMBS_PER_EVENT),
+    });
+    this.storedEvents.push(event);
+    if (this.storedEvents.length > this.eventCapacity) {
+      this.storedEvents = this.storedEvents.slice(-this.eventCapacity);
+    }
+    this.persist();
+    return event;
+  }
+
+  /** The buffer, oldest first. */
+  events(): readonly DiagnosticEvent[] {
+    return this.storedEvents;
+  }
+
+  /** The live breadcrumb trail, oldest first. */
+  breadcrumbs(): readonly DiagnosticBreadcrumb[] {
+    return this.trail;
+  }
+
+  /** Forget everything, on disk as well as in memory. */
+  clear(): void {
+    this.storedEvents = [];
+    this.trail = [];
+    this.persistence?.clear();
+  }
+
+  private load(): DiagnosticEvent[] {
+    const raw = this.persistence?.read();
+    if (!raw) return [];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+    if (typeof parsed !== "object" || parsed === null) return [];
+    const payload = parsed as Partial<PersistedShape>;
+    if (payload.v !== DIAGNOSTICS_SCHEMA_VERSION) return [];
+    // A buffer written by a different install of a different surface is not
+    // this app's history. Revive it only if it says it is ours.
+    const environment = reviveEnvironment(payload.environment);
+    if (!environment || environment.app !== this.environment.app) return [];
+    if (!Array.isArray(payload.events)) return [];
+    const events = payload.events
+      .map(reviveDiagnosticEvent)
+      .filter((event): event is DiagnosticEvent => event !== null);
+    return events.slice(-this.eventCapacity);
+  }
+
+  private persist(): void {
+    if (!this.persistence) return;
+    let events = this.storedEvents;
+    let serialized = this.serialize(events);
+    while (serialized.length > MAX_PERSISTED_CHARACTERS && events.length > 1) {
+      events = events.slice(1);
+      serialized = this.serialize(events);
+    }
+    if (serialized.length > MAX_PERSISTED_CHARACTERS) {
+      // A single event over the ceiling cannot happen — every field is capped
+      // — but if it somehow did, an empty buffer beats a rejected write.
+      this.persistence.write(this.serialize([]));
+      return;
+    }
+    this.storedEvents = events;
+    this.persistence.write(serialized);
+  }
+
+  private serialize(events: readonly DiagnosticEvent[]): string {
+    const payload: PersistedShape = {
+      v: DIAGNOSTICS_SCHEMA_VERSION,
+      environment: this.environment,
+      events,
+    };
+    return JSON.stringify(payload);
+  }
+}

--- a/wallet/shared/src/diagnostics/vocabulary.ts
+++ b/wallet/shared/src/diagnostics/vocabulary.ts
@@ -1,0 +1,178 @@
+/**
+ * The closed vocabularies a diagnostic record is built from.
+ *
+ * ## Why a vocabulary and not strings
+ *
+ * A wallet and an end-to-end encrypted messenger cannot ship a buffer that
+ * accepts arbitrary caller text. `breadcrumb("opened chat with " + handle)` is
+ * one autocomplete away at every call site, and no reviewer catches it twice.
+ * So the capture API takes no free-form string at all: a breadcrumb is a
+ * `(category, code)` pair drawn from the frozen sets below, and the only way to
+ * add one is to edit this file — which is a reviewed change in the shared
+ * package rather than a line in a feature.
+ *
+ * That is the load-bearing half of the privacy design. Everything the store
+ * holds is drawn from here except an `Error`'s own `name`, `message` and
+ * `stack`, and those three are the only text `redact.ts` has to reason about.
+ */
+
+/** The application a record came from. */
+export const DIAGNOSTIC_APPS = ["zuuli", "free2z", "e2e2z"] as const;
+
+/** One of {@link DIAGNOSTIC_APPS}. */
+export type DiagnosticApp = (typeof DIAGNOSTIC_APPS)[number];
+
+/**
+ * How a failure reached the store.
+ *
+ * These are capture paths, not error classifications: a caller does not get to
+ * invent a kind, so the diagnostics screen can group by kind without ever
+ * rendering an attacker- or user-supplied label.
+ */
+export const DIAGNOSTIC_KINDS = [
+  /** `window.onerror` — a throw that escaped to the event loop. */
+  "uncaught-error",
+  /** `unhandledrejection` — the class of failure that caused #973. */
+  "unhandled-rejection",
+  /** A React render/lifecycle throw caught by a root `ErrorBoundary`. */
+  "render-error",
+  /** Locale or mount bootstrap failed before the app was on screen. */
+  "bootstrap-error",
+  /** A failure a feature reported deliberately through `captureError`. */
+  "reported-error",
+] as const;
+
+/** One of {@link DIAGNOSTIC_KINDS}. */
+export type DiagnosticKind = (typeof DIAGNOSTIC_KINDS)[number];
+
+/** The coarse area of the app a breadcrumb belongs to. */
+export const BREADCRUMB_CATEGORIES = [
+  "lifecycle",
+  "navigation",
+  "bridge",
+  "messaging",
+  "enrollment",
+  "wallet",
+] as const;
+
+/** One of {@link BREADCRUMB_CATEGORIES}. */
+export type BreadcrumbCategory = (typeof BREADCRUMB_CATEGORIES)[number];
+
+/**
+ * Every breadcrumb this codebase may leave.
+ *
+ * Deliberately coarse. A breadcrumb answers "what was the app doing", never
+ * "what was the app doing it to" — there is no code here that could be
+ * parameterised by a handle, an address, an amount or a message body, because
+ * there is no parameter at all.
+ */
+export const BREADCRUMB_CODES = [
+  // lifecycle
+  "app-start",
+  "locale-ready",
+  "app-mounted",
+  "app-visible",
+  "app-hidden",
+  // navigation
+  "route-enter",
+  "route-leave",
+  // bridge — the cross-surface intent bridge (docs/intent-bridge/PROTOCOL.md)
+  "bridge-request-encoded",
+  "bridge-response-decoded",
+  "bridge-refused",
+  // messaging
+  "engine-status-requested",
+  "engine-status-ready",
+  "engine-status-failed",
+  "device-info-requested",
+  "device-info-ready",
+  "device-info-failed",
+  "transcript-rendered",
+  // enrollment
+  "enrollment-status-requested",
+  "enrollment-status-ready",
+  "enrollment-unavailable",
+  "enrollment-started",
+  "enrollment-refused",
+  // wallet
+  "wallet-locked",
+  "wallet-unlocked",
+  "sync-started",
+  "sync-failed",
+] as const;
+
+/** One of {@link BREADCRUMB_CODES}. */
+export type BreadcrumbCode = (typeof BREADCRUMB_CODES)[number];
+
+/**
+ * The device families we distinguish.
+ *
+ * A `navigator.userAgent` is free text, and a long enough free-text field is a
+ * place a secret can hide. So the store never keeps one: `describePlatform`
+ * maps it onto this set plus a two-part version number, and anything it cannot
+ * place becomes `unknown`.
+ */
+export const PLATFORM_FAMILIES = [
+  "ios",
+  "ipados",
+  "android",
+  "macos",
+  "windows",
+  "linux",
+  "unknown",
+] as const;
+
+/** One of {@link PLATFORM_FAMILIES}. */
+export type PlatformFamily = (typeof PLATFORM_FAMILIES)[number];
+
+/** The rendering engine families we distinguish. */
+export const ENGINE_FAMILIES = ["webkit", "blink", "gecko", "unknown"] as const;
+
+/** One of {@link ENGINE_FAMILIES}. */
+export type EngineFamily = (typeof ENGINE_FAMILIES)[number];
+
+const APP_SET: ReadonlySet<string> = new Set(DIAGNOSTIC_APPS);
+const KIND_SET: ReadonlySet<string> = new Set(DIAGNOSTIC_KINDS);
+const CATEGORY_SET: ReadonlySet<string> = new Set(BREADCRUMB_CATEGORIES);
+const CODE_SET: ReadonlySet<string> = new Set(BREADCRUMB_CODES);
+const PLATFORM_SET: ReadonlySet<string> = new Set(PLATFORM_FAMILIES);
+const ENGINE_SET: ReadonlySet<string> = new Set(ENGINE_FAMILIES);
+
+/**
+ * Membership tests.
+ *
+ * The types above stop TypeScript callers; these stop everyone else. Records
+ * are re-read from persisted JSON on the next launch, and a JS caller can hand
+ * a plain string to any of these APIs, so the vocabulary is checked at runtime
+ * on the way in and on the way back out of storage rather than trusted.
+ */
+export function isDiagnosticApp(value: unknown): value is DiagnosticApp {
+  return typeof value === "string" && APP_SET.has(value);
+}
+
+/** Whether `value` is one of {@link DIAGNOSTIC_KINDS}. */
+export function isDiagnosticKind(value: unknown): value is DiagnosticKind {
+  return typeof value === "string" && KIND_SET.has(value);
+}
+
+/** Whether `value` is one of {@link BREADCRUMB_CATEGORIES}. */
+export function isBreadcrumbCategory(
+  value: unknown,
+): value is BreadcrumbCategory {
+  return typeof value === "string" && CATEGORY_SET.has(value);
+}
+
+/** Whether `value` is one of {@link BREADCRUMB_CODES}. */
+export function isBreadcrumbCode(value: unknown): value is BreadcrumbCode {
+  return typeof value === "string" && CODE_SET.has(value);
+}
+
+/** Whether `value` is one of {@link PLATFORM_FAMILIES}. */
+export function isPlatformFamily(value: unknown): value is PlatformFamily {
+  return typeof value === "string" && PLATFORM_SET.has(value);
+}
+
+/** Whether `value` is one of {@link ENGINE_FAMILIES}. */
+export function isEngineFamily(value: unknown): value is EngineFamily {
+  return typeof value === "string" && ENGINE_SET.has(value);
+}

--- a/wallet/shared/src/index.ts
+++ b/wallet/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./sensitive-entry-session";
 export * from "./intent";
+export * from "./diagnostics";

--- a/wallet/zuuli/src/lib/diagnostics.test.ts
+++ b/wallet/zuuli/src/lib/diagnostics.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { renderDiagnosticsReport } from "@free2z/wallet-shared";
+import { BUILD_INFO } from "./build-info";
+import { createDiagnosticsStore } from "./diagnostics";
+
+/**
+ * That the wallet authority's buffer is this app's, and that the highest-value
+ * secret in the product cannot appear in it.
+ *
+ * The shared package proves the redaction rules; what has to be proven here is
+ * that ZUULI is wired to them at all, and that the wiring names ZUULI rather
+ * than inheriting another surface's build.
+ */
+describe("the wallet authority's diagnostics buffer", () => {
+  it("identifies itself as ZUULI and carries this build", () => {
+    const store = createDiagnosticsStore();
+    expect(store.environment.app).toBe("zuuli");
+    expect(store.environment.version).toBe(BUILD_INFO.version);
+    expect(store.environment.build).toBe(String(BUILD_INFO.build));
+  });
+
+  it("records a failure without carrying a recovery phrase into the report", () => {
+    const store = createDiagnosticsStore();
+    const phrase =
+      "abandon ability able about above absent absorb abstract absurd abuse access accident";
+    store.breadcrumb("wallet", "wallet-unlocked");
+    store.record(
+      "reported-error",
+      new Error(`could not derive an account from ${phrase}`),
+    );
+
+    const report = renderDiagnosticsReport(store);
+    // The word-run rule takes the two words either side of the phrase with it.
+    // That is the trade the rule makes and it is the right way round: losing
+    // "account from" costs a reader nothing, and keeping it would mean keeping
+    // a rule that a recovery phrase can walk through.
+    expect(report).toContain("could not derive an [redacted:word-run]");
+    expect(report).not.toContain("abandon");
+    expect(report).not.toContain(phrase);
+    expect(report).toContain("wallet/wallet-unlocked");
+  });
+});

--- a/wallet/zuuli/src/lib/diagnostics.ts
+++ b/wallet/zuuli/src/lib/diagnostics.ts
@@ -1,0 +1,65 @@
+import {
+  DiagnosticsStore,
+  createEnvironment,
+  localStoragePersistence,
+} from "@free2z/wallet-shared";
+import { BUILD_INFO } from "./build-info";
+
+/**
+ * The wallet authority's diagnostics buffer.
+ *
+ * ## Why the wallet gets the same buffer as the other two
+ *
+ * Because the failure mode is the same and the privacy bar is higher, not
+ * lower. What makes it safe to run here is that the buffer holds no field a
+ * caller controls: breadcrumbs come from a closed vocabulary, and the only free
+ * text is an error's own name, message and stack, each reduced by
+ * `@free2z/wallet-shared`'s allow-list before it is stored. A seed, a spending
+ * key or an address is not a shape that survives that.
+ *
+ * ## What this does not do yet
+ *
+ * ZUULI has no diagnostics screen in this increment — capture lands in all
+ * three surfaces, the screen lands first in e2e2z, which is the one that
+ * shipped and hung (#973). The right home here is the existing About screen
+ * next to `FeedbackComposer`, and `lib/feedback.ts`'s
+ * `captureFeedbackDiagnostics()` is the seam that was left for it: its comment
+ * says diagnostics stay unavailable "until a future separately reviewed
+ * allowlist can prove a safe schema end to end", and that allowlist is what
+ * this store now is. Wiring the two together is a change to the feedback
+ * handoff's own review rules and belongs in its own pull request.
+ */
+
+function storage() {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    // Reading `localStorage` itself throws when a WebView blocks site data.
+    return null;
+  }
+}
+
+function userAgent(): string {
+  try {
+    return typeof navigator === "undefined" ? "" : navigator.userAgent;
+  } catch {
+    return "";
+  }
+}
+
+/** Build the store. Exported for tests; the app uses {@link diagnostics}. */
+export function createDiagnosticsStore(): DiagnosticsStore {
+  const local = storage();
+  return new DiagnosticsStore({
+    environment: createEnvironment({
+      app: "zuuli",
+      version: BUILD_INFO.version,
+      build: String(BUILD_INFO.build),
+      userAgent: userAgent(),
+    }),
+    persistence: local ? localStoragePersistence(local) : null,
+  });
+}
+
+/** The process-wide buffer. */
+export const diagnostics = createDiagnosticsStore();

--- a/wallet/zuuli/src/main.tsx
+++ b/wallet/zuuli/src/main.tsx
@@ -1,22 +1,38 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
+import {
+  bootstrapReporter,
+  boundaryReporter,
+  installGlobalDiagnostics,
+} from "@free2z/wallet-shared";
 import App from "./App";
 import { mountApplication, RootFallback } from "./app-bootstrap";
 import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { diagnostics } from "./lib/diagnostics";
 import { installDocumentDirection } from "./lib/document-direction";
 import { runWasmSpike } from "./lib/wasm-spike";
 import "./index.css";
 
 installDocumentDirection();
 
+// Before the first `await`, so a rejection during locale bootstrap reaches a
+// listener rather than nobody. A `void promise` whose rejection no handler ever
+// observes is how #973 shipped a build that hung with nothing written down.
+installGlobalDiagnostics(diagnostics, window);
+diagnostics.breadcrumb("lifecycle", "app-start");
+
 void mountApplication({
   root: ReactDOM.createRoot(document.getElementById("root")!),
+  reportError: bootstrapReporter(diagnostics),
   renderApplication: (i18n) => (
     <React.StrictMode>
       <I18nextProvider i18n={i18n}>
         {/* Top-level boundary: no subtree can ever unmount the root. */}
-        <ErrorBoundary fallback={<RootFallback />}>
+        <ErrorBoundary
+          fallback={<RootFallback />}
+          onError={boundaryReporter(diagnostics)}
+        >
           <App />
         </ErrorBoundary>
       </I18nextProvider>


### PR DESCRIPTION
Closes the third acceptance box on #973 and builds the capability its absence exposed.

## The problem this is about

`e2e2z 0.1.0 (2)` shipped to TestFlight, hung forever on a loading skeleton, and left the tester and us with **no way to learn why**. The proximate cause is a `void reconcile()` whose rejection nobody observed (another agent owns that fix). The reason it was unknowable is separate and larger: **none of the three apps captured or surfaced failure at all.** No `unhandledrejection` listener, no `window.onerror`, no boundary in e2e2z, no record of any kind. The `ErrorBoundary` in the other two deliberately swallows the error in production, and `zuuli/src/lib/feedback.ts` states outright that diagnostics have "no shipping capture path".

## What this adds

`wallet/shared/src/diagnostics/` — a bounded, local, restart-surviving buffer — consumed by all three surfaces, plus a screen in e2e2z.

```
 window "error"        -+
 "unhandledrejection"  -|
 ErrorBoundary onError -+-> redact.ts -> DiagnosticsStore -> diagnostics screen
 mountApplication      -+   (allow-list   (ring, bounded,     (read / copy /
                             at write      localStorage)       share by hand)
                             time)
```

**There is no upload, no endpoint, no queue, no retry, no SDK, no sampling.** Not because the packaged CSP would block one — it would, and that is a symptom of the right instinct rather than the reason — but because a Zcash wallet and an end-to-end encrypted messenger cannot ship a process that reports anything about a session without the user doing it. There is no request code anywhere in the module graph to send it with, and `tests/diagnostics.pw.ts` has a real browser watch every request the page makes and assert the list is empty.

## How redaction is enforced structurally

The brief asked for the strong form — secrets that cannot reach the buffer, not secrets filtered on the way out. Four mechanisms, in the order they carry weight:

1. **The vocabulary is closed.** `vocabulary.ts` freezes the app names, capture kinds, breadcrumb categories, breadcrumb codes, platform families and engine families. `store.breadcrumb(category, code)` **takes no free-form argument at all** — there is nowhere to put a handle, an address, an amount or a message body, so no call site can leak one by autocomplete. Adding a breadcrumb means editing the shared package, which is a reviewed change rather than a line in a feature. Everything the buffer holds comes from here except three strings.

2. **Redaction runs at `record()`, not at export.** `createDiagnosticEvent` redacts before it returns, so **an unredacted `DiagnosticEvent` never exists**. Export paths are pure reads of already-redacted values, which deletes the entire bug class of "this one export path forgot to filter". `report.ts` says so in its own header: it may format, it may not redact.

3. **The token rule is an allow-list, so unknown shapes fail closed.** `redact.ts` keeps a token only if it matches a shape known to be safe — a word, a small number, a `line:col`, a code identifier — and replaces everything else with `[redacted:<class>]`, a label describing the shape rather than the value. Long tokens, encoded tokens, anything with a digit past a few characters, anything with `@`, a host, a path separator or a non-Latin letter goes. That covers addresses, spending and viewing keys, device keys, JWTs, ids and amounts **by shape**, so a form we have not met is removed rather than survived. A deny-list is the weak form and fails open; `zuuli/src/lib/feedback.ts` keeps the complementary deny-list and it is right where it is, because it reviews prose a human typed on purpose.

   A recovery phrase passes rule 1 word by word, so a second rule collapses any run of 8 or more consecutive bare lowercase 3–8 letter words entirely.

4. **A thrown non-`Error` is described by type, never serialized.** `record.ts` will not call `toString` on a thrown object — and in this codebase the objects thrown around are wallet state, engine status and message envelopes. `{"name":"Object","message":""}` is less informative and is the only version that is safe by construction.

Stack frames are reduced to `function@basename:line:col`; the URL is dropped, because on desktop it is an absolute `file://` path that names the account and a `blob:`/`data:` URL can carry the module's own text.

### The control is not decoration

`wallet/e2e2z/src/lib/diagnostics.redaction.test.ts` runs each of nine secret-shaped inputs through the real capture path **twice**:

```ts
it("is absent from every field the store keeps", () =>
  expect(captured(thrown)).not.toContain(secret));

it("would be present without redaction, so the assertion is real", () =>
  expect(unredacted(thrown)).toContain(secret));   // PASSTHROUGH_SCRUBBER
```

An absence assertion passes trivially if the value was never there. The paired assertion fails if redaction ever becomes a no-op **and** fails if the input ever stops reaching the capture path, so neither failure can hide behind the other. `PASSTHROUGH_SCRUBBER` is exported for exactly this and is unreachable from a `DiagnosticsStore` — no caller can weaken the store by configuring it.

## The one limit, stated rather than papered over

**Prose is not separable from an error message by token analysis.** "bring the blue folder" and "could not read the file" have the same word lengths, the same punctuation and no digits. A rule aggressive enough to remove a memo removes the error message with it, and a diagnostics screen that cannot say what went wrong is not worth shipping.

So rule 3 **bounds** prose rather than claiming to eliminate it — 32 tokens, 240 characters, both set to what an error message needs and no more. The test says this in as many words instead of asserting something convenient. The control that does eliminate it is upstream: nothing here interpolates a memo or a body into an `Error`, and mechanism 4 stops a state blob carrying one from being stringified. If a call site ever writes `new Error("failed to send " + body)`, redaction is not what should stop it — review is.

## Rebased across #974 — whose side I took, and why

#974 landed the `reconcile()` fix and, along the way, brought e2e2z onto
`mountApplication` + `ErrorBoundary` — which this PR had also done independently.
That produced three add/add conflicts. I took **#974's side wholesale** for all
three files and dropped my duplicates:

- `app-bootstrap.tsx` — byte-identical to mine. Nothing to choose.
- `ErrorBoundary.tsx` — identical apart from the doc comment, and **theirs is
  better**: it explains the e2e2z-specific stake (a single screen with nowhere
  to navigate) rather than restating the generic rationale. Kept theirs.
- `app-bootstrap.test.tsx` — theirs is a superset of mine.

`main.tsx` is a content conflict, and the resolution matters: their version is
the base, and this PR now adds **only** the diagnostics wiring to it — a
`reportError`, an `onError`, `installGlobalDiagnostics`, and two breadcrumbs.
There is exactly **one** `mountApplication` and **one** `<ErrorBoundary>` in the
file. Two boundaries wrapping the same root would be worse than one, and none of
#974's behaviour is re-implemented or undone.

One knock-on: #974 pinned the boundary's shape with a source assertion,
`expect(mainSource).toContain("<ErrorBoundary fallback={<RootFallback />}>")`.
Adding `onError` makes the tag span several lines and breaks the literal match
while *strengthening* the property the guard protects. Rather than delete or
loosen it, I re-expressed it as a pattern:

```ts
expect(mainSource).toMatch(/<ErrorBoundary[^>]*\bfallback=\{<RootFallback \/>\}/u);
```

`[^>]*` cannot cross the closing `>`, so it still requires the fallback to be a
prop **of that tag** — a boundary in one place and a stray `RootFallback` in
another does not satisfy it. I ran it against six cases before trusting it: the
real multi-line tag and #974's original single-line form pass; boundary removed,
fallback dropped, fallback swapped, and boundary-plus-unrelated-`RootFallback`
all still fail. The guard catches everything it caught before.

#979's deletion of ZUULI's dead content-API modules is untouched — the boundary
checker's file count went 502 → 491 across the rebase, which is exactly its 11
deleted files, and nothing in this PR reaches into `wallet/zuuli/src/lib/api/`.

## What I deliberately did not do, and why

**Rust panic capture is not in this change.** The brief asked for `std::panic::set_hook` in all three. I think shipping it now would be wrong, and the reason is architectural rather than effort:

`wallet/free2z/src-tauri/src/lib.rs` registers **no `invoke_handler` at all**, and `no_invoke_handler_is_registered` fails the build if one appears. `docs/architecture.md` §3.1 is explicit that this — not the CSP — is what makes the surface that renders third-party content safe under #367, where a remote subframe resolves as the trusted main window. A `diagnostics_native_records` command is a command, and it would be added to precisely the process where a hostile frame could call it. A Tauri event or an `initialization_script` is worse: Wry injects into every frame.

So a panic hook could write to a bounded file today, but **nothing could read it back into the app that most needs one**. That ships write-only instrumentation — the exact failure this work exists to end — for the cost of a new `rs/crates/` member, three `Cargo.lock` regenerations (one across the librustzcash graph), a `wallet-surfaces.yml` path entry and a toolchain registration. The open question is the transport, not the hook, and it deserves its own change and its own review: **#980**, which weighs three options for the channel.

Also deliberately left:

- **Screens for ZUULI and free2z.** Capture is installed in all three; the screen lands first in the app that actually shipped and hung. ZUULI's home is the existing About screen next to `FeedbackComposer` — and `captureFeedbackDiagnostics()` in `zuuli/src/lib/feedback.ts` is the seam left for it: *"until a future separately reviewed allowlist can prove a safe schema end to end"*. This store is that allowlist. Wiring the two is a change to the feedback handoff's own atomic-refusal rules and belongs in its own PR. free2z needs a route, a nav entry and an addition to `tests/viewport.pw.ts`'s hand-maintained route array.
- **Breadcrumb call sites.** The vocabulary is seeded and `lifecycle/app-start` and `lifecycle/locale-ready` are emitted; the messaging, bridge, enrollment and wallet codes exist but are not yet called from their features. Adding them touches files other agents hold right now.
- **`cause` chains.** One level of `Error.cause` would be useful and is a second free-text surface; left until the rules above have some mileage.

## Verified

Run locally, honestly reported:

- `wallet/e2e2z`: `npm ci`, `npm run typecheck`, `npm run typecheck:tests`, **full `npm test`** — vitest 225, the three `node --test` script suites, and 8 Playwright specs including the new `tests/diagnostics.pw.ts`. Green.
- `wallet/free2z`: `npm ci`, both typechecks, **full `npm test`** — 90 Playwright specs passed; `tests/media-preflight.pw.ts` failed 2 of 4 parametrised cases with "timeout while setting up page", then passed 6/6 when re-run alone. Local contention, in a fixture that runs before any app code loads.

  Worth recording because I nearly reported it wrong: ZUULI's first full run showed **22 Playwright failures**, all "timeout while running beforeEach" at `page.goto`. That was a cold Vite dependency-optimization pass on a machine already running two other suites, not a defect — `tests/about.pw.ts` took 1.6 minutes and failed 2 of 3 cold, then passed 3/3 in 9.9 seconds warm, and the full suite then passed 99/99. A `| tail` on the first run had also swallowed the non-zero exit, which is how the failure nearly went unnoticed.
Re-run in full **after** the rebase onto `a5827cdb`, because a conflict resolution invalidates prior verification as thoroughly as an amend does. For each app, the surfaces job's exact sequence — `typecheck`, `typecheck:tests`, `npm test`, `npm run build`:

| app | typecheck | typecheck:tests | npm test | build |
| --- | --- | --- | --- | --- |
| e2e2z | pass | pass | vitest 273 / 19 files · node 13 · **9 Playwright** | pass |
| free2z | pass | pass | vitest 926 (+5 skipped) / 65 files · node 13 · **92 Playwright** | pass |
| zuuli | pass | pass | vitest 990 (+5 skipped) / 63 files · node **609** · **99 Playwright** | pass |

`project-boundary.mjs` green: 5 projects, 491 source files, 2151 module references, 3 constrained production Vite builds.
- `wallet/zuuli/scripts/project-boundary.mjs`: **green** across 5 projects, 500 source files, 2175 module references and 3 constrained Vite builds.
- **Rust: nothing run, because nothing Rust changed.**

The real-browser proof matters here more than usual. jsdom does not raise `unhandledrejection` for an actually-rejected promise, so vitest can only dispatch a synthetic event — which proves the listener is wired, not that the engine ever calls it. #973 shipped precisely because every test passed against a mocked bridge. `tests/diagnostics.pw.ts` therefore does the real thing: `void Promise.reject(...)` in a live page, then asserts the message is on screen, survives a reload, and that no request left the origin.

## Where I think the brief is wrong

Only on sequencing, and it is the Rust point above: "a `set_hook` that records panics to the same store" presumes a channel from the native side to the renderer that free2z structurally must not have. That is worth deciding on its own rather than inside this change.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
