### PR TITLE
fix(ci): isolate Ubuntu package installs from unrelated APT sources

### DIFF
--- a/.github/workflows/wallet-surfaces.yml
+++ b/.github/workflows/wallet-surfaces.yml
@@ -56,6 +56,8 @@ on:
       - 'rs/crates/f2z-relay-proto/**'
       - 'rs/crates/f2z-relay-testkit/**'
       - 'scripts/check-rust-toolchain.sh'
+      - 'scripts/install-ubuntu-deps.sh'
+      - 'scripts/test-ubuntu-apt-isolation.py'
       - '.github/workflows/wallet-surfaces.yml'
   push:
     branches: [main]
@@ -78,6 +80,8 @@ on:
       - 'rs/crates/f2z-relay-proto/**'
       - 'rs/crates/f2z-relay-testkit/**'
       - 'scripts/check-rust-toolchain.sh'
+      - 'scripts/install-ubuntu-deps.sh'
+      - 'scripts/test-ubuntu-apt-isolation.py'
       - '.github/workflows/wallet-surfaces.yml'
   workflow_dispatch:
 
@@ -113,8 +117,7 @@ jobs:
 
       - name: Install Tauri system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo bash scripts/install-ubuntu-deps.sh \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \

--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -32,6 +32,8 @@ on:
       - 'wallet/plugins/tauri-plugin-zcash/**'
       - 'z/zcash/librustzcash'
       - '.gitmodules'
+      - 'scripts/install-ubuntu-deps.sh'
+      - 'scripts/test-ubuntu-apt-isolation.py'
       - 'scripts/check-rust-fmt.sh'
       - 'scripts/check-rust-deny.sh'
       - 'scripts/check-rust-clippy.sh'
@@ -48,6 +50,8 @@ on:
       - 'wallet/plugins/tauri-plugin-zcash/**'
       - 'z/zcash/librustzcash'
       - '.gitmodules'
+      - 'scripts/install-ubuntu-deps.sh'
+      - 'scripts/test-ubuntu-apt-isolation.py'
       - 'scripts/check-rust-fmt.sh'
       - 'scripts/check-rust-deny.sh'
       - 'scripts/check-rust-clippy.sh'
@@ -154,8 +158,7 @@ jobs:
 
       - name: Install Tauri system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo bash scripts/install-ubuntu-deps.sh \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
@@ -373,8 +376,7 @@ jobs:
 
       - name: Install Tauri system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo bash scripts/install-ubuntu-deps.sh \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -40,6 +40,9 @@ jobs:
           # Diff locally instead of relying on the pull-request files API.
           fetch-depth: 0
 
+      - name: Verify isolated Ubuntu dependency installation
+        run: sudo python3 scripts/test-ubuntu-apt-isolation.py
+
       # This runs before change detection on every event. A workflow cannot
       # replace its own judge with a mutable external action, or mark a job the
       # required gate awaits as best-effort, then skip the full application

