### PR TITLE
fix(free2z): patch xmldom security advisories in both apps

### DIFF
--- a/ts/react/free2z/package-lock.json
+++ b/ts/react/free2z/package-lock.json
@@ -6868,10 +6868,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
-      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
-      "license": "MIT",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "engines": {
         "node": ">=14.6"
       }

--- a/ts/react/free2z/package.json
+++ b/ts/react/free2z/package.json
@@ -132,5 +132,10 @@
     "acorn": "^8.15.0",
     "prettier": "2.6.2",
     "react-app-rewired": "^2.2.1"
+  },
+  "overrides": {
+    "speech-rule-engine": {
+      "@xmldom/xmldom": "0.9.12"
+    }
   }
 }

--- a/wallet/free2z/package-lock.json
+++ b/wallet/free2z/package-lock.json
@@ -3270,11 +3270,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "deprecated": "this version has critical issues, please update to the latest version",
-      "license": "MIT",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "engines": {
         "node": ">=14.6"
       }

--- a/wallet/free2z/package.json
+++ b/wallet/free2z/package.json
@@ -78,5 +78,10 @@
     "typescript": "^5.6.0",
     "vite": "^6.4.3",
     "vitest": "3.2.7"
+  },
+  "overrides": {
+    "speech-rule-engine": {
+      "@xmldom/xmldom": "0.9.12"
+    }
   }
 }


### PR DESCRIPTION
Free2Z CI now rejects the transitive xmldom parser on high-severity advisories. Both current and legacy Free2Z resolve `@xmldom/xmldom` 0.9.12 through a narrowly scoped `speech-rule-engine` override; their existing stable speech engine versions and all other dependency entries remain unchanged. Stable speech-rule-engine 4.1.4 still pins the vulnerable parser, so a lock-only update would not survive installation.

Closes #998.

Upstream: [high-severity amplification advisory](https://github.com/xmldom/xmldom/security/advisories/GHSA-6mj3-qw4j-hgrw), [serialization advisory](https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6), [0.9.12 release](https://github.com/xmldom/xmldom/releases/tag/0.9.12). ZUULI, E2E2Z and zuuallet locks do not contain this dependency. No application exploit has been demonstrated.

Validation:

- Separate clean `npm ci` installs in both affected applications, resolved parser 0.9.12.
- Current Free2Z audit: zero high/critical findings (seven existing moderate findings remain). Legacy audit no longer reports xmldom; unrelated legacy findings remain (13 low, 27 moderate, 37 high, 3 critical), so this does not claim a clean legacy audit.
- Existing Free2Z Markdown suites: 22 tests passed; production build passed. Both installed applications render an inline equation through their actual rehype-mathjax SVG pipeline.
- Upstream mixed-case HTML amplification regression passes with the patched parser in both installs. Negative control against the previous 0.9.10 install expands 1,826 input bytes to 93,763 output bytes and fails the same less-than-2x bound.
- Public-boundary guard and `git diff --check` passed.
