### PR TITLE
ci: allow cold all-root clippy builds to finish

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -142,7 +142,7 @@ jobs:
   clippy:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    # #1001: a cold runner spent ~9m on setup and >36m compiling seven
+    # #1001: a cold runner spent ~9m on setup and ~36m compiling seven
     # independent wallet roots before the old 45m cap killed the final root.
     # Allow cold completion; keep the full discovered-root -D warnings verdict.
     timeout-minutes: 90

--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -142,7 +142,10 @@ jobs:
   clippy:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # #1001: a cold runner spent ~9m on setup and >36m compiling seven
+    # independent wallet roots before the old 45m cap killed the final root.
+    # Allow cold completion; keep the full discovered-root -D warnings verdict.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 


### PR DESCRIPTION
Closes #1001

The Zuuallet clippy job exhausted its 45-minute limit on a cold runner while compiling the final of seven discovered wallet roots. Raise only that job's finite timeout to 90 minutes so the unchanged all-root, locked-dependency, `-D warnings` check has room to finish.

[The failed job](https://github.com/free2z/zuu/actions/runs/34361774408/job/102500291357) spent about 9m23s on setup, reported a cache miss, then completed six roots before cancellation after roughly 36 minutes of compilation. The final ZUULI root was still compiling; no clippy diagnostic preceded cancellation. This does not prove 90 minutes sufficient until the cold hosted job completes. A stalled job may occupy a runner for 45 minutes longer.

Validation: Actions policy passed (273 external references across 22 files); public boundary guard passed; parsed YAML comparison proves the timeout is the only semantic change. Root discovery, toolchain/actions/cache, workflow triggers, required gates, native jobs and lint flags are unchanged.

Strict reviews (exit 0):

First review at `1d05e35b`:

```text
No significant findings.

The change doubles one CI job’s timeout from 45 to 90 minutes. Root discovery, locked dependencies, `-D warnings`, and failure propagation remain intact. A stalled job can occupy a runner and delay feedback for 45 additional minutes.

CI does not validate that a cold build finishes within 90 minutes; that requires an actual cold run, which I did not execute.

RISKIEST LINE: `.github/workflows/zuuallet.yml:148` — `timeout-minutes: 90`, because it doubles the time a stuck lint job can consume before cancellation.
```

Final review at `e298e37d` after correcting only the approximate duration comment:

```text
No significant findings.

The change doubles one Clippy job’s timeout from 45 to 90 minutes. Manifest discovery, pinned toolchain, `--locked`, and `-D warnings` remain intact. CI does not validate that 90 minutes is sufficient for a cold build; that requires an observed run.

RISKIEST LINE: `.github/workflows/zuuallet.yml:148` — `timeout-minutes: 90`. A stalled job can now occupy a runner and delay failure feedback for an additional 45 minutes.
```