--- a/scripts/install-ubuntu-deps.sh
+++ b/scripts/install-ubuntu-deps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install distribution packages without consulting unrelated runner repositories.
+# Keep the runner's complete Ubuntu definition (including security and Signed-By).
+# UBUNTU_APT_SOURCE_FILE is only an input override for isolated fixture tests.
+set -euo pipefail
+
+if (( EUID != 0 )); then
+  echo 'Run this installer with sudo.' >&2
+  exit 2
+fi
+if (( $# == 0 )); then
+  echo 'At least one Ubuntu package is required.' >&2
+  exit 2
+fi
+for package in "$@"; do
+  if [[ -z "$package" || "$package" == -* ]]; then
+    echo 'Package arguments must not be apt options.' >&2
+    exit 2
+  fi
+done
+
+source_file=${UBUNTU_APT_SOURCE_FILE:-/etc/apt/sources.list.d/ubuntu.sources}
+if [[ ! -s "$source_file" ]]; then
+  echo "Missing or empty Ubuntu source definition: $source_file" >&2
+  exit 2
+fi
+
+apt_workspace=$(mktemp -d /tmp/ubuntu-apt.XXXXXXXX)
+trap 'rm -rf -- "$apt_workspace"' EXIT
+mkdir "$apt_workspace/sources" "$apt_workspace/lists"
+# The _apt sandbox user must be able to traverse the private index location.
+chmod 755 "$apt_workspace" "$apt_workspace/sources" "$apt_workspace/lists"
+cp -- "$source_file" "$apt_workspace/sources/ubuntu.sources"
+chmod 644 "$apt_workspace/sources/ubuntu.sources"
+
+apt_options=(
+  -o Dir::Etc::sourcelist=/dev/null
+  -o "Dir::Etc::sourceparts=$apt_workspace/sources"
+  -o "Dir::State::lists=$apt_workspace/lists"
+  -o "Dir::Cache::pkgcache=$apt_workspace/packages.bin"
+  -o "Dir::Cache::srcpkgcache=$apt_workspace/source-packages.bin"
+  -o APT::Update::Error-Mode=any
+)
+apt-get "${apt_options[@]}" update
+apt-get "${apt_options[@]}" install -y "$@"

--- a/scripts/test-ubuntu-apt-isolation.py
+++ b/scripts/test-ubuntu-apt-isolation.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Exercise real signed APT repositories; package installation is simulated.
+
+Run as root in Linux (CI or a disposable container). No host sources are changed.
+The PATH adapter adds --simulate only to install; update remains real APT.
+"""
+from contextlib import ExitStack
+from email.utils import formatdate
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def run(argv, *, env=None, check=True):
+    result = subprocess.run(argv, env=env, text=True, capture_output=True)
+    if check and result.returncode:
+        raise AssertionError(f"{argv[0]} failed:\n{result.stdout}\n{result.stderr}")
+    return result
+
+
+def main():
+    assert os.geteuid() == 0, "run with sudo in Linux"
+    apt = shutil.which("apt-get")
+    assert apt
+    installer = Path(__file__).resolve().with_name("install-ubuntu-deps.sh")
+    with tempfile.TemporaryDirectory(prefix="apt-isolation-fixture-") as tmp, ExitStack() as cleanup:
+        root = Path(tmp)
+        root.chmod(0o755)
+        keys = root / "keys"
+        keys.mkdir(mode=0o700)
+        cleanup.callback(run, ["gpgconf", "--homedir", str(keys), "--kill", "gpg-agent"], check=False)
+        gpg = ["gpg", "--batch", "--homedir", str(keys), "--pinentry-mode", "loopback", "--passphrase", ""]
+        run(gpg + ["--quick-generate-key", "APT isolation fixture", "rsa2048", "sign", "0"])
+        public_key = root / "fixture.gpg"
+        public_key.write_bytes(subprocess.check_output(gpg + ["--export"]))
+        arch = run(["dpkg", "--print-architecture"]).stdout.strip()
+        repo = root / "repo"
+        for suite, version in [("base", "1"), ("security", "2"), ("unrelated", "3")]:
+            package = root / f"package-{suite}"
+            (package / "DEBIAN").mkdir(parents=True)
+            (package / "DEBIAN/control").write_text(
+                f"Package: apt-isolation-probe\nVersion: {version}\nArchitecture: all\n"
+                "Maintainer: Fixture <fixture@example.invalid>\nDescription: isolated test package\n"
+            )
+            pool = repo / "pool" / suite
+            pool.mkdir(parents=True)
+            deb = pool / f"probe_{version}_all.deb"
+            run(["dpkg-deb", "--build", str(package), str(deb)])
+            relative = f"main/binary-{arch}/Packages"
+            distribution = repo / "dists" / suite
+            index = distribution / relative
+            index.parent.mkdir(parents=True)
+            data = (
+                f"Package: apt-isolation-probe\nVersion: {version}\nArchitecture: all\n"
+                "Maintainer: Fixture <fixture@example.invalid>\nDescription: isolated test package\n"
+                f"Filename: pool/{suite}/{deb.name}\nSize: {deb.stat().st_size}\n"
+                f"SHA256: {hashlib.sha256(deb.read_bytes()).hexdigest()}\n\n"
+            ).encode()
+            index.write_bytes(data)
+            release = distribution / "Release"
+            release.write_text(
+                f"Suite: {suite}\nCodename: {suite}\nArchitectures: {arch}\nComponents: main\n"
+                f"Date: {formatdate(usegmt=True)}\n"
+                f"SHA256:\n {hashlib.sha256(data).hexdigest()} {len(data)} {relative}\n"
+            )
+            run(gpg + ["--yes", "--output", str(distribution / "InRelease"), "--clearsign", str(release)])
+
+        def sources(suites):
+            return (
+                f"Types: deb\nURIs: file:{repo}\nSuites: {' '.join(suites)}\n"
+                f"Components: main\nSigned-By: {public_key}\n"
+            )
+
+        source = root / "ubuntu.sources"
+        source.write_text(sources(["base", "security"]))
+        original = source.read_bytes()
+        ambient = root / "ambient"
+        ambient.mkdir()
+        (ambient / "ubuntu.sources").write_bytes(original)
+        (ambient / "unrelated.sources").write_text(sources(["unrelated"]))
+        bad_index = repo / f"dists/unrelated/main/binary-{arch}/Packages"
+        bad_index.write_bytes(bad_index.read_bytes() + b"corrupt index\n")
+        lists = root / "ambient-lists"
+        lists.mkdir()
+        negative = run([
+            apt, "-o", "Dir::Etc::sourcelist=/dev/null", "-o", f"Dir::Etc::sourceparts={ambient}",
+            "-o", f"Dir::State::lists={lists}", "-o", "APT::Update::Error-Mode=any", "update",
+        ], check=False)
+        assert negative.returncode and "Hash Sum mismatch" in negative.stdout + negative.stderr
+        print("PASS: ambient unrelated repository hash mismatch rejects update")
+
+        adapter = root / "bin"
+        adapter.mkdir()
+        calls = root / "calls.jsonl"
+        wrapper = adapter / "apt-get"
+        wrapper.write_text(
+            "#!/usr/bin/env python3\nimport json,os,sys\n"
+            "with open(os.environ['APT_FIXTURE_CALLS'],'a') as f: f.write(json.dumps(sys.argv[1:])+'\\n')\n"
+            "args=sys.argv[1:]\n"
+            "if 'install' in args: args.insert(0,'--simulate')\n"
+            f"os.execv({apt!r},[{apt!r},*args])\n"
+        )
+        wrapper.chmod(0o755)
+        env = {**os.environ, "PATH": f"{adapter}:{os.environ['PATH']}",
+               "APT_FIXTURE_CALLS": str(calls), "UBUNTU_APT_SOURCE_FILE": str(source)}
+
+        def invoke():
+            calls.write_text("")
+            result = run(["bash", str(installer), "apt-isolation-probe"], env=env, check=False)
+            recorded = [json.loads(line) for line in calls.read_text().splitlines()]
+            for args in recorded:
+                state = next(item.split("=", 1)[1] for item in args if item.startswith("Dir::State::lists="))
+                assert not Path(state).exists(), "temporary index directory leaked"
+            return result, recorded
+
+        result, recorded = invoke()
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Inst apt-isolation-probe (2 " in result.stdout, result.stdout
+        assert len(recorded) == 2 and "update" in recorded[0] and "install" in recorded[1]
+        assert recorded[0][:-1] == recorded[1][:-3], "update/install options differ"
+        assert source.read_bytes() == original
+        print("PASS: scoped signed APT chooses security version 2; source unchanged and private indices removed")
+
+        selected = repo / f"dists/security/main/binary-{arch}/Packages"
+        good_index = selected.read_bytes()
+        selected.write_bytes(good_index + b"corrupt selected index\n")
+        result, recorded = invoke()
+        assert result.returncode and "Hash Sum mismatch" in result.stdout + result.stderr
+        assert len(recorded) == 1, "install ran after selected index failure"
+        selected.write_bytes(good_index)
+        print("PASS: selected security index hash failure prevents install")
+
+        signed = repo / "dists/security/InRelease"
+        signed.write_bytes(signed.read_bytes().replace(b"Suite: security", b"Suite: tampered"))
+        result, recorded = invoke()
+        assert result.returncode and "BADSIG" in result.stdout + result.stderr
+        assert len(recorded) == 1, "install ran after signature failure"
+        print("PASS: selected security signature failure prevents install")
+
+        source.unlink()
+        result, recorded = invoke()
+        assert result.returncode and not recorded
+        print("PASS: missing selected source fails before any APT invocation")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hosted Ubuntu Tauri dependency installation fails when an unrelated Google Chrome APT index has a hash mismatch. This happened in both wallet/surfaces Rust jobs before compilation. The three hosted-runner APT blocks now use the complete runner-provided Ubuntu source definition with per-invocation source and index directories, preserving Ubuntu security updates and signature/hash verification. Package lists are unchanged; host source configuration and pinned Linux image builds are untouched.

Closes #1007.

Validation:
- Real signed APT fixture reproduces the ambient unrelated-index hash mismatch, then confirms the isolated installer selects version 2 from the security suite rather than base version 1. Selected-source hash/signature failures prevent installation, and a missing selected source fails before APT runs. Only package installation is simulated; index downloads and signature/hash checks use real APT. Temporary indices and fixture signing agents are cleaned up.
- Actions-pin policy and all mutation controls, 39 workflow-gate controls, 43 pinned-Linux-image negative controls plus runtime cases, shell syntax, diff whitespace, and the public boundary guard pass.
- Both affected workflows trigger for helper/test changes. Regular Zuuallet jobs have no additional file selector; its existing upstream-canary remains scheduled/manual and is not claimed as exercised by PR checks.
- Audited all workflow APT and Playwright dependency call sites: three bare APT blocks changed; no hosted Playwright --with-deps/install-deps calls exist. Dockerfile APT remains within the existing pinned-image boundary.

Independent orchestration review inspected the full helper, signed fixture and workflow changes and found no blocker. Its requested fixture-owned gpg-agent cleanup is included. Hosted Ubuntu package installation and all selected native/build checks must still pass before merge; local fixture success alone does not prove runner source layout or Tauri package availability.
