### PR TITLE
feat(e2ee): seal under a per-device wrap key and let e2e2z install a credential (#928)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,8 +192,11 @@ person approving it, so shipping it first because it "only signs" is backwards.
 Read [`status.md`](./status.md) rather than inferring from this page. In short:
 there is **no transport** ([#461](https://github.com/free2z/zuu/issues/461)),
 `sign-challenge` has neither a caller nor an authority-side implementation, and
-`issue-device-credential` has a caller but no authority-side implementation —
-enrollment could not complete even with a transport
-([#928](https://github.com/free2z/zuu/issues/928)), free2z's native layer is
+`issue-device-credential` has a caller and an install step but **no
+authority-side implementation** — ZUULI still answers it `INTENT_UNKNOWN_INTENT`
+([`intent.rs`](../wallet/zuuli/src-tauri/src/intent.rs)), so nothing issues a
+credential over the bridge. What [#928](https://github.com/free2z/zuu/issues/928)
+closed is the step *after* that one: e2e2z can now install a credential it
+receives, which it could not before. free2z's native layer is
 unwired ([#918](https://github.com/free2z/zuu/issues/918)), and ZUULI's phase-4
 hardening is in progress.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,8 +107,10 @@ pressure; an absent command cannot be invoked.
 
 `wallet/e2e2z/src-tauri/Cargo.lock` contains **zero Zcash crates** — no
 `zcash_*`, no `orchard`, no `sapling`. It registers `tauri-plugin-f2zmsg` and
-exactly one app command, `e2e2z_device_credential_keys`, which returns the
-**public** halves of an OS-CSPRNG device key set and grants nothing.
+three app commands: `e2e2z_device_credential_keys` returns the **public** halves
+of an OS-CSPRNG device key set, `e2e2z_install_device_credential` installs the
+signed credential, and `e2e2z_retry_device_unlock` reopens this device's seal.
+None accepts or derives account keys.
 
 ZUULI's three app-crate enrollment commands — `f2zmsg_enrollment_status`,
 `f2zmsg_enroll`, `f2zmsg_unenroll` — are deliberately absent here. In ZUULI they

--- a/docs/e2ee/CLIENT-CONTRACT.md
+++ b/docs/e2ee/CLIENT-CONTRACT.md
@@ -1382,9 +1382,9 @@ uninitialized ──(wallet present, handle eligible)──► not-enrolled
  (handle not eligible, §11.3)                             │
                                                   (merged at epoch)
                                                           ▼
-   locked ◄──(wallet seed cleared)── starting ──────► running ──► degraded
+   locked ◄──(wrap key unavailable)── starting ──────► running ──► degraded
       │                                 ▲                │   ◄──      │
-      └──(seed available)───────────────┘                │            │
+      └──(wrap key read back)───────────┘                │            │
                                                      stop_engine      │
                                                           ▼           │
                                                        stopped ◄──────┘
@@ -1400,8 +1400,9 @@ type EngineState =
   | "ineligible"      // wallet present; username is not a valid handle (§11.3)
   | "not-enrolled"    // eligible, no directory entry yet
   | "enrolling"       // submitted; awaiting the log's merge
-  | "locked"          // enrolled, but the seed is unavailable: local history
-                      // is wrapped under BackupWrapKey and cannot be decrypted
+  | "locked"          // enrolled, but this device's DeviceWrapKey is
+                      // unavailable, so the sealed device secrets cannot be
+                      // opened and the engine cannot sign as this identity
   | "starting"
   | "running"
   | "degraded"        // running, but relays unreachable and/or threshold unmet
@@ -1439,10 +1440,28 @@ engine- or storage-dependent command — `start_engine` and the §3.2 enrollment
 trio included — refuses with that same code. This is the one `faulted` that
 `start_engine` cannot leave; only fixing the storage and restarting can.
 
-`locked` exists because the local encrypted history is wrapped under a
-seed-derived key
-([`ARCHITECTURE.md` §4.2](./ARCHITECTURE.md#42-derivation-proposed)). Note what
-this does **not** mean: see §9 rule 6 about the blur handler.
+`locked` exists because this device's secrets — its signing key and its queue
+seed — are sealed at rest under a **`DeviceWrapKey`**: thirty-two bytes the
+engine samples from the OS CSPRNG and keeps in the host application's own OS
+secret-store namespace
+([ADR 0016](./decisions/0016-enrollment-sealing-boundary.md) §3). A device is
+`locked` whenever that store cannot answer — a keychain still shut after a
+reboot, a Secret Service daemon not yet up, an item a profile migration left
+behind.
+
+Two consequences follow, and both are changes from the seed-derived
+`BackupWrapKey` this seal used before:
+
+* **Leaving `locked` needs no seed.** The exit is the engine re-asking its own
+  secret store, so it is the same operation in every app. `cash.free2z.e2e2z`
+  holds no mnemonic and has no enrollment path, and it can still recover; before
+  ADR 0016 only the wallet authority could, because only it could re-derive the
+  key.
+* **A wrap key opens one device, not an account.** The key is per device and
+  never leaves it, so it never crosses the intent bridge in either direction and
+  a compromise of one device does not open another's store.
+
+What `locked` still does **not** mean: see §9 rule 6 about the blur handler.
 
 ### 6.2 Delivery state — and what each one is actually evidence of
 

--- a/docs/e2ee/THREAT-MODEL.md
+++ b/docs/e2ee/THREAT-MODEL.md
@@ -347,8 +347,17 @@ user's machine, or physical access to an unlocked device.
 - **Future traffic heals, eventually.** Post-compromise security: once the
   compromised member issues an Update and the adversary is passive thereafter, the
   group's secrets recover.
-- **Local storage is encrypted at rest** under a key wrapped by `BackupWrapKey`
-  and the OS keystore where available.
+- **This device's own secrets are sealed at rest** — its signing key and its
+  queue seed, under a per-device `DeviceWrapKey` the engine samples from the OS
+  CSPRNG and keeps in the OS secret store
+  ([ADR 0016](./decisions/0016-enrollment-sealing-boundary.md) §3). So a copy of
+  the store taken without that item cannot sign as this identity. **It is not a
+  claim about message content:** the SQLite database beside the seal — MLS group
+  state and message plaintext — is not encrypted, and this list is about what a
+  compromise does and does not yield, so the narrower true statement belongs
+  here rather than the wider one. Before ADR 0016 the seal's key was the
+  seed-derived `BackupWrapKey`, which meant one key opened every device of an
+  account; §4.2 assigns that key local *history*, which stays unimplemented.
 - **The FROST per-session encryption key is destroyed after part 2**
   ([`ARCHITECTURE.md` §11.2](./ARCHITECTURE.md#112-mandatory-destruction-of-the-per-session-encryption-key)),
   enforced in the state machine and asserted by test — so a device compromised

--- a/docs/e2ee/decisions/0016-enrollment-sealing-boundary.md
+++ b/docs/e2ee/decisions/0016-enrollment-sealing-boundary.md
@@ -12,9 +12,12 @@ open** — see [§6](#6-device_kem_pk-is-not-resolved-here) ·
 [ADR 0015](./0015-key-package-publication.md) ·
 **Constrains:** [`../../intent-bridge/PROTOCOL.md` §3.3](../../intent-bridge/PROTOCOL.md#33-family-payloads),
 [`../ARCHITECTURE.md` §4.2](../ARCHITECTURE.md#42-derivation-proposed) ·
-**Nothing here is implemented.** This is the decision
-[#928](https://github.com/free2z/zuu/issues/928)'s revised acceptance criteria
-require *before* a wire change, and it changes no code.
+**Implemented.** This document was written before the code and changed none of
+it; [#937](https://github.com/free2z/zuu/issues/937) then built §3's custody
+layer, and [#928](https://github.com/free2z/zuu/issues/928) wired §3's sealing,
+§4's `IdentityInstall`, and §5's e2e2z install command. §6 stays open by
+design — `device_kem_pk` is unresolved, so a completed round trip still does not
+mean enrollment works.
 
 > **Invented here.**
 > [`../ARCHITECTURE.md` §4.2](../ARCHITECTURE.md#42-derivation-proposed) says

--- a/docs/intent-bridge/PROTOCOL.md
+++ b/docs/intent-bridge/PROTOCOL.md
@@ -188,8 +188,10 @@ key-transparency directory is built on.
 > `IdentityInstall`, which is a Rust API rather than a wire format. That work
 > has since landed: `IdentityInstall` lost its `wrap_key`, `Engine::unlock`
 > takes no key, and `cash.free2z.e2e2z` gained the app-crate command that
-> installs a credential and the one that retries the unlock — so the round trip
-> now has both halves, and only the transport (#461) is missing.
+> installs a credential and the one that retries the unlock. The caller can now
+> consume a credential, but the transport (#461) and ZUULI's authority handler
+> for `issue-device-credential` are still missing. ADR 0016 §6 also leaves the
+> `device_kem_pk` binding unresolved.
 
 `ExecutePaymentRequestV1` is a **proposal, not an instruction.** ZUULI
 re-derives its own payment review from its own wallet state and shows that; the

--- a/docs/intent-bridge/PROTOCOL.md
+++ b/docs/intent-bridge/PROTOCOL.md
@@ -185,7 +185,11 @@ key-transparency directory is built on.
 > requires the caller to **refuse a credential whose handle is not the one it
 > requested**, which needs no wire field. So the result type is
 > unchanged, §3.6's vector is unchanged, and the work moves to the plugin's
-> `IdentityInstall`, which is a Rust API rather than a wire format.
+> `IdentityInstall`, which is a Rust API rather than a wire format. That work
+> has since landed: `IdentityInstall` lost its `wrap_key`, `Engine::unlock`
+> takes no key, and `cash.free2z.e2e2z` gained the app-crate command that
+> installs a credential and the one that retries the unlock — so the round trip
+> now has both halves, and only the transport (#461) is missing.
 
 `ExecutePaymentRequestV1` is a **proposal, not an instruction.** ZUULI
 re-derives its own payment review from its own wallet state and shows that; the

--- a/docs/status.md
+++ b/docs/status.md
@@ -119,13 +119,15 @@ one is a claim about the key transparency directory, and a fabricated
 | Issue | What it blocks |
 | --- | --- |
 | [**#461**](https://github.com/free2z/zuu/issues/461) | *Everything cross-app.* Verified App Links / Universal Links need `assetlinks.json` and `apple-app-site-association` served from a domain we control. **The client half has landed:** all three apps claim `applinks:free2z.com` and carry an `autoVerify` intent filter on their own `/bridge/<app>/` prefix, and [`intent-bridge/association/`](./intent-bridge/association/README.md) holds the reviewed record. **Still blocking:** the Android document is not served — the host returns `503` until the three Play App Signing fingerprints are deployed — and nothing has been verified on a signed device on either platform |
-| [**#928**](https://github.com/free2z/zuu/issues/928) | Enrollment could not complete **even with a transport**: `IssueDeviceCredentialResultV1` carries no `identity_pk` and no `BackupWrapKey`, both of which `install_identity` requires, and e2e2z registers no install command. The obvious fix would ship a seed-derived key into e2e2z, breaching the account/device split — so this is a design question, not a wire-format patch. **Decided in [ADR 0016](./e2ee/decisions/0016-enrollment-sealing-boundary.md)** (2026-09-05): sealing moves to a per-device wrap key, the result type gains no fields, and the install step is an e2e2z app-crate command. Nothing is implemented, and `device_kem_pk` stays open |
+| [**#928**](https://github.com/free2z/zuu/issues/928) | Enrollment could not complete **even with a transport**: `install_identity` required the seed-derived `BackupWrapKey`, which e2e2z must never hold, and e2e2z registered no install command. **Decided in [ADR 0016](./e2ee/decisions/0016-enrollment-sealing-boundary.md)** (2026-09-05) and now **implemented**: the engine seals under a per-device `DeviceWrapKey` it samples and keeps in each app's own secret-store namespace, `IdentityInstall` lost its `wrap_key`, `Engine::unlock` takes no key and is reachable from e2e2z, and e2e2z registers `e2e2z_install_device_credential` and `e2e2z_retry_device_unlock`. The wire format is untouched — no field was added, so §3.6's vector still holds. **What this does not mean:** `device_kem_pk` stays open (ADR 0016 §6), so a completed round trip proves the transport works, not that enrollment does |
 | [**#918**](https://github.com/free2z/zuu/issues/918) | free2z's native layer is unwired — the HTTP plugin, the OAuth transport, and its own deep-link scheme. Its bundle is `"active": false` |
 | [**#904**](https://github.com/free2z/zuu/issues/904) phase 4 | ZUULI's hardening. See §4 |
 
-**Therefore: no user can claim a messaging handle in any shipped build** until
-#461 and #928 both resolve. That is the plainest consequence of the two rows
-above and it is stated here so nobody has to derive it.
+**Therefore: no user can claim a messaging handle in any shipped build.** #928's
+half has landed, so the remaining blocker is #461 — there is no channel that
+authenticates either end, and until there is, the request never leaves the app.
+`device_kem_pk` sits behind that: a round trip that completes would still attest
+a key nobody holds.
 
 Also open against the bridge, and worth reading before building on it:
 [#929](https://github.com/free2z/zuu/issues/929) (correlation is not

--- a/docs/status.md
+++ b/docs/status.md
@@ -119,15 +119,15 @@ one is a claim about the key transparency directory, and a fabricated
 | Issue | What it blocks |
 | --- | --- |
 | [**#461**](https://github.com/free2z/zuu/issues/461) | *Everything cross-app.* Verified App Links / Universal Links need `assetlinks.json` and `apple-app-site-association` served from a domain we control. **The client half has landed:** all three apps claim `applinks:free2z.com` and carry an `autoVerify` intent filter on their own `/bridge/<app>/` prefix, and [`intent-bridge/association/`](./intent-bridge/association/README.md) holds the reviewed record. **Still blocking:** the Android document is not served — the host returns `503` until the three Play App Signing fingerprints are deployed — and nothing has been verified on a signed device on either platform |
-| [**#928**](https://github.com/free2z/zuu/issues/928) | Enrollment could not complete **even with a transport**: `install_identity` required the seed-derived `BackupWrapKey`, which e2e2z must never hold, and e2e2z registered no install command. **Decided in [ADR 0016](./e2ee/decisions/0016-enrollment-sealing-boundary.md)** (2026-09-05) and now **implemented**: the engine seals under a per-device `DeviceWrapKey` it samples and keeps in each app's own secret-store namespace, `IdentityInstall` lost its `wrap_key`, `Engine::unlock` takes no key and is reachable from e2e2z, and e2e2z registers `e2e2z_install_device_credential` and `e2e2z_retry_device_unlock`. The wire format is untouched — no field was added, so §3.6's vector still holds. **What this does not mean:** `device_kem_pk` stays open (ADR 0016 §6), so a completed round trip proves the transport works, not that enrollment does |
+| [**#928**](https://github.com/free2z/zuu/issues/928) | Enrollment could not complete **even with a transport**: `install_identity` required the seed-derived `BackupWrapKey`, which e2e2z must never hold, and e2e2z registered no install command. **Decided in [ADR 0016](./e2ee/decisions/0016-enrollment-sealing-boundary.md)** (2026-09-05) and now **implemented**: the engine seals under a per-device `DeviceWrapKey` it samples and keeps in each app's own secret-store namespace, `IdentityInstall` lost its `wrap_key`, `Engine::unlock` takes no key and is reachable from e2e2z, and e2e2z registers `e2e2z_install_device_credential` and `e2e2z_retry_device_unlock`. The wire format is untouched — no field was added, so §3.6's vector still holds. **Still missing:** the transport (#461), ZUULI's `issue-device-credential` authority handler (currently `INTENT_UNKNOWN_INTENT`), and the `device_kem_pk` binding (ADR 0016 §6). Installing a returned credential does not complete these parts of enrollment |
 | [**#918**](https://github.com/free2z/zuu/issues/918) | free2z's native layer is unwired — the HTTP plugin, the OAuth transport, and its own deep-link scheme. Its bundle is `"active": false` |
 | [**#904**](https://github.com/free2z/zuu/issues/904) phase 4 | ZUULI's hardening. See §4 |
 
 **Therefore: no user can claim a messaging handle in any shipped build.** #928's
-half has landed, so the remaining blocker is #461 — there is no channel that
-authenticates either end, and until there is, the request never leaves the app.
-`device_kem_pk` sits behind that: a round trip that completes would still attest
-a key nobody holds.
+install half has landed. The request still cannot leave the app without #461's
+authenticated channel, and ZUULI still has no authority handler to issue the
+credential when it arrives. The `device_kem_pk` binding also remains unresolved:
+a round trip that completes would still attest a key nobody holds.
 
 Also open against the bridge, and worth reading before building on it:
 [#929](https://github.com/free2z/zuu/issues/929) (correlation is not

--- a/wallet/e2e2z/README.md
+++ b/wallet/e2e2z/README.md
@@ -78,7 +78,22 @@ without consulting its own availability flag, so no single edit turns the
 refusal into a success. Response handling is implemented and tested against
 hand-assembled hostile bytes even though nothing can deliver one: correlation,
 family, window, status, framing and the credential's own encoding each get a
-case. What that validation proves is that the responder saw the request; it does
+case.
+
+**The step after the response is built too, since #928.** A credential that came
+back is installed by `e2e2z_install_device_credential`
+(`src/lib/enrollment/installDeviceCredential.ts`), an app-crate command that
+needs no capability and no `zcash:*` grant — possible only because
+[ADR 0016](../../docs/e2ee/decisions/0016-enrollment-sealing-boundary.md) moved
+the seal at rest from the seed-derived `BackupWrapKey` to a per-device
+`DeviceWrapKey` the engine samples itself. Before that, installing needed a
+seed-derived key this app must never hold, so the round trip could not have
+completed even with a transport. The same decision gives this app
+`e2e2z_retry_device_unlock`: a seed-free exit from `locked`, which matters here
+because the exit it replaced was ZUULI re-deriving the wrap key from the
+mnemonic. Two arguments cross into the install — the credential's bytes and the
+handle *this session asked for* — and a wrap key is not among them, which
+`src-tauri/src/device.rs` asserts rather than merely states. What that validation proves is that the responder saw the request; it does
 **not** prove the responder was ZUULI, because
 `docs/intent-bridge/CALLER-AUTHENTICATION.md` §5 records that there is no
 signature over responses. That is #461's job, not this code's.

--- a/wallet/e2e2z/src-tauri/src/device.rs
+++ b/wallet/e2e2z/src-tauri/src/device.rs
@@ -53,8 +53,11 @@
 //! established that a transport exists: preparing a device for a request that
 //! cannot be sent throws away key material for nothing.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Runtime};
+use tauri_plugin_f2zmsg::engine::IdentityInstall;
+use tauri_plugin_f2zmsg::error::Error;
+use tauri_plugin_f2zmsg::models::{EngineStatus, EnrollmentStatus};
 use tauri_plugin_f2zmsg::{F2zMsgExt as _, Result};
 
 /// The public halves of this device's key set, hex-encoded.
@@ -109,6 +112,113 @@ pub async fn e2e2z_device_credential_keys<R: Runtime>(
     })
 }
 
+/// What the renderer hands back once the wallet authority has answered.
+///
+/// Everything here has been through the webview's heap, so both fields are
+/// public: signed credential bytes, and a handle the user typed. A wrap key is
+/// deliberately absent — before ADR 0016 the engine sealed under the
+/// seed-derived `BackupWrapKey`, and routing that through here would have given
+/// this app account-scoped authority (`ARCHITECTURE.md` §4.2).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InstallDeviceCredentialArgs {
+    /// The `DeviceCredential`'s canonical bytes, lowercase hex — the same
+    /// encoding [`DeviceCredentialKeys`] uses on the way out.
+    pub credential: String,
+    /// The handle **this enrollment asked for**, so a credential attesting a
+    /// different one is refused. See [`IdentityInstall::expected_handle`] for
+    /// why a signature is not enough on a first enrollment.
+    pub expected_handle: String,
+}
+
+/// Install a `DeviceCredential` issued by the wallet authority.
+///
+/// ADR 0016 §5, and the step whose absence meant the round trip could not
+/// complete even with a transport (#928). App-crate for the same reason as its
+/// sibling above (§2.2), and it grants nothing new: no wallet crate, no
+/// `zcash:*`, no seed — the install path is seed-free because ADR 0016 moved
+/// the seal to a per-device key.
+///
+/// [`e2e2z_device_credential_keys`] must have run in this process for the
+/// credential being installed. `prepare_device` is not idempotent, so a
+/// credential issued over discarded keys is refused by the engine's `device_pk`
+/// binding, and the UI has to be able to explain that refusal.
+///
+/// # Errors
+///
+/// `internal` if the credential is not hex, does not parse, or does not bind
+/// the device key this process prepared; `handle-ineligible` if it attests a
+/// handle that is not `expectedHandle`; `durability-unavailable` if this device
+/// cannot keep the wrap key the engine seals under.
+#[tauri::command]
+pub async fn e2e2z_install_device_credential<R: Runtime>(
+    app: AppHandle<R>,
+    args: InstallDeviceCredentialArgs,
+) -> Result<EnrollmentStatus> {
+    let engine = app.f2zmsg().engine_handle()?;
+    let credential = unhex(&args.credential)?;
+    engine
+        .install_identity(IdentityInstall {
+            credential,
+            expected_handle: args.expected_handle,
+            submitted_at: now_ms(),
+        })
+        .await
+}
+
+/// Re-ask the OS secret store for this device's wrap key and leave §6.1's
+/// `locked`.
+///
+/// ADR 0016 §3 requires this to be reachable here: the exit it replaced was
+/// `f2zmsg_enroll` re-deriving the wrap key from the mnemonic, which this app
+/// cannot do. Without it a transient secret-store failure leaves this app
+/// `locked` with no way back.
+///
+/// # Errors
+///
+/// `not-enrolled` before enrollment, `durability-unavailable` when the secret
+/// store cannot answer, `engine-locked` when the key does not open the seal.
+#[tauri::command]
+pub async fn e2e2z_retry_device_unlock<R: Runtime>(app: AppHandle<R>) -> Result<EngineStatus> {
+    app.f2zmsg().engine_handle()?.unlock().await
+}
+
+/// Decode lowercase hex. Local for the reason [`hex`] is.
+fn unhex(value: &str) -> Result<Vec<u8>> {
+    let bytes = value.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return Err(Error::internal("the credential is not whole bytes of hex"));
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks(2) {
+        let digits = core::str::from_utf8(pair)
+            .ok()
+            .filter(|text| text.chars().all(|digit| digit.is_ascii_hexdigit()));
+        let Some(digits) = digits else {
+            return Err(Error::internal("the credential is not hex"));
+        };
+        let byte = u8::from_str_radix(digits, 16)
+            .map_err(|_| Error::internal("the credential is not hex"))?;
+        out.push(byte);
+    }
+    if out.is_empty() {
+        return Err(Error::internal("the credential is empty"));
+    }
+    Ok(out)
+}
+
+/// This app's own clock, for `StoredIdentity.submitted_at` — ADR 0016 §4.2
+/// keeps that timestamp local rather than taking it from the responder.
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+    )
+    .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,6 +227,48 @@ mod tests {
     fn hex_is_lowercase_and_zero_padded() {
         assert_eq!(hex(&[0x00, 0x0f, 0xa0, 0xff]), "000fa0ff");
         assert_eq!(hex(&[]), "");
+    }
+
+    #[test]
+    fn hex_round_trips_through_unhex() {
+        assert_eq!(
+            unhex(&hex(&[0x00, 0x0f, 0xa0, 0xff])).expect("hex"),
+            vec![0x00, 0x0f, 0xa0, 0xff]
+        );
+    }
+
+    #[test]
+    fn a_credential_that_is_not_whole_lowercase_bytes_is_refused() {
+        for candidate in ["", "abc", "zz", "00 11", "ab\n"] {
+            assert!(
+                unhex(candidate).is_err(),
+                "{candidate:?} is not a credential"
+            );
+        }
+    }
+
+    /// The field set is asserted rather than left to review: a wrap key routed
+    /// through here would put an account-scoped key in the webview's heap.
+    /// `deny_unknown_fields` is what makes it a check rather than a comment.
+    #[test]
+    fn the_install_arguments_carry_a_credential_and_a_handle_and_nothing_else() {
+        let args: InstallDeviceCredentialArgs = serde_json::from_value(serde_json::json!({
+            "credential": "0a0b",
+            "expectedHandle": "alice",
+        }))
+        .expect("the two reviewed arguments deserialize");
+        assert_eq!(args.credential, "0a0b");
+        assert_eq!(args.expected_handle, "alice");
+
+        let widened = serde_json::from_value::<InstallDeviceCredentialArgs>(serde_json::json!({
+            "credential": "0a0b",
+            "expectedHandle": "alice",
+            "wrapKey": "5a".repeat(32),
+        }));
+        assert!(
+            widened.is_err(),
+            "a wrap key must not be accepted here: e2e2z holds nothing seed-derived"
+        );
     }
 
     /// The response type is public keys and nothing else. A private half added

--- a/wallet/e2e2z/src-tauri/src/lib.rs
+++ b/wallet/e2e2z/src-tauri/src/lib.rs
@@ -5,19 +5,23 @@
 //! and nothing else privileged.
 //!
 //! The app-crate enrollment trio ZUULI carries — `f2zmsg_enrollment_status`,
-//! `f2zmsg_enroll`, `f2zmsg_unenroll` — is deliberately absent. In ZUULI those
-//! commands borrow the wallet seed from `tauri-plugin-zcash`'s managed state
-//! in-process (docs/e2ee/CLIENT-CONTRACT.md §2.2). Here there is no seed to
-//! borrow: enrollment becomes a bridge call into the wallet authority, which
-//! issues the `DeviceCredential` (#905). Until that protocol lands there is no
-//! honest in-process implementation, so there is no command and no capability
-//! entry addressing one.
+//! `f2zmsg_enroll`, `f2zmsg_unenroll` — is deliberately absent, and stays
+//! absent. In ZUULI those commands borrow the wallet seed from
+//! `tauri-plugin-zcash`'s managed state in-process
+//! (docs/e2ee/CLIENT-CONTRACT.md §2.2). Here there is no seed to borrow:
+//! enrollment is a bridge call into the wallet authority, which issues the
+//! `DeviceCredential` (#905), and #461 still owes that call a transport that
+//! authenticates either end.
 //!
-//! What this crate *does* register is [`device::e2e2z_device_credential_keys`]:
-//! the **public** halves of this device's OS-CSPRNG key set, which are what an
-//! `issue-device-credential` request carries. It grants nothing, reveals no
-//! secret, and is the one piece of enrollment that does not need the seed. See
-//! that module for why it is here rather than in the plugin or in the renderer.
+//! What this crate *does* register is three app-crate commands, none of which
+//! needs a seed or a capability entry:
+//!
+//! * [`device::e2e2z_device_credential_keys`] — the public halves of this
+//!   device's key set, which an `issue-device-credential` request carries.
+//! * [`device::e2e2z_install_device_credential`] — consumes the credential the
+//!   wallet authority answers with (ADR 0016 §5, #928).
+//! * [`device::e2e2z_retry_device_unlock`] — the seed-free exit from §6.1's
+//!   `locked` that ADR 0016 §3 requires this app to have.
 
 pub mod device;
 
@@ -54,7 +58,9 @@ pub fn run() {
         // This app's own device wrap-key namespace; see `WRAP_KEY_NAMESPACE`.
         .plugin(tauri_plugin_f2zmsg::init(WRAP_KEY_NAMESPACE))
         .invoke_handler(tauri::generate_handler![
-            device::e2e2z_device_credential_keys
+            device::e2e2z_device_credential_keys,
+            device::e2e2z_install_device_credential,
+            device::e2e2z_retry_device_unlock
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -76,10 +82,9 @@ mod tests {
 
     /// The enrollment trio must stay absent from this crate's IPC surface.
     ///
-    /// `e2e2z_device_credential_keys` is deliberately *not* one of them: it
-    /// returns public keys and cannot enroll anything. If a command whose name
-    /// starts `f2zmsg_` ever appears here, this app has grown the very surface
-    /// #904 split away, so the source is asserted rather than the doc comment.
+    /// The three `e2e2z_*` commands are deliberately not among them — none can
+    /// reach a seed. A command named `f2zmsg_*` appearing here would mean this
+    /// app grew the surface #904 split away, so the source is asserted.
     #[test]
     fn no_enrollment_command_is_registered() {
         let source = include_str!("lib.rs");
@@ -92,6 +97,12 @@ mod tests {
             !handler.contains("f2zmsg_"),
             "e2e2z must register no f2zmsg_* app-crate command: enrollment needs the seed"
         );
-        assert!(handler.contains("e2e2z_device_credential_keys"));
+        for command in [
+            "e2e2z_device_credential_keys",
+            "e2e2z_install_device_credential",
+            "e2e2z_retry_device_unlock",
+        ] {
+            assert!(handler.contains(command), "{command} must stay registered");
+        }
     }
 }

--- a/wallet/e2e2z/src/lib/enrollment/installDeviceCredential.test.ts
+++ b/wallet/e2e2z/src/lib/enrollment/installDeviceCredential.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+//
+// Installing the credential the wallet authority issued.
+//
+// jsdom because `@tauri-apps/api/core` reaches `window.__TAURI_INTERNALS__`,
+// and these cases are for the shipping path: the real lazy import, the real
+// command name, the real argument shape.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DeviceCredentialInstallError,
+  INSTALL_DEVICE_CREDENTIAL_COMMAND,
+  RETRY_DEVICE_UNLOCK_COMMAND,
+  installDeviceCredential,
+  isDeviceCredentialInstallError,
+  parseInstallResult,
+  parseUnlockResult,
+  retryDeviceUnlock,
+} from "./installDeviceCredential";
+
+const ENROLLED = {
+  enrolled: true,
+  handle: "alice",
+  eligibility: { eligible: true, candidate: "alice", reason: null },
+  directoryEntryVersion: null,
+  submittedAt: 1_800_000_000_000,
+  mergedAtEpoch: null,
+  blocked: null,
+};
+
+const STOPPED = {
+  state: "stopped",
+  enrolled: true,
+  handle: "alice",
+  relaysConnected: 0,
+  relaysConfigured: 0,
+  witnessThresholdMet: false,
+  independentWitnesses: 0,
+  pendingInbound: 0,
+  unacknowledgedAlarms: 0,
+  lastError: null,
+};
+
+interface Call {
+  readonly cmd: string;
+  readonly args: unknown;
+}
+
+function installTauriHost(answer: (cmd: string) => unknown): Call[] {
+  const calls: Call[] = [];
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    writable: true,
+    value: {
+      invoke(cmd: string, args: unknown) {
+        calls.push({ cmd, args });
+        return Promise.resolve(answer(cmd));
+      },
+    },
+  });
+  return calls;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(
+    window as unknown as Record<string, unknown>,
+    "__TAURI_INTERNALS__",
+  );
+  vi.restoreAllMocks();
+});
+
+describe("the install command's arguments", () => {
+  it("sends the credential as hex under the §3 args key, with the requested handle", async () => {
+    const calls = installTauriHost(() => ENROLLED);
+
+    const status = await installDeviceCredential(
+      Uint8Array.from([0x00, 0x0f, 0xa0, 0xff]),
+      "alice",
+    );
+
+    expect(status.enrolled).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cmd).toBe(INSTALL_DEVICE_CREDENTIAL_COMMAND);
+    expect(calls[0]?.args).toEqual({
+      args: { credential: "000fa0ff", expectedHandle: "alice" },
+    });
+  });
+
+  // #928's fourth criterion, at the layer where a widening would be typed: a
+  // wrap key here would put an account-scoped key in the renderer's heap. A
+  // third argument is one line, and no other test would notice it.
+  it("carries nothing beyond the credential and the requested handle", async () => {
+    const calls = installTauriHost(() => ENROLLED);
+
+    await installDeviceCredential(Uint8Array.from([1, 2, 3]), "alice");
+
+    const payload = (calls[0]?.args as { args: Record<string, unknown> }).args;
+    expect(Object.keys(payload).sort()).toEqual(["credential", "expectedHandle"]);
+    for (const name of Object.keys(payload)) {
+      expect(name.toLowerCase()).not.toContain("wrap");
+      expect(name.toLowerCase()).not.toContain("seed");
+      expect(name.toLowerCase()).not.toContain("identity");
+    }
+  });
+
+  it("refuses an empty credential without reaching the host", async () => {
+    const calls = installTauriHost(() => ENROLLED);
+
+    await expect(
+      installDeviceCredential(new Uint8Array(), "alice"),
+    ).rejects.toBeInstanceOf(DeviceCredentialInstallError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("carries the engine's refusal rather than summarising it", async () => {
+    installTauriHost(() => {
+      throw "handle-ineligible";
+    });
+
+    const error = await installDeviceCredential(
+      Uint8Array.from([1]),
+      "alice",
+    ).catch((thrown: unknown) => thrown);
+
+    expect(isDeviceCredentialInstallError(error)).toBe(true);
+    expect((error as Error).message).toContain("handle-ineligible");
+  });
+});
+
+describe("the unlock retry", () => {
+  it("invokes the app-crate command with no arguments", async () => {
+    const calls = installTauriHost(() => STOPPED);
+
+    const status = await retryDeviceUnlock();
+
+    expect(status.state).toBe("stopped");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cmd).toBe(RETRY_DEVICE_UNLOCK_COMMAND);
+    expect(calls[0]?.args).toEqual({});
+  });
+});
+
+describe("parsing what the commands answer", () => {
+  it("accepts the engine's own shapes", () => {
+    expect(parseInstallResult(ENROLLED).handle).toBe("alice");
+    expect(parseUnlockResult(STOPPED).state).toBe("stopped");
+  });
+
+  // A status is a claim about the key-transparency directory, so a shape that
+  // is nearly right is refused rather than widened into.
+  it("refuses a status that is not one", () => {
+    for (const answer of [
+      null,
+      "enrolled",
+      {},
+      { ...ENROLLED, enrolled: "yes" },
+      { ...ENROLLED, handle: 17 },
+    ]) {
+      expect(() => parseInstallResult(answer)).toThrow(
+        DeviceCredentialInstallError,
+      );
+    }
+    for (const answer of [null, {}, { ...STOPPED, state: "melted" }]) {
+      expect(() => parseUnlockResult(answer)).toThrow(
+        DeviceCredentialInstallError,
+      );
+    }
+  });
+});

--- a/wallet/e2e2z/src/lib/enrollment/installDeviceCredential.ts
+++ b/wallet/e2e2z/src/lib/enrollment/installDeviceCredential.ts
@@ -1,0 +1,144 @@
+/**
+ * Installing the credential the wallet authority issued (#928, ADR 0016 §5).
+ *
+ * `./issueDeviceCredential.ts` ends with a credential's canonical bytes and,
+ * until this module existed, nothing here could consume them. It works in an
+ * app that holds no seed because ADR 0016 moved the seal at rest from the
+ * seed-derived `BackupWrapKey` to a per-device key the engine samples itself.
+ *
+ * Both arguments are public: signed credential bytes, and the handle this
+ * session asked for. A credential is signed under its own `identity_pk`, so it
+ * is self-consistent no matter who minted it — comparing it against the handle
+ * that was requested is the only authenticity check a first enrollment permits,
+ * and the engine performs it.
+ */
+
+import { toHex } from "@free2z/wallet-shared";
+
+import {
+  EngineStatusSchema,
+  EnrollmentStatusSchema,
+  type EngineStatus,
+  type EnrollmentStatus,
+} from "../messaging/types";
+
+/** The app-crate install command. No `plugin:` prefix — §2.2. */
+export const INSTALL_DEVICE_CREDENTIAL_COMMAND = "e2e2z_install_device_credential";
+
+/** The app-crate unlock-retry command. */
+export const RETRY_DEVICE_UNLOCK_COMMAND = "e2e2z_retry_device_unlock";
+
+/**
+ * The install refused, or answered something that is not a status.
+ *
+ * Distinct from `DeviceKeysUnavailableError` because "the wallet would not
+ * issue one" and "it issued one and this device refused it" want different
+ * words in front of a user.
+ */
+export class DeviceCredentialInstallError extends Error {
+  readonly reason = "device-credential-install-failed" as const;
+
+  /** Declared, not `Error`'s ES2022 `options.cause`; this app compiles to ES2020. */
+  readonly cause?: unknown;
+
+  constructor(detail: string, options?: { cause?: unknown }) {
+    super(`this device could not install the issued credential: ${detail}`);
+    this.name = "DeviceCredentialInstallError";
+    this.cause = options?.cause;
+  }
+}
+
+/** Whether a caught value is a {@link DeviceCredentialInstallError}. */
+export function isDeviceCredentialInstallError(
+  error: unknown,
+): error is DeviceCredentialInstallError {
+  return (
+    error instanceof DeviceCredentialInstallError ||
+    (typeof error === "object" &&
+      error !== null &&
+      (error as { reason?: unknown }).reason ===
+        "device-credential-install-failed")
+  );
+}
+
+/**
+ * Parse the install command's response.
+ *
+ * App-crate commands sit outside the plugin's schema contract, so this checks
+ * against the same schema the bridge uses for every other `EnrollmentStatus`.
+ *
+ * @throws {@link DeviceCredentialInstallError}
+ */
+export function parseInstallResult(value: unknown): EnrollmentStatus {
+  const parsed = EnrollmentStatusSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new DeviceCredentialInstallError(
+      "the install command answered something that is not an enrollment status",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}
+
+/** As {@link parseInstallResult}, for the unlock retry's `EngineStatus`. */
+export function parseUnlockResult(value: unknown): EngineStatus {
+  const parsed = EngineStatusSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new DeviceCredentialInstallError(
+      "the unlock retry answered something that is not an engine status",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}
+
+/**
+ * Install a credential the wallet authority issued for `expectedHandle`.
+ *
+ * The credential must be the one issued over the key set this process most
+ * recently prepared: `prepare_device` is not idempotent, and a credential over
+ * discarded keys is refused by the engine's `device_pk` binding.
+ *
+ * @throws {@link DeviceCredentialInstallError}
+ */
+export async function installDeviceCredential(
+  credential: Uint8Array,
+  expectedHandle: string,
+): Promise<EnrollmentStatus> {
+  if (credential.length === 0) {
+    throw new DeviceCredentialInstallError("the credential is empty");
+  }
+  const { invoke } = await import("@tauri-apps/api/core");
+  let answer: unknown;
+  try {
+    answer = await invoke(INSTALL_DEVICE_CREDENTIAL_COMMAND, {
+      args: { credential: toHex(credential), expectedHandle },
+    });
+  } catch (cause) {
+    // f2zmsg errors arrive as a bare `ErrorCode` string, so the code is the
+    // detail. Carried rather than summarised: a refused handle and a store that
+    // would not open are different events.
+    throw new DeviceCredentialInstallError(String(cause), { cause });
+  }
+  return parseInstallResult(answer);
+}
+
+/**
+ * Re-ask this device's secret store for its wrap key and leave §6.1's `locked`.
+ *
+ * ADR 0016 §3 requires this app to have a seed-free exit; the one it replaced
+ * was `f2zmsg_enroll` re-deriving the wrap key from the mnemonic, which only
+ * ZUULI can do.
+ *
+ * @throws {@link DeviceCredentialInstallError}
+ */
+export async function retryDeviceUnlock(): Promise<EngineStatus> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  let answer: unknown;
+  try {
+    answer = await invoke(RETRY_DEVICE_UNLOCK_COMMAND);
+  } catch (cause) {
+    throw new DeviceCredentialInstallError(String(cause), { cause });
+  }
+  return parseUnlockResult(answer);
+}

--- a/wallet/e2e2z/src/lib/messaging/bridge.ts
+++ b/wallet/e2e2z/src/lib/messaging/bridge.ts
@@ -200,10 +200,12 @@ async function invoke<T>(
  * The path is the `issue-device-credential` intent (#905,
  * `rs/crates/f2z-intent`), and it cannot ship yet: custom-scheme deep links are
  * not an authenticated channel, so the cross-surface protocol is blocked on
- * #461. Until it lands there is no honest local implementation, so this app has
- * no enrollment command, no capability addressing one, and — here — no stub
- * that can be mistaken for one. Every call refuses with a distinct, typed
- * refusal the UI presents as "enrollment happens in the wallet app".
+ * #461. Every call still refuses with a typed refusal the UI presents as
+ * "enrollment happens in the wallet app".
+ *
+ * #928 closed the install half — `e2e2z_install_device_credential` exists (ADR
+ * 0016 §5) and `enroll` calls it. Still absent, deliberately: anything that
+ * could *issue* a credential, which needs the seed.
  *
  * What must NOT be done in its place: synthesizing an `EnrollmentStatus`. Every
  * field of one is a claim about the key-transparency directory, and a
@@ -211,12 +213,11 @@ async function invoke<T>(
  * published and offer first contact it cannot complete. Failing closed is the
  * only answer that stays true.
  *
- * `enroll` is no longer a bare refusal: it runs `../enrollment`'s real
- * `issue-device-credential` client, which builds the request the wallet
- * authority would answer and fails at the one seam that has no implementation.
- * The refusal it produces is wrapped back into this type, with the underlying
- * cause attached, so every consumer's branch is unchanged and no shipping build
- * can reach an `EnrollmentStatus` by that path either.
+ * `enroll` is no longer a bare refusal: it runs `../enrollment`'s real client,
+ * fails at the one seam that has no implementation, and — past it — installs
+ * the credential and returns the engine's own status. The refusal is wrapped
+ * back into this type with the cause attached, so consumers' branches are
+ * unchanged, and no status in this path comes from a literal in this file.
  */
 export class EnrollmentUnavailableError extends Error {
   /** Machine-readable, so a caller never has to match on the message. */
@@ -661,30 +662,22 @@ export const enrollment = {
   },
 
   /**
-   * In ZUULI: a directory submission, not an instant effect. Here: an
-   * `issue-device-credential` intent addressed to the wallet authority, which
-   * holds the seed-derived §4.2 `IdentitySigningKey` this app never will.
+   * In ZUULI: a directory submission. Here: an `issue-device-credential` intent
+   * to the wallet authority, then the install of the credential it answers
+   * with.
    *
-   * The request is built for real — through `@free2z/wallet-shared`, over this
-   * device's OS-CSPRNG public keys, byte-identical to what `f2z-intent` parses
-   * — and then fails at the transport, because there is no channel that
-   * authenticates either end (`docs/intent-bridge/PROTOCOL.md` §7, #461).
+   * **It still rejects in every shipping build, for one reason: there is no
+   * transport** (`docs/intent-bridge/PROTOCOL.md` §7, #461). What #928 changed
+   * is that the step after the transport now exists — before ADR 0016 the
+   * install needed the seed-derived `BackupWrapKey` this app must never hold.
    *
-   * **It can only reject.** The declared return type is `EnrollmentStatus` and
-   * there is no expression in this function that produces one: even a
-   * successful round trip yields a `DeviceCredential`, which has to be
-   * installed before any status could be read back, and installing it is
-   * `install_identity`'s job in a process this app does not have a command for.
-   * The refusal is re-wrapped so the screen's branch stays the one it was.
+   * Nothing is fabricated on any path: the status is whatever
+   * `install_identity` reports, and every refusal throws.
    *
-   * The dynamic `import()` is **inside** the `try` deliberately. A chunk that
-   * fails to load — offline, a half-rolled deploy, a stale service worker —
-   * rejects, and outside the `try` that rejection would escape as an untyped
-   * error. It would still fail closed, since nothing about it can produce a
-   * status, but the screen branches on `isEnrollmentUnavailable` and would take
-   * the error path instead of the standing gap path: a user would be told
-   * something broke rather than that enrollment happens in the wallet app. The
-   * typed refusal is the contract, so every way this can fail has to wear it.
+   * The dynamic `import()` is inside the `try` deliberately. A chunk that fails
+   * to load would otherwise escape untyped, and the screen branches on
+   * `isEnrollmentUnavailable` — the user would be told something broke rather
+   * than that enrollment happens in the wallet app.
    */
   async enroll(handle: string): Promise<EnrollmentStatus> {
     if (useMock()) return mockMessaging.enroll(handle);
@@ -692,15 +685,17 @@ export const enrollment = {
       const { createDeviceCredentialClient } = await import(
         "../enrollment/issueDeviceCredential"
       );
-      await createDeviceCredentialClient().requestDeviceCredential(handle);
+      const { installDeviceCredential } = await import(
+        "../enrollment/installDeviceCredential"
+      );
+      const credential =
+        await createDeviceCredentialClient().requestDeviceCredential(handle);
+      // The handle this session asked for, not one read back out of the
+      // answer: the engine compares the credential's signed handle against it.
+      return await installDeviceCredential(credential, handle);
     } catch (cause) {
       throw new EnrollmentUnavailableError("enroll", { cause });
     }
-    // Unreachable while no transport exists, and it must stay unreachable in
-    // the sense that matters: a credential is not a status, and this app has no
-    // way to install one. Refusing here rather than returning a shape is what
-    // keeps `enrolled: true` unfabricatable.
-    return refuseEnrollment("enroll");
   },
 
   async unenroll(confirmation: string): Promise<EnrollmentStatus> {

--- a/wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts
+++ b/wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts
@@ -3,17 +3,16 @@
 // The negative control that matters most, run against the *best* case.
 //
 // `enrollment-gap.test.ts` proves `enroll` refuses when there is nowhere to
-// send an intent. This file proves something stronger and less obvious: even
-// when a transport exists, even when it answers with a perfectly framed,
-// correctly correlated `issue-device-credential` response carrying a
-// credential, `enroll` **still** refuses — because a `DeviceCredential` is not
-// an `EnrollmentStatus`, and this app has no command that could install one.
+// send an intent. This file drives the whole path with a transport in place: a
+// perfectly framed, correctly correlated `issue-device-credential` response
+// carrying a credential, answered by a stand-in for the wallet authority.
 //
-// That is the shape of the mistake this whole boundary exists to prevent: a
-// client that gets a plausible answer and renders itself enrolled. `docs/e2ee/
-// CLIENT-CONTRACT.md` §2.4 states the rule — nothing in e2e2z may fabricate an
-// `EnrollmentStatus` — and a rule that is only true because the happy path is
-// unreachable is a rule that breaks the day the path opens.
+// It used to prove `enroll` refuses even then, because nothing here could
+// install a credential. ADR 0016 §5 changed that, so the property under test is
+// the one that was always the point: **the only `EnrollmentStatus` this app can
+// return is one the engine produced.** `docs/e2ee/CLIENT-CONTRACT.md` §2.4 is
+// the rule — a rule that held only because the happy path was unreachable would
+// have broken the day it opened.
 //
 // jsdom, because this exercises the shipping path end to end: the real lazy
 // `@tauri-apps/api/core` import, the real app-crate command, the real shared
@@ -35,6 +34,7 @@ import {
   type IntentTransport,
 } from "../enrollment/transport";
 import { DEVICE_CREDENTIAL_KEYS_COMMAND } from "../enrollment/deviceKeys";
+import { INSTALL_DEVICE_CREDENTIAL_COMMAND } from "../enrollment/installDeviceCredential";
 import { EnrollmentUnavailableError, enrollment } from "./bridge";
 
 const DEVICE_PK_HEX = "ab".repeat(32);
@@ -66,25 +66,58 @@ function fulfilled(requestId: Uint8Array): Uint8Array {
   ]);
 }
 
-function installTauriHost(): string[] {
-  const invoked: string[] = [];
+/** The status the stand-in engine answers an install with. */
+const INSTALLED = {
+  enrolled: true,
+  handle: "alice",
+  eligibility: { eligible: true, candidate: "alice", reason: null },
+  directoryEntryVersion: null,
+  submittedAt: 1_800_000_000_000,
+  mergedAtEpoch: null,
+  blocked: null,
+};
+
+interface HostCall {
+  readonly cmd: string;
+  readonly args: unknown;
+}
+
+/**
+ * A stand-in for the native side. `install` picks what the install command
+ * does: no such command, a refusal, or an install that answers with a status.
+ */
+function installTauriHost(
+  install: "absent" | "refuse" | "accept" = "absent",
+): HostCall[] {
+  const calls: HostCall[] = [];
   Object.defineProperty(window, "__TAURI_INTERNALS__", {
     configurable: true,
     writable: true,
     value: {
-      invoke(cmd: string) {
-        invoked.push(cmd);
+      invoke(cmd: string, args: unknown) {
+        calls.push({ cmd, args });
         if (cmd === DEVICE_CREDENTIAL_KEYS_COMMAND) {
           return Promise.resolve({
             devicePk: DEVICE_PK_HEX,
             deviceKemPk: KEM_HEX,
           });
         }
+        if (cmd === INSTALL_DEVICE_CREDENTIAL_COMMAND && install === "accept") {
+          return Promise.resolve(INSTALLED);
+        }
+        if (cmd === INSTALL_DEVICE_CREDENTIAL_COMMAND && install === "refuse") {
+          return Promise.reject("handle-ineligible");
+        }
         return Promise.reject(new Error(`Command ${cmd} not found`));
       },
     },
   });
-  return invoked;
+  return calls;
+}
+
+/** The command names a run invoked, in order. */
+function names(calls: readonly HostCall[]): string[] {
+  return calls.map((call) => call.cmd);
 }
 
 afterEach(() => {
@@ -116,8 +149,12 @@ describe("enroll builds a real intent and still cannot enroll", () => {
       EnrollmentUnavailableError,
     );
 
-    // …and it got that far by doing the real work.
-    expect(invoked).toEqual([DEVICE_CREDENTIAL_KEYS_COMMAND]);
+    // …and it got that far by doing the real work, up to a host with no
+    // install command.
+    expect(names(invoked)).toEqual([
+      DEVICE_CREDENTIAL_KEYS_COMMAND,
+      INSTALL_DEVICE_CREDENTIAL_COMMAND,
+    ]);
     expect(sent).toHaveLength(1);
     const decoded = decodeIntentRequest(sent[0] as Uint8Array);
     expect(decoded.ok).toBe(true);
@@ -127,8 +164,8 @@ describe("enroll builds a real intent and still cannot enroll", () => {
     expect(decoded.value.purpose).toBe(ISSUE_DEVICE_CREDENTIAL_PURPOSE);
   });
 
-  it("never resolves to an EnrollmentStatus even on a fulfilled response", async () => {
-    installTauriHost();
+  it("never resolves to a status the engine refused to give", async () => {
+    installTauriHost("refuse");
     setIntentTransport({
       id: "wallet-stand-in",
       available: true,
@@ -143,6 +180,34 @@ describe("enroll builds a real intent and still cannot enroll", () => {
       () => ({ resolved: false as const }),
     );
     expect(settled.resolved).toBe(false);
+  });
+
+  it("installs the credential it received, for the handle it asked for", async () => {
+    const calls = installTauriHost("accept");
+    setIntentTransport({
+      id: "wallet-stand-in",
+      available: true,
+      async dispatch(request) {
+        const decoded = decodeIntentRequest(request);
+        if (!decoded.ok) throw new Error("undecodable request");
+        return fulfilled(decoded.value.requestId);
+      },
+    });
+
+    const status = await enrollment.enroll("alice");
+
+    // The status is the engine's, field for field. Nothing here composes one.
+    expect(status).toEqual(INSTALLED);
+
+    const install = calls.find(
+      (call) => call.cmd === INSTALL_DEVICE_CREDENTIAL_COMMAND,
+    );
+    const args = (install?.args as { args: Record<string, unknown> }).args;
+    // The credential that came back, and the handle this session asked for —
+    // not one read out of the answer, which is #929's distinction.
+    expect(args["credential"]).toBe("33".repeat(96));
+    expect(args["expectedHandle"]).toBe("alice");
+    expect(Object.keys(args).sort()).toEqual(["credential", "expectedHandle"]);
   });
 
   it("keeps the refusal typed, with the underlying cause attached", async () => {

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/bin/peer.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/bin/peer.rs
@@ -464,11 +464,10 @@ async fn enroll(engine: &Engine<SqliteBackend>, options: &Options) -> Result<()>
         .install_identity(IdentityInstall {
             credential: credential_bytes,
             expected_handle: options.handle.clone(),
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: now,
         })
         .await?;
-    engine.unlock(account.backup_wrap.as_bytes()).await?;
+    engine.unlock().await?;
     Ok(())
 }
 

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -251,15 +251,10 @@ pub struct IdentityInstall {
     /// trust-on-first-response permits. What contains the rest is the KT
     /// directory, not this function.
     pub expected_handle: String,
-    /// The seed-derived `BackupWrapKey` (`ARCHITECTURE.md` §4.2), under which
-    /// the device secrets are sealed. §6.1's `locked` is the state this device
-    /// is in whenever it does not have it.
+    /// When this enrollment was submitted, by the installing app's own clock.
     ///
-    /// ADR 0016 (#935) decides this field is removed in favour of a per-device
-    /// `DeviceWrapKey` the plugin samples and seals under itself. That is a
-    /// larger change with its own restore analysis and is deliberately **not**
-    /// bundled with the credential-binding fix; #928 tracks it.
-    pub wrap_key: [u8; 32],
+    /// ADR 0016 §4.2: §3.2 UI bookkeeping, not a security value, so it is taken
+    /// locally rather than from an unauthenticated responder.
     pub submitted_at: i64,
 }
 
@@ -383,8 +378,8 @@ impl<B: StorageBackend> Engine<B> {
     ///
     /// # Errors
     ///
-    /// `not-enrolled` before enrollment, `engine-locked` when the seed-derived
-    /// wrap key has not been supplied this session.
+    /// `not-enrolled` before enrollment, `engine-locked` when this device's
+    /// `DeviceWrapKey` has not opened the seal this session.
     pub async fn start(&self) -> Result<EngineStatus> {
         let mut inner = self.inner.lock().await;
         if inner.state == EngineState::Running || inner.state == EngineState::Degraded {
@@ -402,7 +397,7 @@ impl<B: StorageBackend> Engine<B> {
             self.sink.engine_state(&status);
             return Err(Error::new(
                 ErrorCode::EngineLocked,
-                "the seed-derived wrap key has not been supplied this session",
+                "this device's wrap key has not opened the seal this session",
             ));
         }
 
@@ -686,7 +681,20 @@ impl<B: StorageBackend> Engine<B> {
             // and the UI shows "submitted", not "active".
             merged_at_epoch: None,
         };
-        let sealed = seal(&secrets, &install.wrap_key)?;
+        // ADR 0016 §3. Sampled here rather than in `prepare_device`, where the
+        // ADR's sketch puts it: a whole round trip to the wallet authority sits
+        // between the two and can be refused or abandoned, so a key written at
+        // prepare time is an orphan under a name the next enrollment
+        // overwrites. `prepare_device` still probes custody, so the fail-closed
+        // gate is unchanged.
+        //
+        // The custody write precedes the seal and the commit because the
+        // inverse failure is unrecoverable: secrets committed under a key the
+        // store then refused to keep leave an enrolled device permanently
+        // `locked`. This way round leaves a stray key that opens nothing.
+        let wrap_key = device_wrap_key();
+        self.wrap_key_custody.put_wrap_key(&wrap_key)?;
+        let sealed = seal(&secrets, &wrap_key)?;
         inner.queue_seed = Some(decode_key(&secrets.queue_seed)?);
 
         inner.records().commit(|records| {
@@ -701,14 +709,22 @@ impl<B: StorageBackend> Engine<B> {
         inner.enrollment_status()
     }
 
-    /// Supply the seed-derived wrap key and leave §6.1's `locked`.
+    /// Re-ask the OS secret store for this device's `DeviceWrapKey` and leave
+    /// §6.1's `locked`.
+    ///
+    /// ADR 0016 §3's retry, and it takes no seed — which is what makes it
+    /// reachable from `cash.free2z.e2e2z`, the app with no enrollment path to
+    /// fall back on. Worth retrying: a keychain still shut at launch, or a
+    /// Secret Service daemon not yet up, leaves a `locked` a later attempt
+    /// opens.
     ///
     /// # Errors
     ///
-    /// `not-enrolled` before enrollment, `engine-locked` when the key does not
-    /// open the seal — which is the honest answer: a wrong key is
-    /// indistinguishable from an absent one, and neither can decrypt history.
-    pub async fn unlock(&self, wrap_key: &[u8; 32]) -> Result<EngineStatus> {
+    /// `not-enrolled` before enrollment, `durability-unavailable` when the
+    /// store cannot answer, `engine-locked` when the key does not open the seal
+    /// — a wrong key and an absent one are the same thing to a user.
+    pub async fn unlock(&self) -> Result<EngineStatus> {
+        let wrap_key = self.wrap_key_custody.wrap_key()?;
         let mut inner = self.inner.lock().await;
         let identity = inner
             .records()
@@ -718,7 +734,7 @@ impl<B: StorageBackend> Engine<B> {
             .records()
             .sealed_secrets()?
             .ok_or_else(|| Error::internal("an identity with no sealed secrets"))?;
-        let secrets = open(&sealed, wrap_key)?;
+        let secrets = open(&sealed, &wrap_key)?;
 
         let signer = device_signer(decode_key(&secrets.device_signing_key)?)?;
         let credential_bytes = hex::decode(&identity.credential)
@@ -3542,6 +3558,15 @@ fn prepare_device_material(rng: &mut impl rand::Rng) -> Result<(DevicePublicKeys
     ))
 }
 
+/// Sample a `DeviceWrapKey` (ADR 0016 §3): 32 bytes from the OS CSPRNG, which
+/// is what makes it a device secret in `ARCHITECTURE.md` §4.2's sense. It never
+/// appears in [`DevicePublicKeys`] and never crosses the intent bridge.
+fn device_wrap_key() -> [u8; 32] {
+    let mut key = [0u8; 32];
+    rand::Rng::fill_bytes(&mut rand::rng(), &mut key);
+    key
+}
+
 fn signing_key(seed_hex: &str) -> Result<SigningKey> {
     Ok(SigningKey::from_seed(&decode_key(seed_hex)?))
 }
@@ -5279,8 +5304,15 @@ mod tests {
             Arc::new(NullSink) as Arc<dyn EventSink>,
             Platform::ZuuliDesktop,
         )
-        .unwrap();
+        .unwrap()
+        // The seal under test was written by this device's own custody, which
+        // is where `unlock` now reads it from (ADR 0016 §3).
+        .with_wrap_key_custody(crate::custody::WrapKeyCustody::in_memory());
         let wrap_key = [0x5a; 32];
+        engine
+            .wrap_key_custody()
+            .put_wrap_key(&wrap_key)
+            .expect("the in-memory store accepts a key");
         let sealed = seal(
             &DeviceSecrets {
                 device_signing_key: hex::encode([0; 32]),
@@ -5312,7 +5344,7 @@ mod tests {
         }
 
         let error = engine
-            .unlock(&wrap_key)
+            .unlock()
             .await
             .expect_err("a restored zero signing seed must be refused");
         assert_eq!(error.code(), ErrorCode::Internal);

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -540,8 +540,9 @@ impl<B: StorageBackend> Engine<B> {
     /// Returns `durability-unavailable` if this device has nowhere to durably
     /// hold a `DeviceWrapKey` (#937 — no OS secret store, a locked or absent
     /// one, or a namespace this application does not own), and `internal` if
-    /// the signing-key sample is the forbidden all-zero seed. Both refusals
-    /// happen before pending enrollment state is installed, so a refused
+    /// the device is already enrolled or the signing-key sample is the forbidden
+    /// all-zero seed. These refusals happen before pending enrollment state is
+    /// installed, so a refused
     /// enrollment leaves nothing behind.
     pub async fn prepare_device(&self) -> Result<DevicePublicKeys> {
         self.prepare_device_with(|| prepare_device_material(&mut rand::rng()))
@@ -568,13 +569,18 @@ impl<B: StorageBackend> Engine<B> {
         // signal that protects them, and the log is append-only, so the phantom
         // devices are permanent. `crate::custody`'s module header §3 has the
         // full argument and the option-F alternative that was left on the shelf.
+        let mut inner = self.inner.lock().await;
+        if inner.records().identity()?.is_some() {
+            return Err(Error::internal(
+                "prepare_device requires an unenrolled device",
+            ));
+        }
         self.wrap_key_custody.probe()?;
 
-        // Validate the sampled signing key before taking the lock or changing
+        // Validate the sampled signing key before changing
         // enrollment state. Tests inject a zero-only generator through this
         // exact production route rather than testing an uncalled keygen API.
         let (public, secrets) = prepare()?;
-        let mut inner = self.inner.lock().await;
         inner.pending_device = Some(secrets);
         Ok(public)
     }
@@ -604,10 +610,22 @@ impl<B: StorageBackend> Engine<B> {
     ///
     /// `handle-ineligible` if the credential's handle is not §11.3's charset or
     /// is not the one this enrollment asked for, `internal` if
-    /// [`Engine::prepare_device`] was not called first, the credential does not
-    /// parse, or it does not bind the prepared device key.
+    /// the device is already enrolled, [`Engine::prepare_device`] was not called
+    /// first, the credential does not parse, or it does not bind the prepared
+    /// device key.
     pub async fn install_identity(&self, install: IdentityInstall) -> Result<EnrollmentStatus> {
         let mut inner = self.inner.lock().await;
+        // A custody item has exactly one current key. Replacing it while an
+        // identity exists would destroy that identity's only unlock key if the
+        // following database commit failed or the process stopped before it.
+        // Check under the same lock as installation, including for credentials
+        // prepared before another install completed. Switching identities must
+        // go through explicit unenrollment first.
+        if inner.records().identity()?.is_some() {
+            return Err(Error::internal(
+                "install_identity requires an unenrolled device",
+            ));
+        }
 
         let credential = f2z_msg_mls::credential::parse(&install.credential).map_err(|error| {
             Error::internal(format!("the issued credential does not parse: {error}"))
@@ -718,18 +736,28 @@ impl<B: StorageBackend> Engine<B> {
     /// Secret Service daemon not yet up, leaves a `locked` a later attempt
     /// opens.
     ///
+    /// Already-unlocked engines retain their current state without querying
+    /// custody again.
+    ///
     /// # Errors
     ///
     /// `not-enrolled` before enrollment, `durability-unavailable` when the
     /// store cannot answer, `engine-locked` when the key does not open the seal
     /// — a wrong key and an absent one are the same thing to a user.
     pub async fn unlock(&self) -> Result<EngineStatus> {
-        let wrap_key = self.wrap_key_custody.wrap_key()?;
         let mut inner = self.inner.lock().await;
         let identity = inner
             .records()
             .identity()?
             .ok_or_else(|| Error::not_enrolled("unlock"))?;
+        // A retry may race another retry or arrive after start. Once unlocked,
+        // preserve the live MLS engine, connections, and lifecycle state; a
+        // redundant retry must not silently stop inbound processing. Checking
+        // and loading under one lock also keeps the key paired with its seal.
+        if inner.mls.is_some() {
+            return inner.status(&*self.directory);
+        }
+        let wrap_key = self.wrap_key_custody.wrap_key()?;
         let sealed = inner
             .records()
             .sealed_secrets()?

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs
@@ -33,7 +33,7 @@ fn engine() -> Engine<MemoryBackend> {
 
 /// Enrollment as the app crate performs it (§2.2): the seed stays here, and
 /// only public material reaches the engine.
-async fn enroll(engine: &Engine<MemoryBackend>, handle: &str, seed: u8) -> [u8; 32] {
+async fn enroll(engine: &Engine<MemoryBackend>, handle: &str, seed: u8) {
     let device = engine.prepare_device().await.expect("device keys");
     let account = AccountKeys::from_seed(&[seed; 64], 0).expect("§4.2 keys");
     let credential = account
@@ -46,17 +46,14 @@ async fn enroll(engine: &Engine<MemoryBackend>, handle: &str, seed: u8) -> [u8; 
             not_after_ms: u64::MAX / 2,
         })
         .expect("credential");
-    let wrap_key = *account.backup_wrap.as_bytes();
     engine
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
             expected_handle: handle.to_owned(),
-            wrap_key,
             submitted_at: NOW,
         })
         .await
         .expect("install");
-    wrap_key
 }
 
 #[tokio::test]
@@ -144,7 +141,6 @@ async fn a_flawlessly_signed_credential_for_another_handle_is_refused() {
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&forged).expect("encode"),
             expected_handle: "alice".to_owned(),
-            wrap_key: [9; 32],
             submitted_at: NOW,
         })
         .await
@@ -171,7 +167,6 @@ async fn a_flawlessly_signed_credential_for_another_handle_is_refused() {
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&genuine).expect("encode"),
             expected_handle: "alice".to_owned(),
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
         .await
@@ -209,7 +204,6 @@ async fn an_install_asking_for_a_handle_the_credential_does_not_attest_is_refuse
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
             expected_handle: "bob".to_owned(),
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
         .await
@@ -242,28 +236,49 @@ async fn the_installed_identity_is_read_out_of_the_credential() {
     );
 }
 
+/// The seal opens from the device's own custody, and only from it (ADR 0016 §3):
+/// it opens when the store still holds the key the install wrote, and stays
+/// `locked` when the store answers with a different one.
 #[tokio::test]
-async fn a_wrong_wrap_key_is_indistinguishable_from_an_absent_one() {
+async fn unlock_opens_from_custody_and_a_wrong_key_leaves_it_locked() {
     let engine = engine();
-    let wrap_key = enroll(&engine, "alice", 1).await;
+    enroll(&engine, "alice", 1).await;
 
-    // §6.1's `locked`: enrolled, but local history is wrapped under
-    // `BackupWrapKey` and cannot be decrypted. A wrong key and no key are the
-    // same thing to a user, and the code says the same thing about both.
-    let wrong = engine.unlock(&[0xab; 32]).await.expect_err("must refuse");
-    assert_eq!(wrong.code(), ErrorCode::EngineLocked);
-
-    let status = engine.unlock(&wrap_key).await.expect("unlock");
+    let status = engine.unlock().await.expect("unlock");
     assert_eq!(status.state, EngineState::Stopped);
     assert!(status.enrolled);
     assert_eq!(status.handle.as_deref(), Some("alice"));
+
+    // §6.1's `locked`. A wrong key and no key are the same thing to a user.
+    engine
+        .wrap_key_custody()
+        .put_wrap_key(&[0xab; 32])
+        .expect("the in-memory store accepts a key");
+    let wrong = engine.unlock().await.expect_err("must refuse");
+    assert_eq!(wrong.code(), ErrorCode::EngineLocked);
+}
+
+/// A store that has lost the key is `durability-unavailable`, not
+/// `engine-locked`. The distinction is what tells the UI whether the retry in
+/// ADR 0016 §3.5 is worth offering.
+#[tokio::test]
+async fn a_custody_that_lost_the_key_reports_durability_rather_than_a_bad_seal() {
+    let engine = engine();
+    enroll(&engine, "alice", 1).await;
+    engine
+        .wrap_key_custody()
+        .clear_wrap_key()
+        .expect("the in-memory store forgets a key");
+
+    let refused = engine.unlock().await.expect_err("must refuse");
+    assert_eq!(refused.code(), ErrorCode::DurabilityUnavailable);
 }
 
 #[tokio::test]
 async fn an_in_memory_store_reports_no_durability_and_a_desktop_platform() {
     let engine = engine();
-    let wrap_key = enroll(&engine, "alice", 1).await;
-    engine.unlock(&wrap_key).await.expect("unlock");
+    enroll(&engine, "alice", 1).await;
+    engine.unlock().await.expect("unlock");
 
     let device = engine.device_info().await.expect("device");
     assert_eq!(device.platform, Platform::ZuuliDesktop);
@@ -281,8 +296,8 @@ async fn an_in_memory_store_reports_no_durability_and_a_desktop_platform() {
 #[tokio::test]
 async fn first_contact_fails_closed_rather_than_resolving_an_unverified_key() {
     let engine = engine();
-    let wrap_key = enroll(&engine, "alice", 1).await;
-    engine.unlock(&wrap_key).await.expect("unlock");
+    enroll(&engine, "alice", 1).await;
+    engine.unlock().await.expect("unlock");
 
     // §6.4's first row and §9 rule 5. This is the #133 moment: an unverified
     // key at first contact *is* the MITM, so the refusal is the behaviour and
@@ -315,8 +330,8 @@ async fn safety_number_verification_is_available_regardless_of_directory_state()
     // asserts is the *reason* a caller is turned away: a missing conversation,
     // never `witness-threshold-unmet` or `engine-not-running`.
     let engine = engine();
-    let wrap_key = enroll(&engine, "alice", 1).await;
-    engine.unlock(&wrap_key).await.expect("unlock");
+    enroll(&engine, "alice", 1).await;
+    engine.unlock().await.expect("unlock");
 
     let refused = engine
         .safety_number("no-such-conversation")
@@ -429,8 +444,8 @@ async fn a_conversation_that_never_existed_is_refused_by_every_command_that_name
     // and an absent conversation are different things, and §3.5 is emphatic
     // that absence is never inferred.
     let engine = engine();
-    let wrap_key = enroll(&engine, "alice", 1).await;
-    engine.unlock(&wrap_key).await.expect("unlock");
+    enroll(&engine, "alice", 1).await;
+    engine.unlock().await.expect("unlock");
 
     assert!(engine.list_messages("nope", 50, None, None).await.is_err());
     assert!(engine.list_gaps("nope").await.is_err());

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs
@@ -243,6 +243,7 @@ async fn the_installed_identity_is_read_out_of_the_credential() {
 async fn unlock_opens_from_custody_and_a_wrong_key_leaves_it_locked() {
     let engine = engine();
     enroll(&engine, "alice", 1).await;
+    engine.shutdown().await;
 
     let status = engine.unlock().await.expect("unlock");
     assert_eq!(status.state, EngineState::Stopped);
@@ -250,6 +251,7 @@ async fn unlock_opens_from_custody_and_a_wrong_key_leaves_it_locked() {
     assert_eq!(status.handle.as_deref(), Some("alice"));
 
     // §6.1's `locked`. A wrong key and no key are the same thing to a user.
+    engine.shutdown().await;
     engine
         .wrap_key_custody()
         .put_wrap_key(&[0xab; 32])
@@ -265,6 +267,7 @@ async fn unlock_opens_from_custody_and_a_wrong_key_leaves_it_locked() {
 async fn a_custody_that_lost_the_key_reports_durability_rather_than_a_bad_seal() {
     let engine = engine();
     enroll(&engine, "alice", 1).await;
+    engine.shutdown().await;
     engine
         .wrap_key_custody()
         .clear_wrap_key()
@@ -470,5 +473,134 @@ async fn unenrolling_requires_a_typed_confirmation_and_then_forgets_everything()
     assert_eq!(
         engine.status().await.expect("status").state,
         EngineState::NotEnrolled
+    );
+}
+
+/// A late enrollment response must never replace an installed device's key.
+/// A failed commit made that replacement irreversible before this guard.
+#[tokio::test]
+async fn a_late_install_preserves_the_existing_seal_even_when_writes_fail() {
+    use f2z_msg_store::{Durability, Op, StorageBackend, StoreError};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Clone, Default)]
+    struct FaultableBackend {
+        data: Arc<MemoryBackend>,
+        refuse_writes: Arc<AtomicBool>,
+    }
+    impl StorageBackend for FaultableBackend {
+        fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+            self.data.get(key)
+        }
+        fn apply(&self, ops: &[Op]) -> Result<(), StoreError> {
+            if !ops.is_empty() && self.refuse_writes.load(Ordering::SeqCst) {
+                return Err(StoreError::Backend("injected enrollment commit failure"));
+            }
+            self.data.apply(ops)
+        }
+        fn durability(&self) -> Durability {
+            self.data.durability()
+        }
+    }
+    let backend = FaultableBackend::default();
+    let custody = WrapKeyCustody::in_memory();
+    let open = || {
+        Engine::new(backend.clone(), Arc::new(NullSink), Platform::ZuuliDesktop)
+            .expect("engine")
+            .with_wrap_key_custody(custody.clone())
+    };
+    // Two app sessions can prepare before either has installed. The second
+    // then receives its credential after the first has committed enrollment.
+    let first = open();
+    let late = open();
+    let account = AccountKeys::from_seed(&[1; 64], 0).expect("account");
+    let issue = |device: tauri_plugin_f2zmsg::engine::DevicePublicKeys| {
+        let credential = account
+            .identity
+            .issue_device_credential(&DeviceCredentialRequest {
+                handle: Handle::new(b"alice".to_vec()).expect("handle"),
+                device_pk: PublicKey::new(device.device_pk),
+                device_kem_pk: KemPublicKey::new(device.device_kem_pk).expect("kem"),
+                not_before_ms: 0,
+                not_after_ms: u64::MAX / 2,
+            })
+            .expect("credential");
+        IdentityInstall {
+            credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
+            expected_handle: "alice".to_owned(),
+            submitted_at: NOW,
+        }
+    };
+    let first_install = issue(first.prepare_device().await.expect("first device"));
+    let late_install = issue(late.prepare_device().await.expect("late device"));
+    first
+        .install_identity(first_install)
+        .await
+        .expect("first install");
+    let original_key = custody.wrap_key().expect("installed key");
+    let original_device = first.device_info().await.expect("device").device_id;
+    backend.refuse_writes.store(true, Ordering::SeqCst);
+    late.install_identity(late_install)
+        .await
+        .expect_err("must refuse replacement");
+    assert_eq!(*custody.wrap_key().expect("key remains"), *original_key);
+    backend.refuse_writes.store(false, Ordering::SeqCst);
+    let reopened = open();
+    reopened
+        .unlock()
+        .await
+        .expect("the original seal still opens after restart");
+    assert_eq!(
+        reopened.device_info().await.expect("device").device_id,
+        original_device
+    );
+    first
+        .prepare_device()
+        .await
+        .expect_err("an enrolled device must not prepare a replacement");
+}
+
+#[tokio::test]
+async fn redundant_unlock_preserves_a_running_engine_without_consulting_custody() {
+    let engine = engine();
+    enroll(&engine, "alice", 1).await;
+    let running = engine.start().await.expect("start");
+    assert_eq!(running.state, EngineState::Degraded);
+    let retried = engine.unlock().await.expect("retry with available custody");
+    assert_eq!(
+        retried.state, running.state,
+        "retry must not stop inbound processing"
+    );
+    engine
+        .wrap_key_custody()
+        .clear_wrap_key()
+        .expect("simulate temporarily missing custody");
+    for _ in 0..2 {
+        let retried = engine.unlock().await.expect("already unlocked");
+        assert_eq!(retried.state, running.state);
+        assert_eq!(retried.handle, running.handle);
+    }
+    engine.shutdown().await;
+    assert_eq!(
+        engine
+            .unlock()
+            .await
+            .expect_err("a real unlock needs custody")
+            .code(),
+        ErrorCode::DurabilityUnavailable
+    );
+}
+
+#[tokio::test]
+async fn unlock_of_an_unenrolled_device_does_not_require_custody() {
+    let engine = Engine::new(
+        MemoryBackend::new(),
+        Arc::new(NullSink),
+        Platform::ZuuliDesktop,
+    )
+    .expect("engine");
+    assert_eq!(
+        engine.unlock().await.expect_err("no identity").code(),
+        ErrorCode::NotEnrolled
     );
 }

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/enrollment_refuses_without_custody.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/enrollment_refuses_without_custody.rs
@@ -85,7 +85,6 @@ async fn enroll(engine: &Engine<MemoryBackend>, handle: &str) -> tauri_plugin_f2
             // helper's argument rather than anything read back out of the
             // credential, so the comparison stays a real one.
             expected_handle: handle.to_owned(),
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
         .await?;
@@ -172,7 +171,6 @@ async fn a_refused_enrollment_mints_nothing() {
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
             expected_handle: "someone".to_owned(),
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
         .await
@@ -206,6 +204,75 @@ async fn a_store_that_accepts_writes_and_loses_them_is_not_good_enough() {
         .await
         .expect_err("a store that forgets must refuse before enrollment, not after");
     assert_eq!(refused.code(), ErrorCode::DurabilityUnavailable);
+}
+
+/// The probe is not the last word: a store that passes it and then refuses the
+/// real key leaves the engine unenrolled, not sealed shut.
+///
+/// This pins `install_identity`'s ordering. The opposite order fails the
+/// unrecoverable way — secrets committed under a key the store refused to keep
+/// are an enrolled device that can never open its own seal. Not contrived: a
+/// keychain can lock, or a Secret Service daemon go away, while the wallet
+/// authority is answering.
+#[tokio::test]
+async fn a_store_that_passes_the_probe_and_refuses_the_key_installs_nothing() {
+    let engine = engine(WrapKeyCustody::with_store(
+        tauri_plugin_f2zmsg::custody::WrapKeyNamespace::new("cash.free2z.e2e2z.f2zmsg.wrap.v1")
+            .expect("namespace"),
+        Arc::new(ProbeOnly::default()),
+    ));
+
+    let refused = enroll(&engine, "someone")
+        .await
+        .expect_err("a key that cannot be kept must not be sealed under");
+    assert_eq!(refused.code(), ErrorCode::DurabilityUnavailable);
+
+    // Nothing was minted, so this device can enrol again.
+    let status = engine.enrollment_status().await.expect("status");
+    assert!(!status.enrolled);
+    assert_eq!(status.handle, None);
+    assert_eq!(
+        engine.status().await.expect("status").state,
+        EngineState::Uninitialized
+    );
+}
+
+/// Answers the probe round trip and refuses the real wrap key.
+#[derive(Default)]
+struct ProbeOnly {
+    probes: std::sync::Mutex<std::collections::HashMap<String, zeroize::Zeroizing<String>>>,
+}
+
+impl tauri_plugin_f2zmsg::custody::WrapKeyStore for ProbeOnly {
+    fn put(
+        &self,
+        account: &str,
+        value: &str,
+    ) -> Result<(), tauri_plugin_f2zmsg::custody::CustodyError> {
+        if account == tauri_plugin_f2zmsg::custody::WRAP_KEY_ACCOUNT {
+            return Err(tauri_plugin_f2zmsg::custody::CustodyError::Locked);
+        }
+        self.probes.lock().expect("the probe map").insert(
+            account.to_owned(),
+            zeroize::Zeroizing::new(value.to_owned()),
+        );
+        Ok(())
+    }
+    fn get(
+        &self,
+        account: &str,
+    ) -> Result<zeroize::Zeroizing<String>, tauri_plugin_f2zmsg::custody::CustodyError> {
+        self.probes
+            .lock()
+            .expect("the probe map")
+            .get(account)
+            .cloned()
+            .ok_or(tauri_plugin_f2zmsg::custody::CustodyError::NotFound)
+    }
+    fn delete(&self, account: &str) -> Result<(), tauri_plugin_f2zmsg::custody::CustodyError> {
+        self.probes.lock().expect("the probe map").remove(account);
+        Ok(())
+    }
 }
 
 /// Accepts every write and holds nothing.

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/last_resort_rotation.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/last_resort_rotation.rs
@@ -42,17 +42,15 @@ async fn enrolled_engine() -> Engine<MemoryBackend> {
             not_after_ms: u64::MAX / 2,
         })
         .expect("credential");
-    let wrap_key = *account.backup_wrap.as_bytes();
     engine
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
             expected_handle: "alice".to_owned(),
-            wrap_key,
             submitted_at: NOW,
         })
         .await
         .expect("install");
-    engine.unlock(&wrap_key).await.expect("unlock");
+    engine.unlock().await.expect("unlock");
     engine
 }
 

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
@@ -336,15 +336,11 @@ async fn enroll<B: StorageBackend>(
         .install_identity(IdentityInstall {
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode credential"),
             expected_handle: handle.to_owned(),
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
         .await
         .expect("install identity");
-    engine
-        .unlock(account.backup_wrap.as_bytes())
-        .await
-        .expect("unlock");
+    engine.unlock().await.expect("unlock");
     let directory_auth_pk = PublicKey::new(*account.directory_auth.public().as_bytes());
     (credential, directory_auth_pk)
 }

--- a/wallet/zuuli/src-tauri/src/messaging.rs
+++ b/wallet/zuuli/src-tauri/src/messaging.rs
@@ -21,8 +21,9 @@
 //!
 //! So this module reads the seed **in process** from `tauri-plugin-zcash`'s
 //! managed state, derives §4.2's keys, issues a `DeviceCredential`, and hands
-//! the messaging engine only public material plus the wrap key. The seed never
-//! becomes JSON, never crosses IPC, and never enters the webview. The engine's
+//! the messaging engine **only public material** — since ADR 0016 not even a
+//! wrap key, because the engine seals under one it samples itself. The seed
+//! never becomes JSON, never crosses IPC, and never enters the webview. The engine's
 //! own API — [`Engine::prepare_device`] and [`Engine::install_identity`] — is
 //! shaped so it never sees the seed either: the device secrets are generated
 //! *inside* the engine from the OS CSPRNG and only their public halves come
@@ -50,17 +51,19 @@
 //! `issue-device-credential` intent, and it does not ship before #461 gives it
 //! an authenticated channel — a custom-scheme deep link is not one.
 //!
-//! # `f2zmsg_enroll` is also the unlock path, and that is deliberate
+//! # `f2zmsg_enroll` still unlocks, but it is no longer the only thing that can
 //!
 //! §6.1's `locked` is a real state: after a restart the engine has an identity
-//! in its store but no device signing key, because that key is sealed under the
-//! seed-derived `BackupWrapKey` and the wrap key is not persisted. Nothing in
-//! §3's forty-three plugin commands can lift `locked`, and nothing should be
-//! able to — lifting it needs the seed, which is the whole reason this file
-//! exists. So `f2zmsg_enroll` is idempotent in the strong sense: on a device
-//! that is already enrolled under the requested handle it re-derives the wrap
-//! key and unlocks, rather than refusing. A frontend that calls `enroll` on
-//! launch gets "ready", not an error it has no command to resolve.
+//! but no device signing key, because that key is sealed at rest. Until ADR
+//! 0016 (#935, #928) the seal was under the seed-derived `BackupWrapKey`, so
+//! lifting `locked` needed the seed and therefore needed this file. It is now
+//! under a per-device key the plugin keeps in the OS secret store, so
+//! `Engine::unlock` needs no seed and `cash.free2z.e2e2z` can leave `locked` on
+//! its own.
+//!
+//! This command keeps unlocking anyway, so a frontend that calls `enroll` on
+//! launch gets "ready" rather than an error it cannot resolve — but that is now
+//! a convenience, and the branch no longer reads the seed.
 //!
 //! # These three refuse when the plugin has no engine
 //!
@@ -128,11 +131,6 @@ pub async fn f2zmsg_enroll<R: Runtime>(
 ) -> Result<EnrollmentStatus> {
     let engine = app.f2zmsg().engine_handle()?;
 
-    // Derive first, in every branch. Enrolling and unlocking need the same
-    // §4.2 account keys, and deriving before the branch keeps the seed's
-    // lifetime one short, obvious stretch of this function rather than two.
-    let account = account_keys(&app).await?;
-
     let status = engine.enrollment_status().await?;
     if status.enrolled {
         if status.handle.as_deref() != Some(args.handle.as_str()) {
@@ -152,10 +150,15 @@ pub async fn f2zmsg_enroll<R: Runtime>(
         // next `start_engine` would reconnect relays it was already connected
         // to. Every other state is already unlocked, so there is nothing to do.
         if engine.status().await?.state == EngineState::Locked {
-            engine.unlock(account.backup_wrap.as_bytes()).await?;
+            engine.unlock().await?;
         }
         return engine.enrollment_status().await;
     }
+
+    // Read the seed only on the branch that needs it. Before ADR 0016 both did,
+    // because unlocking meant re-deriving `BackupWrapKey`; now an `enroll` with
+    // nothing to enroll never opens the wallet's custody.
+    let account = account_keys(&app).await?;
 
     // The device keys are generated inside the engine, from the OS CSPRNG, and
     // are deliberately not seed-derivable (§4.2): restoring the mnemonic
@@ -195,11 +198,10 @@ pub async fn f2zmsg_enroll<R: Runtime>(
             // is the same check e2e2z will need when the credential arrives
             // over the intent bridge instead (#936).
             expected_handle: args.handle,
-            wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: now,
         })
         .await?;
-    engine.unlock(account.backup_wrap.as_bytes()).await?;
+    engine.unlock().await?;
     engine.enrollment_status().await
 }
 


### PR DESCRIPTION
Closes #928. Implements [ADR 0016](docs/e2ee/decisions/0016-enrollment-sealing-boundary.md) §3, §4 and §5.

**The wire format does not change.** No field is added to `IssueDeviceCredentialResultV1`, so `PROTOCOL.md` §3.6's 130-byte vector, the `f2z-intent` conformance vectors and `wallet/zuuli/src/lib/intent-bridge.test.ts` are untouched. This follows the correction on the issue rather than its original acceptance criteria, which would have shipped a seed-derived key into e2e2z.

## Sealing moves off the seed (§3)

`install_identity` samples a `DeviceWrapKey` from the OS CSPRNG, writes it to the custody #937 built, and seals under it. `IdentityInstall` loses `wrap_key`; `Engine::unlock` takes no key and re-asks the store.

Two ordering decisions, both written down at the call site:

- **The custody write precedes the seal and the commit.** The inverse order fails unrecoverably: secrets committed under a key the store then refused to keep are an enrolled device that can never open its own seal, whose only exit is `unenroll`. This way round leaves a stray key that opens nothing.
- **The key is sampled at install, not at `prepare_device`** where §3's sketch puts it. A round trip to the wallet authority sits between the two and can be refused, abandoned, or answered with a credential this device must reject; a key written at prepare time outlives all three under a name the next enrollment overwrites. `prepare_device` still probes custody, so §3.5's fail-closed gate is unchanged.

## The install step (§5)

e2e2z gains two app-crate commands, neither needing a capability entry nor a `zcash:*` grant:

- `e2e2z_install_device_credential` — the step whose absence meant the round trip could not complete even with a transport. Two arguments, both public: the credential's bytes and the handle **this session requested**. `deny_unknown_fields` refuses a third.
- `e2e2z_retry_device_unlock` — the seed-free exit from `locked` that §3 requires an app with no enrollment path to have. It replaces `f2zmsg_enroll` re-deriving the wrap key from the mnemonic, which only ZUULI can do.

`bridge.ts`'s `enroll` installs what comes back and returns the engine's own status. It still rejects in every shipping build, for one reason: there is no transport (#461).

ZUULI stops passing `account.backup_wrap`, and its already-enrolled branch no longer reads the seed at all.

## What this does not mean

`device_kem_pk` stays open (ADR 0016 §6). When #461 lands, a completed round trip proves the **transport** works, not that enrollment does. `status.md` records that so nobody infers otherwise. ZUULI's authority side still answers `issue-device-credential` with `INTENT_UNKNOWN_INTENT` — the issue puts that out of scope.

## Docs

`CLIENT-CONTRACT.md` §6.1 is reworded in both places ADR 0016 §10 flags as covered by no test, and its state diagram with them. `THREAT-MODEL.md`'s at-rest claim is narrowed to what the seal actually covers — the SQLite database beside it is not encrypted, and Fact 6 says so.

## Verification

- `tauri-plugin-f2zmsg`: `cargo test` 90 + 2 + 14 + 5, plus the `relay-harness` suite; `clippy --all-targets --features relay-harness` and `fmt` clean
- `e2e2z`: 7 Rust tests, 281 vitest, 9 Playwright, both typechecks, `clippy` and `fmt` clean
- ZUULI: `cargo check --all-targets`, `clippy --all-targets`, `fmt` clean
- `messaging-contract.node-test.mjs` 9/9, `project-boundary.mjs`, `surface-capability-authority.mjs`, `authority-boundary.node-test.mjs` (unchanged, which is the mechanical statement that the boundary held), `check-markdown-links.mjs`, `check-tauri-plugin-permissions.mjs`

New tests, rather than adjusted ones:

- a store that passes the probe and then refuses the real key installs nothing — pins the ordering above
- a custody that lost the key reports `durability-unavailable`, not `engine-locked`; the distinction is what tells the UI whether the §3.5 retry is worth offering
- the install arguments carry a credential and a handle and nothing else, asserted in both Rust and TypeScript
- `enroll` installs the credential that came back over the bridge, for the handle it asked for, and returns the engine's status field for field

`enroll-intent.test.ts` was rewritten rather than patched: its premise was that this app has no command that could install a credential, which is no longer true. The property it now pins is the one that was always the point — the only `EnrollmentStatus` this app can return is one the engine produced.