### PR TITLE
docs(ci): record rs policy timings and budget decision

### DIFF
--- a/docs/ci/RS-POLICY-RUNTIME.md
+++ b/docs/ci/RS-POLICY-RUNTIME.md
@@ -1,0 +1,87 @@
+# `rs / changes` runtime observations
+
+Measured on 2026-09-09 for [#939](https://github.com/free2z/zuu/issues/939).
+The required job in [`rs.yml`](../../.github/workflows/rs.yml) has a **300-second
+budget**. Retain that budget and every unconditional policy/self-test command:
+four recent hosted jobs took **128–174 seconds**, or **43–58%** of the budget.
+These are observations, not a worst-case bound or a promise about future runners.
+
+## Hosted evidence
+
+GitHub's job and step timestamps have one-second resolution; a reported zero
+means below that resolution. Job duration includes setup and checkout, so it
+need not equal the sum of policy steps. Each policy row combines its self-test
+and live check; signing combines its self-test and Node test suite.
+
+| Step (seconds) | Main | App PR | Ownership PR | Budget PR |
+| --- | ---: | ---: | ---: | ---: |
+| Action pins / fail-closed jobs | 43 | 41 | 61 | 40 |
+| Gate wiring | 0 | 1 | 0 | 0 |
+| Hash-domain labels | 1 | 0 | 1 | 0 |
+| Markdown links | 0 | 0 | 0 | 1 |
+| Server image policy | 0 | 1 | 1 | 0 |
+| Apple signing controls | 2 | 3 | 23 | 3 |
+| Rust toolchain pin / census | 70 | 93 | 76 | 90 |
+| **Complete job** | **128** | **148** | **174** | **144** |
+
+Exact jobs and source heads:
+
+- [Main job](https://github.com/free2z/zuu/actions/runs/34361718293/job/102500095136), `882cdef492bee3a5b60ec1b10f179b5f1a41cace`.
+- [App PR job](https://github.com/free2z/zuu/actions/runs/34361774407/job/102500291876), `20fe9628b966c0851fa34f1cae51c60ec282e77c`.
+- [Ownership PR job](https://github.com/free2z/zuu/actions/runs/34361957881/job/102500917251), `4111676586697d355be4cb9db80317c4eedc2eca`.
+- [Budget PR job](https://github.com/free2z/zuu/actions/runs/34367512931/job/102519953363), `e298e37dff481fa781d8260511640bf06308ea6b`.
+
+## Decision and follow-up
+
+The toolchain and action-policy steps account for most of the observed time.
+That does not establish that any of their work is redundant. Do not remove a
+mutation control, cache a verdict across different source inputs, or filter a
+policy by the paths it is supposed to audit.
+
+Keep the existing serial execution and five-minute timeout. Splitting or
+parallelizing the job would add orchestration and gate-contract changes without
+an observed timeout in this sample. Raising the timeout is unnecessary on this
+evidence. No job, path selector, command order, policy pin, or mutation control
+changes with this record.
+
+Use **210 seconds (70%)** as an observation trigger: when a completed job reaches
+that duration, record its per-step times and compare a few adjacent runs before
+choosing a focused optimization or budget change. This is a review convention,
+not an automated monitor. A new timing failure gate was considered and deferred:
+runner and certificate-generation variation would make wall time an additional
+source of merge failures, while the existing 300-second timeout already bounds
+the job. A timeout or repeated growth warrants investigation immediately.
+
+## Reproduce hosted measurements
+
+This reads GitHub metadata only; it does not rerun CI or execute PR code.
+Set `run_id` to an `rs` workflow run and retain the exact source SHA with the
+result. `gh`, Python 3, and repository read access are required.
+
+```bash
+run_id=34361718293
+timing_file="$(mktemp "${TMPDIR:-/tmp}/rs-policy-job.XXXXXX")"
+gh api "repos/free2z/zuu/actions/runs/$run_id" --jq .head_sha
+gh api --paginate "repos/free2z/zuu/actions/runs/$run_id/jobs?per_page=100" \
+  --jq '.jobs[] | select(.name == "rs / changes")' > "$timing_file"
+python3 - "$timing_file" <<'PY'
+import datetime
+import json
+import sys
+from pathlib import Path
+
+job = json.loads(Path(sys.argv[1]).read_text())
+def elapsed(item):
+    if not item.get('completed_at'):
+        raise SystemExit('Wait for a completed job before measuring it.')
+    start = datetime.datetime.fromisoformat(item['started_at'].replace('Z', '+00:00'))
+    end = datetime.datetime.fromisoformat(item['completed_at'].replace('Z', '+00:00'))
+    return (end - start).total_seconds()
+
+print(job['html_url'], job['conclusion'])
+print(f"job: {elapsed(job):.0f}s")
+for step in job['steps']:
+    print(f"{elapsed(step):.0f}s\t{step['conclusion']}\t{step['name']}")
+PY
+rm "$timing_file"
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -109,6 +109,9 @@ of them.
 | `wallet-surfaces.yml` | no | `cargo build --all-targets` and `cargo test` of the free2z and e2e2z backends. Their frontend suites moved into `zuuli.yml`'s gated `surfaces` job in #915 |
 | `zuuallet.yml` | no | Zuuallet frontend + backend, and the weekly `upstream-canary` against latest librustzcash `main` |
 
+The [rs policy runtime record](ci/RS-POLICY-RUNTIME.md) contains per-step
+measurements, the five-minute budget decision, and the read-only refresh command.
+
 Two consequences worth internalising:
 
 - **The delegated surfaces are gated by `zuuli.yml`, not by their own


### PR DESCRIPTION
Closes #939.

Four recent hosted `rs / changes` jobs took 128–174 seconds against the 300-second limit. Record every policy-step duration with exact public job/source links and a tested read-only refresh command. Retain all unconditional checks, mutation controls, command ordering, and the timeout; document 210 seconds (70%) as a follow-up observation trigger and why a timing failure gate is deferred.

Validation: extracted documentation command reproduced the 128-second main job; Markdown links passed (947 links/122 documents), public boundary passed. Root independently reviewed the complete document and hosted evidence. The strict reviewer could not access GitHub; its limitation is recorded verbatim below. Four samples do not establish a worst-case bound.

Normal integration of merged #1002 changes only the Zuuallet clippy timeout; the complete documentation PR diff remains byte-identical to the reviewed abee84cb diff.

## Codex adversarial review

No significant findings.

This is documentation only; the five-minute timeout, unconditional checks, and gate behavior remain unchanged. The percentages are correct, and the relative Markdown link check passes.

CI does not validate the reported hosted timings or execute the measurement snippet. I could not independently verify the timings because GitHub access failed.

RISKIEST LINE: `docs/ci/RS-POLICY-RUNTIME.md:41` — retaining the five-minute timeout based on four runs. Slower runners could exhaust that budget and block merges, including urgent fixes; the document appropriately acknowledges that the sample is not a worst-case bound.



Current-main integration: normal merge of public main 1d6c86b4 after #997. The complete PR diff is byte-identical before/after integration; prior strict review still covers every changed line. Markdown validation passes (948 links, 122 docs) and the public boundary guard passes. Fresh hosted checks must pass at the updated head.
