### PR TITLE
fix(intent): preserve uncertainty for unfamiliar response statuses

### DIFF
--- a/docs/intent-bridge/CONFORMANCE.md
+++ b/docs/intent-bridge/CONFORMANCE.md
@@ -253,6 +253,7 @@ it work*, and the honest axis is **do we know what happened**:
 | `unsendable` | yes — nothing was encoded, the wallet was never asked |
 | `refused` + `INTENT_NOT_CONFIRMED` | yes — ZUULI returns it before `execute_send` |
 | `transport-failed` | **no** — the request may have arrived, the answer did not |
+| `unknown-status` | **no** — the response is well-formed but its meaning is unfamiliar |
 | `refused` + anything else | **no** |
 
 The sharpest case is `INTENT_UNAVAILABLE`: `intent.rs`'s `payment_outcome`
@@ -267,24 +268,21 @@ matters.
 `rs/crates/f2z-intent/src/error.rs` and `wallet/shared/src/intent/error.ts` —
 when it introduced the status. The two have never disagreed on `main`.
 
-The behaviour that makes it worth a test here is
-`IntentSession.accept`'s `intentErrorFromStatus(status) ?? Malformed`: a status
-this build does not know becomes `INTENT_MALFORMED`, which reads as "the
-wallet's answer was garbage" rather than "the wallet could not finish, go
-look". For a status that can mean *a transaction may exist*, those are the
-difference between reassuring a payer and sending them to their wallet. The
-mutation deletes status 12 from the client and reproduces exactly that reading:
+The client preserves unfamiliar well-formed statuses as `unknown-status`
+with the original uint16 value. It must not relabel them `INTENT_MALFORMED`,
+accept a payload, infer no effect, or leave the question available for replay.
+The normative caller rule is [PROTOCOL §6.2](./PROTOCOL.md#62-outcome-uncertainty-and-unfamiliar-statuses).
 
-```
-× carries INTENT_UNAVAILABLE through as itself, not as a decode failure
-  → expected { kind: 'refused', error: 1 } to deeply equal { kind: 'refused', error: undefined }
-```
-
-The test pins main's definition, not a local one — so it also fails if a future
-change drops a status the wallet still emits.
+| Required property | Consumer test | Conformance failure |
+|---|---|---|
+| Preserve an unknown status and consume the question once | ZUULI `intent-bridge.test.ts`: `preserves unknown status %i and consumes the question exactly once` | Unknown status becomes malformed/success, or a replay becomes acceptable |
+| Keep decoding and correlation ahead of status handling | ZUULI `intent-bridge.test.ts`: `does not let unknown statuses bypass framing, correlation, family or expiry checks` | An unfamiliar status bypasses a response check |
+| Preserve payment uncertainty without a new payment | Free2Z `creator-tip.test.ts`: `preserves a well-formed unknown status without a txid or automatic retry` | A txid, decode-failure label, or second dispatch is fabricated |
+| Do not claim no funds moved on uncertain statuses | Free2Z `tip-copy.test.ts`: `is certain only where certainty is earned`, plus all shipped locale checks | `INTENT_UNAVAILABLE` or `unknown-status` receives no-effect copy |
+| Preserve enrollment uncertainty without a credential | E2E2Z `issueDeviceCredential.test.ts`: `surfaces an unknown status without claiming a decode failure or enrollment` | An unfamiliar status installs a credential, becomes malformed, or permits response replay |
 
 `features/creator/tip-copy.ts` is now the single exhaustive map, with a `never`
-binding so a sixth outcome cannot fall through, and
+binding so a new outcome cannot fall through, and
 `tip-copy.test.ts` asserts the honesty property against the **real shipped
 `en`/`es`/`fr` catalogs** through a real i18next instance — a reassuring
 sentence added to the wrong message by a later translation is exactly what a

--- a/docs/intent-bridge/PROTOCOL.md
+++ b/docs/intent-bridge/PROTOCOL.md
@@ -416,6 +416,49 @@ Two details of that caller are worth copying rather than reinventing:
   `decodeExecutePaymentResult`, which reads exactly 32 bytes and refuses
   anything else, because an app that has shown "sent" cannot unshow it.
 
+### 6.2 Outcome uncertainty and unfamiliar statuses
+
+`INTENT_UNAVAILABLE` MUST NOT be interpreted as a claim that the requested
+action had no effect. Callers MUST NOT describe it as “nothing happened”,
+“nothing was sent”, or “your funds are untouched”. In particular,
+`payment_outcome` returns it for `BroadcastStatus::Unknown`: a transaction
+exists locally and may have reached the network, but the wallet cannot
+establish acceptance. This is deliberately not a fulfilled payment response.
+
+Callers MUST distinguish what they know about this request:
+
+| Outcome | May the caller state that this request sent nothing? |
+|---|---|
+| No transport exists; dispatch never occurred | Yes |
+| Request could not be encoded; dispatch never occurred | Yes |
+| A validated, authenticated `INTENT_NOT_CONFIRMED` response | Yes: ZUULI returns it before `execute_send` |
+| `INTENT_UNAVAILABLE` | No: the action's effect is unknown |
+| Transport failure after dispatch, an invalid response, or local response expiry | No: failure to judge an answer proves nothing about the wallet's action |
+| A well-formed response with an unfamiliar status | No: the client cannot interpret the outcome |
+
+A caller receiving an uncertain payment outcome MUST direct the user to check
+the wallet's authoritative transaction state. It MUST NOT report success or
+no effect, and MUST NOT automatically create another payment attempt. A fresh
+request identifier satisfies the one-use rule; it does not establish that a
+second payment is safe. Recovery of a pending transaction belongs to the
+wallet's existing retry path, not a new caller-side payment.
+
+For a supported envelope version, a canonical response with an unfamiliar
+nonzero status and an empty payload is **unknown but well-formed**, not
+`INTENT_MALFORMED`. The client MUST preserve that distinction and the original
+uint16 status, without guessing the newer wallet's meaning. This rule applies
+when a later implementation introduces a status an older client does not
+recognize; it does not relax the unsupported-version or canonical-decoding
+gates. Family, request identifier and expiry checks still run first, and a
+correlated answer consumes the outstanding question even when its status is
+unfamiliar. A replay MUST remain unsolicited.
+
+`IntentSession.accept` exposes this as
+`{ ok: false, error: "unknown-status", status }`, a client-only outcome rather
+than a newly allocated wire refusal code. Free2Z preserves it through its tip
+result and maps it to uncertain copy; E2E2Z raises `IntentStatusUnknownError`
+and does not install a credential or infer enrollment.
+
 ## 7. What is blocked on #461
 
 Everything above is correct regardless of how the bytes travel. Nothing above is

--- a/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.test.ts
+++ b/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.test.ts
@@ -33,6 +33,7 @@ import {
   E2E2Z_CALLER,
   ISSUE_DEVICE_CREDENTIAL_PURPOSE,
   IntentRefusedError,
+  IntentStatusUnknownError,
   REQUEST_LIFETIME_MS,
   createDeviceCredentialClient,
   isIntentRefused,
@@ -431,13 +432,21 @@ describe("a response is judged as if the responder were hostile", () => {
     );
   });
 
-  it("refuses an unknown refusal status rather than guessing", async () => {
-    const transport = walletStandIn((requestId) =>
-      responseBytes({ requestId, status: 4242, payload: new Uint8Array(0) }),
-    );
-    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
-      IntentErrorCode.Malformed,
-    );
+  it("surfaces an unknown status without claiming a decode failure or enrollment", async () => {
+    let first: Uint8Array | null = null;
+    const transport = walletStandIn((requestId) => {
+      first ??= responseBytes({ requestId, status: 4242, payload: new Uint8Array(0) });
+      return first;
+    });
+    const client = clientWith(transport);
+    const result = await client.requestDeviceCredential("alice").catch((error: unknown) => error);
+    expect(result).toBeInstanceOf(IntentStatusUnknownError);
+    expect(result).toMatchObject({ reason: "intent-status-unknown", status: 4242 });
+    expect(isIntentRefused(result)).toBe(false);
+    expect(result).not.toHaveProperty("code");
+    expect(client.pending).toBe(0);
+    // Replaying the unfamiliar answer cannot install a credential on a new request.
+    expect(await refusalCode(client.requestDeviceCredential("alice"))).toBe(IntentErrorCode.Unsolicited);
   });
 
   it("refuses a replay of an answer it already accepted", async () => {

--- a/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts
+++ b/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts
@@ -53,7 +53,7 @@ import {
   intentFamilyName,
   newRequestId,
   toHex,
-  type IntentOutcome,
+  type IntentSessionOutcome,
   type IntentSession,
 } from "@free2z/wallet-shared";
 import {
@@ -135,6 +135,18 @@ export class IntentRefusedError extends Error {
   }
 }
 
+/** A well-formed wallet response, but neither enrollment success nor no effect. */
+export class IntentStatusUnknownError extends Error {
+  readonly reason = "intent-status-unknown" as const;
+
+  constructor(readonly status: number) {
+    super(
+      "The wallet returned an unrecognized status; the action's outcome is unknown.",
+    );
+    this.name = "IntentStatusUnknownError";
+  }
+}
+
 /** Whether a caught value is an {@link IntentRefusedError}, prototype or not. */
 export function isIntentRefused(error: unknown): error is IntentRefusedError {
   return (
@@ -147,10 +159,15 @@ export function isIntentRefused(error: unknown): error is IntentRefusedError {
 
 /** Unwrap an outcome, or throw the refusal it carries. */
 function orRefuse<T>(
-  outcome: IntentOutcome<T>,
+  outcome: IntentSessionOutcome<T>,
   stage: "request" | "response",
 ): T {
-  if (!outcome.ok) throw new IntentRefusedError(stage, outcome.error);
+  if (!outcome.ok) {
+    if (outcome.error === "unknown-status") {
+      throw new IntentStatusUnknownError(outcome.status);
+    }
+    throw new IntentRefusedError(stage, outcome.error);
+  }
   return outcome.value;
 }
 
@@ -177,6 +194,7 @@ export interface DeviceCredentialClient {
    *
    * @throws {@link IntentTransportUnavailableError} in every shipping build.
    * @throws {@link IntentRefusedError} when the protocol refuses either half.
+   * @throws {@link IntentStatusUnknownError} for an unfamiliar response status.
    * @throws `DeviceKeysUnavailableError` when this device's keys are unusable.
    */
   requestDeviceCredential(handle: string): Promise<Uint8Array>;

--- a/wallet/free2z/src/features/creator/tip-copy.test.ts
+++ b/wallet/free2z/src/features/creator/tip-copy.test.ts
@@ -29,6 +29,7 @@ const OUTCOMES: ReadonlyArray<readonly [string, CreatorTipOutcome]> = [
   ["no-transport", { kind: "no-transport", reason: "no verified link (#461)" }],
   ["unsendable", { kind: "unsendable", error: IntentErrorCode.InvalidValue }],
   ["transport-failed", { kind: "transport-failed", detail: "TypeError" }],
+  ["unknown-status", { kind: "unknown-status", status: 4242 }],
   [
     "refused/NotConfirmed",
     { kind: "refused", error: IntentErrorCode.NotConfirmed },

--- a/wallet/free2z/src/features/creator/tip-copy.ts
+++ b/wallet/free2z/src/features/creator/tip-copy.ts
@@ -120,6 +120,10 @@ export function creatorTipCopy(outcome: CreatorTipOutcome): CreatorTipCopy {
       // A channel existed and threw. The request may have arrived; the answer
       // did not. We do not know.
       return INDETERMINATE;
+    case "unknown-status":
+      // A newer wallet may know this status. It proves neither success nor
+      // that nothing happened; use the existing check-your-wallet guidance.
+      return INDETERMINATE;
     case "refused":
       // `NotConfirmed` is the only refusal this client can read as "the wallet
       // did not act": ZUULI returns it before `execute_send` is ever reached.

--- a/wallet/free2z/src/lib/bridge/creator-tip.test.ts
+++ b/wallet/free2z/src/lib/bridge/creator-tip.test.ts
@@ -607,6 +607,17 @@ describe("a response is accepted only when it answers this exact request", () =>
     });
   });
 
+  it("preserves a well-formed unknown status without a txid or automatic retry", async () => {
+    const transport = replyingTransport((request) => responseBytes({
+      requestId: requestIdOf(request), status: 4242, payload: new Uint8Array(0),
+    }));
+    const outcome = await tip(100_000, transport);
+    expect(outcome).toEqual({ kind: "unknown-status", status: 4242 });
+    expect(outcome).not.toHaveProperty("txid");
+    expect(transport.sent).toHaveLength(1);
+    if (outcome.kind === "unknown-status") expect(creatorTipFailureName(outcome)).toBe("INTENT_UNKNOWN_STATUS_4242");
+  });
+
   it("never reads a refusal as a success", async () => {
     const outcome = await tip(
       100_000,

--- a/wallet/free2z/src/lib/bridge/creator-tip.ts
+++ b/wallet/free2z/src/lib/bridge/creator-tip.ts
@@ -40,7 +40,7 @@
  * 3. **Report a payment it cannot prove.** A txid is returned only when the
  *    response decoded, correlated to *this* request, named this family, arrived
  *    inside the window, carried status 0, and held exactly 32 bytes. Anything
- *    else is a refusal with a code, and the refusal is what the UI renders.
+ *    else is a non-success outcome, with uncertainty preserved for the UI.
  *
  * ## What the correlation proves, and what it does not
  *
@@ -193,7 +193,7 @@ export function creatorTipPurpose(username: string): string {
   return `Tip ${username} on free2z`;
 }
 
-/** Why a tip request could not be completed, and nothing was sent. */
+/** Why a tip could not be confirmed here. A transaction may still exist. */
 export type CreatorTipFailure =
   /** This app could not build a sendable request. Nothing left the process. */
   | { readonly kind: "unsendable"; readonly error: IntentErrorCode }
@@ -201,6 +201,8 @@ export type CreatorTipFailure =
   | { readonly kind: "no-transport"; readonly reason: string }
   /** A channel existed and failed. No response was judged. */
   | { readonly kind: "transport-failed"; readonly detail: string }
+  /** A well-formed answer this build cannot interpret. Effects are unknown. */
+  | { readonly kind: "unknown-status"; readonly status: number }
   /** An answer arrived and was refused: unsolicited, malformed, or a "no". */
   | { readonly kind: "refused"; readonly error: IntentErrorCode };
 
@@ -219,7 +221,9 @@ export function creatorTipFailureName(failure: CreatorTipFailure): string {
     ? "INTENT_TRANSPORT_UNAVAILABLE"
     : failure.kind === "transport-failed"
       ? "INTENT_TRANSPORT_FAILED"
-      : intentErrorName(failure.error);
+      : failure.kind === "unknown-status"
+        ? `INTENT_UNKNOWN_STATUS_${failure.status}`
+        : intentErrorName(failure.error);
 }
 
 /**
@@ -267,9 +271,8 @@ function creatorTipRequest(
  *
  * The source is validated by {@link recordCreatorTipIntent} first, so this
  * throws exactly what that throws for a creator with no usable address; every
- * *other* failure is a returned {@link CreatorTipFailure}, because "nothing was
- * sent, and here is why" is information the payer needs rather than an
- * exception the UI has to interpret.
+ * *other* failure is a returned {@link CreatorTipFailure}, so the UI can
+ * distinguish a request that never left from an uncertain payment outcome.
  *
  * ## One question per exchange
  *
@@ -364,7 +367,11 @@ export async function requestCreatorTipPayment(
   // makes the expiry path drivable — a test issues in the past and lets the
   // real clock close the window.
   const accepted = session.accept(answer, Date.now());
-  if (!accepted.ok) return { kind: "refused", error: accepted.error };
+  if (!accepted.ok) {
+    return accepted.error === "unknown-status"
+      ? { kind: "unknown-status", status: accepted.status }
+      : { kind: "refused", error: accepted.error };
+  }
   if (accepted.value.intent !== IntentFamily.ExecutePayment) {
     return { kind: "refused", error: IntentErrorCode.UnknownIntent };
   }

--- a/wallet/shared/src/intent/error.ts
+++ b/wallet/shared/src/intent/error.ts
@@ -41,9 +41,10 @@ export const IntentErrorCode = {
   /** A response to a question this client never asked. */
   Unsolicited: 11,
   /**
-   * The wallet understood the request but could not act on it: no wallet
-   * open, the payment cannot be funded, the network is unreachable, or a
-   * broadcast did not complete.
+   * The wallet could not establish completion: no wallet open, an unfunded
+   * payment, an unreachable network, or an ambiguous broadcast. This carries
+   * no claim that the action had no effect: BroadcastStatus::Unknown may mean
+   * a transaction reached the network. Callers must surface uncertainty.
    *
    * Deliberately distinct from {@link IntentErrorCode.InvalidValue}: a
    * request the wallet cannot fund is not a malformed request, and a caller

--- a/wallet/shared/src/intent/index.ts
+++ b/wallet/shared/src/intent/index.ts
@@ -50,4 +50,4 @@ export {
   MAX_PENDING_INTENTS,
   createIntentSession,
 } from "./session";
-export type { AcceptedIntentResponse, IntentSession } from "./session";
+export type { AcceptedIntentResponse, IntentSession, IntentSessionOutcome } from "./session";

--- a/wallet/shared/src/intent/session.ts
+++ b/wallet/shared/src/intent/session.ts
@@ -59,6 +59,14 @@ export interface AcceptedIntentResponse {
   readonly payload: Uint8Array;
 }
 
+/** A correlated, well-formed answer whose effect this client cannot interpret. */
+export type IntentSessionOutcome<T> = IntentOutcome<T> | {
+  readonly ok: false;
+  readonly error: "unknown-status";
+  /** Original uint16 wire status; not a newly assigned protocol error code. */
+  readonly status: number;
+};
+
 interface Pending {
   readonly requestId: Uint8Array;
   readonly intent: IntentFamily;
@@ -73,7 +81,7 @@ export interface IntentSession {
   accept(
     bytes: Uint8Array,
     nowMs: number,
-  ): IntentOutcome<AcceptedIntentResponse>;
+  ): IntentSessionOutcome<AcceptedIntentResponse>;
   /** How many questions are outstanding. */
   readonly size: number;
 }
@@ -130,7 +138,7 @@ export function createIntentSession(
     accept(
       bytes: Uint8Array,
       nowMs: number,
-    ): IntentOutcome<AcceptedIntentResponse> {
+    ): IntentSessionOutcome<AcceptedIntentResponse> {
       const decoded = decodeIntentResponse(bytes);
       if (!decoded.ok) return decoded;
       const response = decoded.value;
@@ -152,11 +160,13 @@ export function createIntentSession(
         return { ok: false, error: IntentErrorCode.Expired };
       }
       if (response.status !== 0) {
-        return {
-          ok: false,
-          error:
-            intentErrorFromStatus(response.status) ?? IntentErrorCode.Malformed,
-        };
+        const error = intentErrorFromStatus(response.status);
+        // Preserve forward-compatible uncertainty. The question has already
+        // been consumed; an unfamiliar status cannot authorize a replay or
+        // establish that the wallet did nothing.
+        return error === null
+          ? { ok: false, error: "unknown-status", status: response.status }
+          : { ok: false, error };
       }
       return {
         ok: true,

--- a/wallet/zuuli/src/lib/intent-bridge.test.ts
+++ b/wallet/zuuli/src/lib/intent-bridge.test.ts
@@ -40,7 +40,7 @@ import {
   parseVisibleText,
   toHex,
 } from "@free2z/wallet-shared";
-import type { IntentOutcome, IntentRequest } from "@free2z/wallet-shared";
+import type { IntentSessionOutcome, IntentRequest } from "@free2z/wallet-shared";
 
 /**
  * The canonical fixture, byte for byte.
@@ -85,15 +85,16 @@ const ISSUED_AT_MS = 1_700_000_000_000;
 const EXPIRES_AT_MS = ISSUED_AT_MS + 60_000;
 const REQUEST_ID = new Uint8Array(32).fill(0x77);
 
-function unwrap<T>(outcome: IntentOutcome<T>): T {
+function unwrap<T>(outcome: IntentSessionOutcome<T>): T {
   if (!outcome.ok) {
     throw new Error(`expected success, got status ${outcome.error}`);
   }
   return outcome.value;
 }
 
-function refusal<T>(outcome: IntentOutcome<T>): IntentErrorCode {
+function refusal<T>(outcome: IntentSessionOutcome<T>): IntentErrorCode {
   if (outcome.ok) throw new Error("expected a refusal, got success");
+  if (outcome.error === "unknown-status") throw new Error("expected a known refusal");
   return outcome.error;
 }
 
@@ -417,7 +418,7 @@ describe("the session refuses answers to questions it did not ask", () => {
     );
   });
 
-  it("reports the wallet's refusal as that refusal, and an unknown one as malformed", () => {
+  it("reports the wallet's known refusal as that refusal", () => {
     const session = createIntentSession();
     unwrap(session.issue(canonicalRequest(), ISSUED_AT_MS));
     expect(
@@ -432,16 +433,30 @@ describe("the session refuses answers to questions it did not ask", () => {
       ),
     ).toBe(IntentErrorCode.CallerNotAuthorized);
 
-    const second = createIntentSession();
-    unwrap(second.issue(canonicalRequest(), ISSUED_AT_MS));
-    expect(
-      refusal(
-        second.accept(
-          response({ status: 60_000, payload: new Uint8Array(0) }),
-          ISSUED_AT_MS,
-        ),
-      ),
-    ).toBe(IntentErrorCode.Malformed);
+  });
+
+  it.each([13, 4242, 60_000, 65_535])("preserves unknown status %i and consumes the question exactly once", (status) => {
+    const session = createIntentSession();
+    unwrap(session.issue(canonicalRequest(), ISSUED_AT_MS));
+    const reply = response({ status, payload: new Uint8Array(0) });
+    expect(session.accept(reply, ISSUED_AT_MS)).toEqual({ ok: false, error: "unknown-status", status });
+    expect(session.size).toBe(0);
+    expect(refusal(session.accept(reply, ISSUED_AT_MS))).toBe(IntentErrorCode.Unsolicited);
+    expect(refusal(session.accept(response({}), ISSUED_AT_MS))).toBe(IntentErrorCode.Unsolicited);
+  });
+
+  it("does not let unknown statuses bypass framing, correlation, family or expiry checks", () => {
+    for (const [options, time, expected] of [
+      [{ payload: new Uint8Array([1]) }, ISSUED_AT_MS, IntentErrorCode.Malformed],
+      [{ requestId: new Uint8Array(32) }, ISSUED_AT_MS, IntentErrorCode.Unsolicited],
+      [{ intent: IntentFamily.ExecutePayment }, ISSUED_AT_MS, IntentErrorCode.Unsolicited],
+      [{}, EXPIRES_AT_MS, IntentErrorCode.Expired],
+    ] as const) {
+      const session = createIntentSession();
+      unwrap(session.issue(canonicalRequest(), ISSUED_AT_MS));
+      const reply = response({ status: 4242, ...options, payload: "payload" in options ? options.payload : new Uint8Array(0) });
+      expect(refusal(session.accept(reply, time))).toBe(expected);
+    }
   });
 
   it("fails closed when full instead of evicting the record it needs", () => {


### PR DESCRIPTION
A well-formed intent response carrying an unfamiliar status was reported as `INTENT_MALFORMED`, hiding the difference between a decoding failure and an outcome this client cannot interpret. The shared session now preserves the original uint16 in a client-only `unknown-status` outcome, after canonical decoding, correlation, family and expiry checks; the outstanding question is consumed exactly once.

Free2Z carries the outcome to its existing uncertain-payment copy without a txid or automatic retry. E2E2Z exposes a distinct typed error without returning a credential or claiming enrollment. The protocol and conformance table now require uncertainty for `INTENT_UNAVAILABLE` (including `BroadcastStatus::Unknown`), unfamiliar statuses and failures after dispatch, and distinguish the cases where no dispatch occurred. Wire statuses, native payment authority and transport availability remain unchanged.

Closes #930, including its forward-compatibility and consumer-test follow-ups.

Validation:

- ZUULI shared intent suite: 33 tests and full test typecheck passed. Statuses 13, 4242, 60000 and 65535 preserve uncertainty and reject replay; malformed payloads, wrong identifiers/families and expired responses still fail their original checks.
- Free2Z full `verify`: typechecks, 929 unit tests (5 skipped), 13 source checks and 93 Playwright tests passed. Existing known-`INTENT_UNAVAILABLE` coverage remains intact; shipped en/es/fr copy checks include the new outcome.
- E2E2Z full `verify`: typechecks, 273 unit tests, 13 source checks and 9 Playwright tests passed.
- Restoring the old unknown→Malformed fallback in each isolated installed shared package made 4 ZUULI, 1 Free2Z and 1 E2E2Z regressions fail; exact sources restored afterward.
- Shared-project boundary audit, Markdown links, public-boundary guard and `git diff --check` passed.
