### PR TITLE
chore(e2e2z): bump release build 2 -> 3 to ship the skeleton fix

### DIFF
--- a/wallet/e2e2z/release.json
+++ b/wallet/e2e2z/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.e2e2z",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 2,
+  "build": 3,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.e2e2z"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "2").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "3").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist
+++ b/wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/wallet/e2e2z/src-tauri/gen/apple/project.yml
+++ b/wallet/e2e2z/src-tauri/gen/apple/project.yml
@@ -52,7 +52,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "2"
+        CFBundleVersion: "3"
     entitlements:
       path: e2e2z_iOS/e2e2z_iOS.entitlements
     scheme:

--- a/wallet/e2e2z/src-tauri/tauri.conf.json
+++ b/wallet/e2e2z/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "2",
+      "bundleVersion": "3",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 2
+      "versionCode": 3
     }
   },
   "plugins": {


### PR DESCRIPTION
## Why

e2e2z `0.1.0 (2)` is live on TestFlight and broken — it never leaves the loading skeleton on device (#973). The fix merged as #974: `get_device_info` fails 100% on e2e2z because only ZUULI's app crate installs a device identity, and the unhandled rejection left `status` null forever. Build 3 is how the fix reaches the tester.

## The change

`wallet/e2e2z/release.json`: `build` 2 → 3. `version` stays `0.1.0`.

Same five build-carrying surfaces `wallet/e2e2z/scripts/release-identity.mjs` asserts by name, matching the shape of #968 (e2e2z 1→2) and #976 (zuuli 20→21):

- `wallet/e2e2z/release.json`
- `wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts` (versionCode fallback)
- `wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist` (CFBundleVersion)
- `wallet/e2e2z/src-tauri/gen/apple/project.yml` (CFBundleVersion)
- `wallet/e2e2z/src-tauri/tauri.conf.json` (iOS bundleVersion + Android versionCode)

e2e2z has no `release-bump.mjs` of its own, so these were hand-edited to the values Tauri would emit, then verified against both generated-tree normalizers for zero churn.

## Verification (all run after the final edit)

- `node scripts/release-identity.mjs` — passes, reports `{"version":"0.1.0","build":3,"identity":"0.1.0+3","tag":"e2e2z-v0.1.0+3"}`
- `node scripts/normalize-generated-android-manifest.mjs` and `node scripts/normalize-generated-ios-project.mjs` — both ran clean, **zero churn** beyond the 5 intended files
- `npm test` in `wallet/e2e2z` — 228 vitest tests + 13 `node --test` assertions (including "release identity agrees across every file that restates it" and "the generated iOS project is canonical") + 5 Playwright specs, all green
- Grepped for a pinned `0.1.0+2` or `bundleVersion` literal across `.pw.ts` / test files — none found; e2e2z's specs read the identity dynamically (as #976 found for its adjacent specs)

## What merging triggers — expected and fine

`e2e2z-release.yml`'s push trigger fires on `wallet/e2e2z/release.json`, forcing `target=mobile, dry_run=false`. `prepare` then calls `store-identity.mjs --require=apple --require=android`, and `google.playConsoleListing` is still `"missing"`, so the run dies in the first job: nothing built, nothing uploaded, no identity consumed. This is #969 and is deliberate — not fixed by this PR. `ITSAppUsesNonExemptEncryption`/`iosUsesNonExemptEncryption`, `playConsoleListing`, and all workflows are untouched.

The real iOS TestFlight upload will be dispatched manually afterward.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH