### PR TITLE
Cover all three app trees with existing code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,16 +5,8 @@
 /.github/workflows/ @skyl @azhrcs
 /.github/actions/ @skyl @azhrcs
 
-# Release identity, credential boundaries, packaging, and publication logic.
-/wallet/zuuli/release.json @skyl @azhrcs
-/wallet/zuuli/release.schema.json @skyl @azhrcs
-/wallet/zuuli/scripts/ @skyl @azhrcs
-
-# Native authority/signing configuration and checked-in platform projects.
-/wallet/zuuli/src-tauri/tauri.conf.json @skyl @azhrcs
-/wallet/zuuli/src-tauri/capabilities/ @skyl @azhrcs
-/wallet/zuuli/src-tauri/gen/apple/ @skyl @azhrcs
-/wallet/zuuli/src-tauri/gen/android/ @skyl @azhrcs
-
-# Store-facing metadata and listing media are part of the promoted release.
-/wallet/zuuli/store/ @skyl @azhrcs
+# All three apps: source, release identity, native authority/signing,
+# platform projects, packaging scripts, and store metadata/media.
+/wallet/zuuli/ @skyl @azhrcs
+/wallet/free2z/ @skyl @azhrcs
+/wallet/e2e2z/ @skyl @azhrcs


### PR DESCRIPTION
Closes #965

Changes anywhere in ZUULI, Free2Z or E2E2Z now request the existing code owners, including app source, native capabilities, platform projects, release scripts and store assets. The whole-app directory rules preserve the previously covered ZUULI paths and existing workflow/action ownership.

Validation: all 1,090 tracked app/workflow/action/ownership files resolve to `@skyl @azhrcs`; the previous rules miss 865 of those files, including Free2Z and E2E2Z. Public-boundary and whitespace checks pass.

## Codex adversarial review

Strict review at `4111676586697d355be4cb9db80317c4eedc2eca`, exit 0:

No significant findings.

The broader directory rules preserve every previously protected path and add coverage for all three apps. Owner identities remain unchanged.

CI does not validate live GitHub code-owner enforcement or reviewer permissions; those settings were not verified.

RISKIEST LINE: `.github/CODEOWNERS:10` — `/wallet/zuuli/ @skyl @azhrcs` replaces all granular Zuuli rules. A matching error here would remove owner coverage from signing and release configuration, but the directory rule correctly covers those paths.


### Current-main integration

Head `54e84900939e420cc6d688abfcf3e5f6a80b97d4` normally merges actual main `5910e782` after #996. The complete one-file CODEOWNERS PR delta is byte-identical to the independently reviewed version. Public-boundary and diff-whitespace checks pass; GitHub CODEOWNERS validation returns `errors: []` for the pushed branch. Fresh hosted QA is pending.
