### PR TITLE
fix(e2e2z): select uses-permission by xpath, not a name-prefix grep

### DIFF
--- a/.github/workflows/e2e2z-release.yml
+++ b/.github/workflows/e2e2z-release.yml
@@ -521,9 +521,16 @@ jobs:
           # e2e2z's only declared permission; androidx.core injects a
           # signature-level self-permission of its own, which is the only other
           # entry that may appear.
-          manifest_permissions=$(java -jar "$bundletool" dump manifest --bundle="$aab" |
-            grep -o 'android:name="[^"]*"' | sed -n 's/.*"\(.*\)"/\1/p' |
-            grep -E '^(android\.permission\.|cash\.free2z\.e2e2z\.)' | LC_ALL=C sort -u | paste -sd, -)
+          #
+          # Selected by xpath (structural: only <uses-permission> elements)
+          # rather than by grepping every android:name in the dump and
+          # filtering by string prefix — that prefix filter also matches
+          # component names Tauri emits under the same application-id prefix
+          # (e.g. the cash.free2z.e2e2z.MainActivity activity), which fails
+          # this assertion on a manifest that is entirely correct (#964).
+          # free2z-release.yml established this xpath form (#963).
+          manifest_permissions=$(java -jar "$bundletool" dump manifest --bundle="$aab" \
+            --xpath=/manifest/uses-permission/@android:name | LC_ALL=C sort -u | paste -sd, -)
           test "$manifest_permissions" = "android.permission.INTERNET,cash.free2z.e2e2z.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"
           actual_abis=$(unzip -Z1 "$aab" | awk -F/ '$2 == "lib" && NF >= 4 && $NF ~ /\.so$/ {print $3}' | LC_ALL=C sort -u | paste -sd, -)
           test "$actual_abis" = arm64-v8a,armeabi-v7a,x86,x86_64


### PR DESCRIPTION
## Summary

Fixes #964. `e2e2z-release.yml`'s manifest permission assertion
(`.github/workflows/e2e2z-release.yml:524-527`) grepped **every**
`android:name` attribute in the whole `bundletool dump manifest` output and
filtered by string prefix (`^(android\.permission\.|cash\.free2z\.e2e2z\.)`).
Tauri emits the app's activity as `cash.free2z.e2e2z.MainActivity`, which
matches the second prefix alternative alongside the injected
`DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` self-permission — so the equality
test fails on a manifest that is entirely correct. This is latent today only
because e2e2z's Android release lane has never actually run (TestFlight-only
so far); it would fail the first real Android release, and the failure reads
as a permission-boundary violation rather than what it is.

## Fix

Select `uses-permission` structurally instead of by string prefix, using
`bundletool`'s xpath support — the exact form `wallet/free2z`'s release
workflow already uses (#963):

```
--xpath=/manifest/uses-permission/@android:name
```

```bash
manifest_permissions=$(java -jar "$bundletool" dump manifest --bundle="$aab" \
  --xpath=/manifest/uses-permission/@android:name | LC_ALL=C sort -u | paste -sd, -)
test "$manifest_permissions" = "android.permission.INTERNET,cash.free2z.e2e2z.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"
```

This is scoped to the `<uses-permission>` element by construction, so it
cannot collide with any component name that happens to share the
application-id prefix. The prefix filter is no longer needed and is removed.

## ZUULI audit (also in scope per #964)

`zuuli-release.yml`'s equivalent assertion (`.github/workflows/zuuli-release.yml:451-458`)
uses a *different*-looking but **not vulnerable** approach: it first splits
the raw dump on `<` (`tr '<' '\n'`), then keeps only lines that literally
begin with `uses-permission` (`grep -a '^uses-permission'`), and only *then*
extracts `android:name` from what's left. Because each XML tag becomes its
own line after that split, an `<activity android:name="cash.free2z.zuuli.MainActivity">`
line begins with `activity`, never `uses-permission`, so it can never enter
the candidate set in the first place. This is already element-scoped — just
implemented with `tr`/`grep` instead of bundletool's xpath — so it doesn't
share e2e2z's defect and is **left unchanged**. Verified this by running
ZUULI's exact extraction logic (see below) against the same MainActivity-bearing
manifest used to reproduce the e2e2z bug: it correctly excludes the activity.

## Proof

Built a real, minimal AAB with the actual toolchain (`aapt2` compiling a
manifest to proto format, `bundletool build-bundle`, `bundletool dump manifest`
— same `bundletool-all-1.18.3.jar` this workflow pins, sha256 verified) whose
manifest declares:
- `android.permission.INTERNET`
- the injected `cash.free2z.e2e2z.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` self-permission
- an activity named `cash.free2z.e2e2z.MainActivity` (sharing the application-id prefix)

Running the **old** logic verbatim against that real AAB:
```
computed: android.permission.INTERNET,cash.free2z.e2e2z.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION,cash.free2z.e2e2z.MainActivity
OLD: FAIL
```

Running the **new** xpath form against the same AAB:
```
computed: android.permission.INTERNET,cash.free2z.e2e2z.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION
NEW: PASS
```

And ZUULI's tr/grep form against the same AAB (audit confirmation):
```
computed: android.permission.INTERNET,cash.free2z.e2e2z.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION
PASS — correctly excludes MainActivity, not vulnerable
```

## Verification

- `bash -n` on the extracted `run:` block: OK
- `actionlint .github/workflows/e2e2z-release.yml`: clean
- `node scripts/check-github-actions-pins.mjs`: passes (270 external refs, 22 files)
- `node scripts/check-workflow-gates.mjs`: passes (2 gates, 85 jobs, 21 workflow files)
- `node wallet/zuuli/scripts/apple-credential-boundary.mjs`: passes
- No `release.json` bump. `free2z-release.yml` untouched. Expected permission
  sets unchanged — only the selection mechanism changed.

## Test plan

- [ ] CI gate green on this PR
- [ ] Reviewer confirms the xpath form matches free2z-release.yml's precedent
- [ ] Reviewer confirms the zuuli-release.yml audit reasoning

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH