### PR TITLE
fix(free2z): catch detached async failures at launch boundaries

### DIFF
--- a/wallet/free2z/src/App.bootstrap.test.tsx
+++ b/wallet/free2z/src/App.bootstrap.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+
+vi.mock("react-router-dom", async (original) => ({
+  ...await original<typeof import("react-router-dom")>(),
+  createBrowserRouter: vi.fn(() => ({})),
+  RouterProvider: () => <p>Session loading</p>,
+}));
+vi.mock("@/features/auth", () => ({ default: () => null }));
+vi.mock("@/components/layout/AppShell", () => ({ AppShell: () => null }));
+vi.mock("@/components/ui/sonner", () => ({ Toaster: () => null }));
+vi.mock("@/lib/auth/paid-intent", () => ({
+  discardPaidIntent: vi.fn(() => { throw new Error("local storage unavailable"); }),
+  discardPaidIntentForAccountTransition: vi.fn(),
+}));
+vi.mock("@/lib/api/http", async (original) => ({
+  ...await original<typeof import("@/lib/api/http")>(),
+  isAuthed: () => false,
+}));
+import App from "./App";
+import { useSession } from "@/store/session";
+import { discardPaidIntent } from "@/lib/auth/paid-intent";
+
+afterEach(() => { vi.clearAllMocks(); vi.unstubAllGlobals(); });
+
+it("shows a terminal fallback when session cleanup rejects before auth validation", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  useSession.setState({ loading: true, user: null, tuzis: 0 });
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  try {
+    await act(async () => { root.render(<App />); });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("Couldn’t restore your session");
+    expect(container.textContent).not.toContain("Session loading");
+    expect(container.textContent).toContain("Reload the app");
+    expect(useSession.getState().loading).toBe(true);
+    expect(discardPaidIntent).toHaveBeenCalledTimes(1);
+  } finally {
+    await act(async () => root.unmount());
+  }
+});

--- a/wallet/free2z/src/App.bootstrap.test.tsx
+++ b/wallet/free2z/src/App.bootstrap.test.tsx
@@ -20,21 +20,25 @@ vi.mock("@/lib/api/http", async (original) => ({
   isAuthed: () => false,
 }));
 import App from "./App";
+import { diagnostics } from "@/lib/diagnostics";
 import { useSession } from "@/store/session";
 import { discardPaidIntent } from "@/lib/auth/paid-intent";
 
-afterEach(() => { vi.clearAllMocks(); vi.unstubAllGlobals(); });
+afterEach(() => { vi.restoreAllMocks(); vi.clearAllMocks(); vi.unstubAllGlobals(); });
 
 it("shows a terminal fallback when session cleanup rejects before auth validation", async () => {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   useSession.setState({ loading: true, user: null, tuzis: 0 });
+  const record = vi.spyOn(diagnostics, "record");
   const container = document.createElement("div");
   const root = createRoot(container);
   try {
     await act(async () => { root.render(<App />); });
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain("Couldn’t restore your session");
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("Something went wrong");
     expect(container.textContent).not.toContain("Session loading");
-    expect(container.textContent).toContain("Reload the app");
+    expect(container.querySelector("button")?.textContent).toBe("Reload");
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record).toHaveBeenCalledWith("bootstrap-error", expect.objectContaining({ message: "local storage unavailable" }));
     expect(useSession.getState().loading).toBe(true);
     expect(discardPaidIntent).toHaveBeenCalledTimes(1);
   } finally {

--- a/wallet/free2z/src/App.tsx
+++ b/wallet/free2z/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import {
   createBrowserRouter,
   Navigate,
@@ -197,9 +197,25 @@ const appRouter = createBrowserRouter([{ path: "*", element: <AppRoutes /> }]);
 export default function App() {
   const bootstrapSession = useSession((s) => s.bootstrap);
 
+  const [bootstrapFailed, setBootstrapFailed] = useState(false);
   useEffect(() => {
-    void bootstrapSession();
+    let active = true;
+    void Promise.resolve().then(bootstrapSession).catch(() => {
+      if (active) setBootstrapFailed(true);
+    });
+    return () => { active = false; };
   }, [bootstrapSession]);
+
+  // An unvalidated session must not unlock OAuth recovery or authenticated
+  // routes. Show a terminal fallback without changing credentials or retrying.
+  if (bootstrapFailed) {
+    return (
+      <main role="alert" className="p-6">
+        <h1>Couldn’t restore your session</h1>
+        <p>Reload the app to try again.</p>
+      </main>
+    );
+  }
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/wallet/free2z/src/App.tsx
+++ b/wallet/free2z/src/App.tsx
@@ -1,3 +1,6 @@
+import { bootstrapReporter } from "@free2z/wallet-shared";
+import { diagnostics } from "@/lib/diagnostics";
+import { RootFallback } from "./app-bootstrap";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import {
   createBrowserRouter,
@@ -200,7 +203,8 @@ export default function App() {
   const [bootstrapFailed, setBootstrapFailed] = useState(false);
   useEffect(() => {
     let active = true;
-    void Promise.resolve().then(bootstrapSession).catch(() => {
+    void Promise.resolve().then(bootstrapSession).catch((error: unknown) => {
+      bootstrapReporter(diagnostics)("free2z session bootstrap failed", error);
       if (active) setBootstrapFailed(true);
     });
     return () => { active = false; };
@@ -209,12 +213,7 @@ export default function App() {
   // An unvalidated session must not unlock OAuth recovery or authenticated
   // routes. Show a terminal fallback without changing credentials or retrying.
   if (bootstrapFailed) {
-    return (
-      <main role="alert" className="p-6">
-        <h1>Couldn’t restore your session</h1>
-        <p>Reload the app to try again.</p>
-      </main>
-    );
+    return <RootFallback />;
   }
 
   return (

--- a/wallet/free2z/src/features/articles/components/Comments/index.tsx
+++ b/wallet/free2z/src/features/articles/components/Comments/index.tsx
@@ -31,29 +31,25 @@ export function CommentsSection({
 
   const load = useCallback(async () => {
     setStatus("loading");
-    try {
-      const acc: Comment[] = [];
-      let page: number | null = 1;
-      let total = 0;
-      while (page) {
-        const res = await commentsApi.list(contentType, uuid, {
-          rootsOnly: true,
-          page,
-        });
-        acc.push(...res.items);
-        total = res.count;
-        page = res.next;
-      }
-      setRoots(acc);
-      setCount(total);
-      setStatus("ready");
-    } catch {
-      setStatus("error");
+    const acc: Comment[] = [];
+    let page: number | null = 1;
+    let total = 0;
+    while (page) {
+      const res = await commentsApi.list(contentType, uuid, {
+        rootsOnly: true,
+        page,
+      });
+      acc.push(...res.items);
+      total = res.count;
+      page = res.next;
     }
+    setRoots(acc);
+    setCount(total);
+    setStatus("ready");
   }, [contentType, uuid]);
 
   useEffect(() => {
-    void load();
+    void load().catch(() => setStatus("error"));
   }, [load]);
 
   async function submitRoot(body: CommentInput) {

--- a/wallet/free2z/src/features/articles/components/Comments/loading.test.tsx
+++ b/wallet/free2z/src/features/articles/components/Comments/loading.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+vi.mock("@/lib/api/free2z", () => ({ comments: { list: vi.fn(), create: vi.fn() } }));
+vi.mock("./CommentForm", () => ({ CommentForm: () => null }));
+vi.mock("./CommentThread", () => ({ CommentThread: () => null }));
+import { comments } from "@/lib/api/free2z";
+import { CommentsSection } from "./index";
+
+it("settles the comments skeleton when a later pagination request rejects", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.mocked(comments.list)
+    .mockResolvedValueOnce({ items: [], count: 1, next: 2 })
+    .mockRejectedValueOnce(new Error("response decoder failed"));
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  try {
+    await act(async () => { root.render(<CommentsSection uuid="article-one" />); });
+    expect(container.textContent).toContain("Couldn’t load comments");
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+    expect(comments.list).toHaveBeenCalledTimes(2);
+    expect(comments.create).not.toHaveBeenCalled();
+  } finally {
+    await act(async () => root.unmount());
+  }
+});
+
+afterEach(() => vi.unstubAllGlobals());

--- a/wallet/free2z/src/features/creator/index.tsx
+++ b/wallet/free2z/src/features/creator/index.tsx
@@ -1,3 +1,4 @@
+import { useLiveGate } from "./useLiveGate";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -33,7 +34,7 @@ import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
 import { RemoteMedia } from "@/components/common/RemoteMedia";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
-import { discover, live, tuzi } from "@/lib/api/free2z";
+import { discover, tuzi } from "@/lib/api/free2z";
 import {
   formatTuzis,
   formatZecDisplay,
@@ -367,63 +368,6 @@ function CreatorProfile({
       </div>
     </div>
   );
-}
-
-/**
- * Resolve whether a creator is live, fast AND accurate:
- *
- *  1. **Instant** — seed state from `payloadIsLive` (the server-computed
- *     `is_live` on the creator payload), so the very first render gates the
- *     live marker correctly with NO network request on mount.
- *  2. **Graceful fallback** — if the payload omits the field (`undefined`,
- *     e.g. an older backend mid-deploy), probe the cheap `live.status`
- *     endpoint once on mount so nothing breaks during the deploy window.
- *  3. **Accurate over time** — a creator can go live/offline while the profile
- *     is open, so poll the same light `live.status` endpoint on a 30s interval
- *     and correct the button. We never refetch the heavy creator profile here.
- *
- * The interval and in-flight guard are torn down on unmount / username change,
- * so navigating away leaves no lingering timers or requests.
- */
-const LIVE_POLL_MS = 30_000;
-
-function useLiveGate(
-  username: string,
-  payloadIsLive: boolean | undefined,
-): boolean {
-  // Initialise from the payload so the first paint is already correct.
-  const [isLive, setIsLive] = useState<boolean>(payloadIsLive ?? false);
-  // Track whether THIS mount has ever had a definitive answer, so an initial
-  // `undefined` payload triggers the fallback probe immediately.
-  const hasPayload = payloadIsLive !== undefined;
-
-  useEffect(() => {
-    // Reset to the payload value whenever we switch creators (or the payload
-    // arrives) — keeps the instant gate correct without waiting on a probe.
-    setIsLive(payloadIsLive ?? false);
-
-    let alive = true;
-    const probe = async () => {
-      try {
-        const s = await live.status(username);
-        if (alive) setIsLive(s.live);
-      } catch {
-        // Keep the last known value on a failed probe rather than flicker.
-      }
-    };
-
-    // Fallback: only probe on mount when the payload couldn't tell us.
-    if (!hasPayload) void probe();
-
-    // Light poll keeps the button accurate while the profile stays mounted.
-    const timer = setInterval(probe, LIVE_POLL_MS);
-    return () => {
-      alive = false;
-      clearInterval(timer);
-    };
-  }, [username, payloadIsLive, hasPayload]);
-
-  return isLive;
 }
 
 // ─── Subscribe ────────────────────────────────────────────────────────────────

--- a/wallet/free2z/src/features/creator/useLiveGate.test.tsx
+++ b/wallet/free2z/src/features/creator/useLiveGate.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+vi.mock("@/lib/api/free2z", () => ({ live: { status: vi.fn() } }));
+import { live } from "@/lib/api/free2z";
+import { useLiveGate } from "./useLiveGate";
+function ProfileStatus() {
+  const isLive = useLiveGate("alice", undefined);
+  return <p>{isLive ? "Watch live" : "Creator profile"}</p>;
+}
+afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); vi.unstubAllGlobals(); });
+
+it("preserves usable profile and last live status across failed initial and periodic probes", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.useFakeTimers();
+  vi.mocked(live.status)
+    .mockRejectedValueOnce(new Error("invalid response"))
+    .mockResolvedValueOnce({ live: true } as Awaited<ReturnType<typeof live.status>>)
+    .mockRejectedValueOnce(new Error("connection closed"));
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  try {
+    await act(async () => root.render(<ProfileStatus />));
+    expect(container.textContent).toBe("Creator profile");
+    expect(live.status).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(30_000));
+    expect(container.textContent).toBe("Watch live");
+    await act(async () => vi.advanceTimersByTimeAsync(30_000));
+    expect(container.textContent).toBe("Watch live");
+    expect(live.status).toHaveBeenCalledTimes(3);
+  } finally {
+    await act(async () => root.unmount());
+  }
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/wallet/free2z/src/features/creator/useLiveGate.ts
+++ b/wallet/free2z/src/features/creator/useLiveGate.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { live } from "@/lib/api/free2z";
+
+/**
+ * Resolve whether a creator is live, fast AND accurate:
+ *
+ *  1. **Instant** — seed state from `payloadIsLive` (the server-computed
+ *     `is_live` on the creator payload), so the very first render gates the
+ *     live marker correctly with NO network request on mount.
+ *  2. **Graceful fallback** — if the payload omits the field (`undefined`,
+ *     e.g. an older backend mid-deploy), probe the cheap `live.status`
+ *     endpoint once on mount so nothing breaks during the deploy window.
+ *  3. **Accurate over time** — a creator can go live/offline while the profile
+ *     is open, so poll the same light `live.status` endpoint on a 30s interval
+ *     and correct the button. We never refetch the heavy creator profile here.
+ *
+ * The interval is cleared and late results are ignored on unmount / username
+ * change; a request already in flight may still finish.
+ */
+const LIVE_POLL_MS = 30_000;
+
+export function useLiveGate(
+  username: string,
+  payloadIsLive: boolean | undefined,
+): boolean {
+  // Initialise from the payload so the first paint is already correct.
+  const [isLive, setIsLive] = useState<boolean>(payloadIsLive ?? false);
+  // Track whether THIS mount has ever had a definitive answer, so an initial
+  // `undefined` payload triggers the fallback probe immediately.
+  const hasPayload = payloadIsLive !== undefined;
+
+  useEffect(() => {
+    // Reset to the payload value whenever we switch creators (or the payload
+    // arrives) — keeps the instant gate correct without waiting on a probe.
+    setIsLive(payloadIsLive ?? false);
+
+    let alive = true;
+    const probe = async () => {
+      const s = await live.status(username);
+      if (alive) setIsLive(s.live);
+    };
+    const refresh = () => {
+      void probe().catch(() => {
+        // Keep the last known value on any failed probe rather than flicker.
+      });
+    };
+
+    // Fallback: only probe on mount when the payload couldn't tell us.
+    if (!hasPayload) refresh();
+
+    // Light poll keeps the button accurate while the profile stays mounted.
+    const timer = setInterval(refresh, LIVE_POLL_MS);
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, [username, payloadIsLive, hasPayload]);
+
+  return isLive;
+}

--- a/wallet/free2z/src/features/live/useMediaPreflight.test.tsx
+++ b/wallet/free2z/src/features/live/useMediaPreflight.test.tsx
@@ -608,6 +608,24 @@ describe("useMediaPreflight", () => {
     });
   });
 
+  it("keeps the removed preview settled when ended-track enumeration rejects", async () => {
+    const media = new FakeMediaDevices();
+    const capture = fakeStream();
+    media.getUserMedia.mockResolvedValue(capture.stream);
+    await render(media);
+    await act(async () => latest.requestPreview());
+    media.enumerateDevices.mockRejectedValueOnce(new Error("device service unavailable"));
+    await act(async () => capture.video[0].end());
+
+    expect(latest.status).toBe("removed");
+    expect(latest.stream).toBeNull();
+    expect(latest.cameraEnabled).toBe(false);
+    expect(latest.microphoneEnabled).toBe(false);
+    expect(media.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(media.enumerateDevices).toHaveBeenCalledTimes(3);
+    capture.stream.getTracks().forEach((track) => expect(track.stop).toHaveBeenCalledTimes(1));
+  });
+
   it("detects selected-device removal and exposes denial, no-device, and busy states", async () => {
     const media = new FakeMediaDevices();
     const capture = fakeStream();

--- a/wallet/free2z/src/features/live/useMediaPreflight.ts
+++ b/wallet/free2z/src/features/live/useMediaPreflight.ts
@@ -183,7 +183,9 @@ export function useMediaPreflight({
       setStatus("removed");
       setMicrophoneEnabled(false);
       setCameraEnabled(false);
-      void refreshDevices(requestGeneration.current);
+      void refreshDevices(requestGeneration.current).catch(() => {
+        // Enumeration is optional; retain the already-set preview state.
+      });
     };
     endedListenersRef.current = next.getTracks().map((track) => {
       const listener = () => onEnded(track.kind);
@@ -359,8 +361,10 @@ export function useMediaPreflight({
       return;
     }
 
-    void refreshDevices(requestGeneration.current);
-    const onDeviceChange = async () => {
+    void refreshDevices(requestGeneration.current).catch(() => {
+      // Enumeration is optional; retain the already-set preview state.
+    });
+    const updateDevices = async () => {
       const expectedGeneration = requestGeneration.current;
       const current = streamRef.current;
       const selectionBeforeRefresh = selectedRef.current;
@@ -396,6 +400,9 @@ export function useMediaPreflight({
         setCameraEnabled(false);
       }
     };
+    const onDeviceChange = () => updateDevices().catch(() => {
+      // Keep the current preview state if an unexpected refresh error escapes.
+    });
     mediaDevices.addEventListener?.("devicechange", onDeviceChange);
 
     return () => {


### PR DESCRIPTION
Closes #975.

Make detached Free2Z work catch rejection at its launch boundary. Unexpected session bootstrap failure now shows the existing terminal recovery screen with its Reload button and a diagnostics record instead of leaving the app behind a session skeleton; it preserves unvalidated session/credential state and does not unlock OAuth recovery. Comments settle their existing error fallback; initial and periodic live probes retain the last known display; optional media refresh failures preserve preview state and stopped-stream ownership.

The existing comments, creator, and media callees already handled their current expected failures. This change makes the detached boundaries explicit against future callee escapes; it does not claim those paths had a current visible outage. The bootstrap test substitutes an unexpectedly throwing cleanup callee before its internal try. Ordinary storage denial is already caught inside the current cleanup helper; this is fault injection, not evidence of a current storage-denial outage. The creator hook is extracted into a production module so its initial and periodic probes can be exercised directly. No automatic retry loop or payment behavior is introduced; Reload is an explicit user action.

Validation:

- Free2Z production/test typechecks pass; full Vitest: 931 passed, 5 existing skips; Playwright: 93 passed on an isolated port; copy/release-path Node suites pass.
- Session test makes the cleanup callee throw before bootstrap’s internal try and observes terminal fallback, Reload control, and one diagnostics record without validating the session. Removing the reporter fails that assertion. Comments test rejects a later pagination request and observes settled error UI. Live probe test covers failed initial request, successful next scheduled poll, then failure retaining the last known value.
- Controlled Vite transforms remove the new catches: bootstrap/comments lose fallback and emit unhandled rejections; creator emits two unhandled rejections. An additional fault injection makes ended-track enumeration escape its callee's internal try: stopped/removed state remains settled with the launch catch, while removing it causes an unhandled rejection. These are temporary fault-injection controls, not permanent lint rules or claims that the original handled failures were broken.
- Public boundary and diff checks pass. Temporary mutation configuration was removed; shipping source was not rewritten by the fault injections.

## Codex adversarial review — final

No significant findings.

Reviewed session/OAuth flow, diagnostics, comment submission, media cleanup, dependencies, tests, and CI configuration. Tests were not run. CI does not validate these failures against real native WebView storage and media devices.

RISKIEST LINE: `wallet/free2z/src/App.tsx:208` — `if (active) setBootstrapFailed(true);` replaces the entire content app with a reload-only fallback when session bootstrap rejects. A persistent bootstrap failure would therefore block every route for the affected user.

## Codex adversarial review — initial

1. **wallet/free2z/src/App.tsx:203 — Medium severity, high confidence:** The new catch discards the bootstrap error. If session initialization unexpectedly rejects, the entire content app becomes a terminal fallback, but the rejection no longer reaches `installGlobalDiagnostics`’s `unhandledrejection` listener. A recurring startup failure leaves users blocked and support without the error needed to diagnose it. Report through the existing diagnostics reporter before setting the fallback.

2. **wallet/free2z/src/App.tsx:215 — Low severity, high confidence:** Recovery is text only. In the packaged Tauri app, a user encountering this failure has no browser reload control, and the fallback removes all application navigation. They must discover how to terminate and relaunch the app. Provide a reload button, as the existing `RootFallback` does.

CI does not validate recovery through the real router in the new bootstrap test: `RouterProvider` is mocked, and the test checks only fallback text. The new media test’s enumeration rejection is already swallowed inside `refreshDevices`, so it does not exercise the added outer catch.

Review was read-only; tests were not run.

RISKIEST LINE: `wallet/free2z/src/App.tsx:203` — it now owns an app-wide startup failure while discarding its diagnostic cause.

Disposition: addressed both findings. The bootstrap catch now reports through the existing fail-safe diagnostics reporter and renders the existing RootFallback with its Reload button. The updated test verifies one diagnostics record and the recovery control; removing the reporter fails the test. Full Vitest and all 93 browser cases passed again after this correction. The unit router is mocked and native WebView failure behavior remains unverified; the media escape/control distinction is documented above.


### Fresh-main integration validation

Normal merge `b3b33fe2eff59b7826f091b0304a58d133225e8b` incorporates actual main `e83c1ac8`; the complete PR diff remains byte-identical to independently reviewed `b31eb0d39`. No production conflict resolutions or new authored changes.

Node 24 with explicit peer-enforced `npm ci --legacy-peer-deps=false`: both typechecks passed; all 933 Vitest cases passed with 5 existing skips; copy/release-path controls passed; all 93 Playwright cases passed on an isolated port; production build and public-boundary guard passed. The first typecheck before reinstall saw stale copied `file:../shared` types from before the shared intent update; reinstall resolved both errors without source changes. Production build ran after browser completion. Prior independent reviews and mutation controls above remain applicable to the byte-identical change.

### Final CI-fix integration

Normal merge `2d1a4df6daea2169ec69a6feeb3471caca196a4a` includes current main `c95741badbb833184afbb4c8fe603b9dc2af73ad`. The full PR diff is byte-identical to the previously reviewed head; incoming changes are the Android test-label correction and isolated Ubuntu dependency installation. Both Free2Z typechecks, all 933 Vitest cases (5 existing skips), copy/release-path controls, all 93 browser cases, production build, and public-boundary/diff guards pass again. Browser and build steps ran sequentially on an isolated port. Existing independent reviews and causal controls remain applicable to the unchanged authored delta. Fresh hosted QA is required at this head.
