### PR TITLE
release: prepare current internal TestFlight audit and sibling builds (#1010)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,8 @@ authority, why the division exists, and what mechanically enforces it.
 Issues: [#904](https://github.com/free2z/zuu/issues/904) (the split),
 [#367](https://github.com/free2z/zuu/issues/367) (the driver),
 [#905](https://github.com/free2z/zuu/issues/905) (the bridge),
-[#461](https://github.com/free2z/zuu/issues/461) (the blocking prerequisite).
+[#461](https://github.com/free2z/zuu/issues/461) (closed association-declaration history;
+transport remains in #905).
 
 Companion documents. This page deliberately does **not** restate them:
 
@@ -90,7 +91,7 @@ authority **nor** messaging keys.
 | Holds | master seed, spending keys, account-level messaging keys | Knox token, 2Z balance | device keys + device credential |
 | Renders remote content | never | **yes** — articles, creator, live, AI, search | never |
 | Privileged plugins | `zcash` | **none** | `f2zmsg` |
-| Bundle `active` | `true` | `false` (native layer unwired, [#918](https://github.com/free2z/zuu/issues/918)) | `true` |
+| Bundle `active` | `true` | `true` (native layer landed in [#942](https://github.com/free2z/zuu/pull/942), closing #918) | `true` |
 
 ### 3.1 What makes the content surface safe
 
@@ -192,13 +193,16 @@ person approving it, so shipping it first because it "only signs" is backwards.
 ## 6. What is not built yet
 
 Read [`status.md`](./status.md) rather than inferring from this page. In short:
-there is **no transport** ([#461](https://github.com/free2z/zuu/issues/461)),
+there is **no transport** ([#905](https://github.com/free2z/zuu/issues/905));
+#461 closed after client association declarations landed, without implementing
+the channel.
 `sign-challenge` has neither a caller nor an authority-side implementation, and
 `issue-device-credential` has a caller and an install step but **no
 authority-side implementation** — ZUULI still answers it `INTENT_UNKNOWN_INTENT`
 ([`intent.rs`](../wallet/zuuli/src-tauri/src/intent.rs)), so nothing issues a
 credential over the bridge. What [#928](https://github.com/free2z/zuu/issues/928)
 closed is the step *after* that one: e2e2z can now install a credential it
-receives, which it could not before. free2z's native layer is
-unwired ([#918](https://github.com/free2z/zuu/issues/918)), and ZUULI's phase-4
-hardening is in progress.
+receives, which it could not before. Free2Z's native layer landed in
+[#942](https://github.com/free2z/zuu/pull/942), closing #918; its production
+HTTP capability remains scoped and stateless, without wallet or device-key
+authority. ZUULI's phase-4 hardening is in progress.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,165 +1,119 @@
 # Status of the three-app split
 
-What works, what fails closed on purpose, and what is blocked. Last derived
-against `main` on **2026-09-04**.
+Source and availability re-derived on **2026-09-10** for the internal
+TestFlight refresh in [#1010](https://github.com/free2z/zuu/issues/1010).
+The exact audited source and release evidence are recorded in
+[`wallet/zuuli/STATUS.md`](../wallet/zuuli/STATUS.md).
 
-This page exists so that no other page has to hedge. If something here
-contradicts a claim elsewhere in the repository, this page is the one that was
-checked against the tree — and the other page is a bug.
+**The three apps are separate, but they do not communicate through the intent
+bridge yet.** Both shipping transport implementations refuse dispatch. Building,
+signing or installing the apps together does not change that behavior.
 
-> **The one-line summary.** The three apps exist, build, and are held apart by
-> the required CI gate. **No intent can cross between them**, because there is
-> no transport. Every cross-app feature you can see in the UI stops at a single
-> named seam and says so.
-
-Per-app detail stays in the per-app documents:
-[`wallet/zuuli/STATUS.md`](../wallet/zuuli/STATUS.md),
-[`wallet/free2z/README.md`](../wallet/free2z/README.md),
-[`wallet/e2e2z/README.md`](../wallet/e2e2z/README.md).
-
-Store-side state — what each app looks like in Google Play Console, and what is
-blocking it — is in
-[`docs/release/PLAY-STORE-SETUP.md`](release/PLAY-STORE-SETUP.md). That page
-records console state, which nothing in this repository can prove; this page
-records the tree.
-
----
+Per-app details:
+[`ZUULI readiness`](../wallet/zuuli/STATUS.md),
+[`Free2Z`](../wallet/free2z/README.md), and
+[`E2E2Z`](../wallet/e2e2z/README.md).
+Store setup has its own evidence in
+[`release/PLAY-STORE-SETUP.md`](release/PLAY-STORE-SETUP.md); source declarations
+are not observations from a store or a physical device.
 
 ## 1. What works
 
-| | Evidence |
-| --- | --- |
-| Three apps exist as buildable Tauri projects with distinct identifiers | `wallet/{zuuli,free2z,e2e2z}/src-tauri/tauri.conf.json` |
-| free2z has **no** privileged capability and **no** IPC surface at all | `wallet/free2z/src-tauri/src/lib.rs` registers no `invoke_handler`; its `Cargo.toml` links neither wallet plugin |
-| e2e2z holds **no** Zcash code | `wallet/e2e2z/src-tauri/Cargo.lock` contains zero `zcash_*`/`orchard`/`sapling` crates |
-| Those two properties are enforced, not asserted | `wallet/zuuli/scripts/surface-capability-authority.mjs`, run by `npm run test` inside the required `zuuli / frontend` gate job |
-| No import crosses between wallet applications | `wallet/zuuli/scripts/project-boundary.mjs`, same gate |
-| One versioned wire format, agreed byte-for-byte by two implementations | the same 130-byte vector pinned by hand in `rs/crates/f2z-intent/tests/wire_vectors.rs` **and** `wallet/zuuli/src/lib/intent-bridge.test.ts` |
-| Every bridge guard has a mutation-verified test | [`intent-bridge/CONFORMANCE.md`](./intent-bridge/CONFORMANCE.md) |
-| `execute-payment` is implemented end-to-end **on ZUULI's side of the seam** | `wallet/zuuli/src-tauri/src/intent.rs` — admit, propose, re-derive the review, confirm natively, bind, execute |
-| Content surfaces are ported to free2z: articles, creator, live, AI, search | `wallet/free2z/src/features/` |
-| The messaging surface is ported to e2e2z | `wallet/e2e2z/src/features/messages/` |
-| Both delegated surfaces' own test suites can fail a merge | the `surfaces` job in `.github/workflows/zuuli.yml`, awaited by the required `gate` (#915) |
+The following are source implementations and automated checks. They do not
+claim authenticated, money-moving, or signed-device product acceptance.
 
-Merged for the split, in order: [#909](https://github.com/free2z/zuu/pull/909)
-scaffolds · [#911](https://github.com/free2z/zuu/pull/911) intent protocol ·
-[#919](https://github.com/free2z/zuu/pull/919) CI gate ·
-[#914](https://github.com/free2z/zuu/pull/914) ZUULI authority side ·
-[#913](https://github.com/free2z/zuu/pull/913) messaging → e2e2z ·
-[#912](https://github.com/free2z/zuu/pull/912) articles/creator → free2z ·
-[#920](https://github.com/free2z/zuu/pull/920) live/AI/search → free2z ·
-[#926](https://github.com/free2z/zuu/pull/926) e2e2z caller ·
-[#924](https://github.com/free2z/zuu/pull/924) free2z caller.
+| Surface | Implemented and checked | Remaining boundary |
+| --- | --- | --- |
+| ZUULI | Wallet vault, registered Zcash plugin, narrow content policy, no messaging capability grants. `execute-payment` has an authority-side proposal, native confirmation and execution path | No bridge transport; physical wallet operations retain their explicit evidence gaps in the readiness matrix |
+| Free2Z | Articles, creator/profile, Live, AI, Search and revenue-share surfaces. Scoped native HTTP is registered; the bundle is active and uses its own deep-link scheme | No wallet or messaging plugin and no app `invoke_handler`. Packaged social OAuth is deliberately unavailable; password sign-in is present but this audit performs no authenticated operation |
+| E2E2Z | Messaging plugin, device public-key preparation, credential installation and seed-free unlock retry. Diagnostics viewing is present | No Zcash dependency or seed authority. Credential installation does not provide a transport or a credential issuer |
+| Boundaries | `project-boundary.mjs`, `surface-capability-authority.mjs`, the delegated suites and the required gate enforce application separation and registered plugin/permission contracts | A passed check proves its tested contract, not OS link verification or a completed user operation |
+| Intent wire format | Shared Rust/TypeScript vectors and [conformance tests](intent-bridge/CONFORMANCE.md) cover requests, responses and outcome uncertainty | Correlation does not authenticate the caller or response destination |
+
+Free2Z's native layer landed in [#942](https://github.com/free2z/zuu/pull/942),
+closing [#918](https://github.com/free2z/zuu/issues/918). HTTP is scoped and
+stateless; the ten wallet OAuth commands were **not** copied into the content
+app. Its packaged OAuth transport returns unavailable before opening a provider.
+The earlier claim that the app's native layer is unwired and its bundle inactive
+is obsolete.
 
 ## 2. What fails closed, by design
 
-These are built, validated, tested — and then refuse. That is the intended
-behaviour today, not an outage.
-
 ### 2.1 There is no transport
 
-**Nothing can cross between the apps.** Verified App Links / Universal Links
-([#461](https://github.com/free2z/zuu/issues/461)) are not wired, and a
-custom-scheme deep link is not an authenticated channel — any app can register
-`zuuli://`, so shipping on one would recreate
-[#367](https://github.com/free2z/zuu/issues/367)'s confused deputy at the OS
-layer instead of the frame layer.
-
-Both callers build a real, validated request and then stop at **one named
-seam**:
-
-| Caller | The seam | Behaviour |
+| Caller | Shipping seam | Behavior |
 | --- | --- | --- |
-| `wallet/free2z/src/lib/bridge/intent-transport.ts` | `installedIntentTransport` | rejects with `IntentTransportUnavailableError`, code `INTENT_TRANSPORT_UNAVAILABLE`, reason naming #461 |
-| `wallet/e2e2z/src/lib/enrollment/transport.ts` | the single `IntentTransport` implementation | rejects before device keys are sampled, and again unconditionally inside `dispatch` |
+| Free2Z | `wallet/free2z/src/lib/bridge/intent-transport.ts` → `installedIntentTransport` | Rejects with `IntentTransportUnavailableError`; no intent is sent |
+| E2E2Z | `wallet/e2e2z/src/lib/enrollment/transport.ts` → installed `IntentTransport` | Refuses before preparing device keys and refuses dispatch |
 
-Neither seam has a flag, an environment check, or an "if a wallet is installed"
-branch — those are the shapes that decay into a channel nobody reviewed.
-`rs/crates/f2z-intent` contains no URL parsing, no intent filter and no scheme,
-for the same reason. When #461 lands, the work is to write an `IntentTransport`
-and register it; nothing else on either path changes.
+Client App Link/Universal Link declarations landed in
+[#977](https://github.com/free2z/zuu/pull/977). The closed
+[#461](https://github.com/free2z/zuu/issues/461) records that association work;
+its closure does not implement an `IntentTransport`. Both refusal types still
+name #461 in source, so that reference in an error is historical rather than a
+live implementation milestone. Remaining bridge work is tracked by
+[#905](https://github.com/free2z/zuu/issues/905).
 
-The creator-tip UI is honest about this: only three outcomes may tell a payer
-that nothing was sent — no transport, a request that could not be built, and an
-explicit `INTENT_NOT_CONFIRMED` from the wallet. A lost answer or an
-`INTENT_UNAVAILABLE` sends the payer to ZUULI to look instead of reassuring
-them.
+On 2026-09-10, `free2z.com`'s AASA returned 200 and was byte-identical to
+[`association/apple-app-site-association.json`](intent-bridge/association/apple-app-site-association.json).
+Its `assetlinks.json` endpoint returned 503. No signed-device link-verification
+result was recorded in this audit. Serving an association, OS verification and
+implementing a transport are separate requirements.
+
+Free2Z's creator-tip response handling also preserves uncertainty: a lost answer,
+`INTENT_UNAVAILABLE` or an unfamiliar status cannot assure the payer that nothing
+happened. The guarded caller does not become a usable payment path until the
+transport exists.
 
 ### 2.2 `sign-challenge` has no caller and no implementation
 
-ZUULI refuses it with `INTENT_UNKNOWN_INTENT`, and that status is not a lie:
-this build genuinely does not implement it. The ordering is deliberate —
-[`AUTHORITY.md`](./intent-bridge/AUTHORITY.md) §3: a challenge is an opaque
-nonce that confirms nothing to the person approving it, so absent caller
-attestation both "who is asking" and "why" are attacker-chosen. Shipping it
-first because it "only signs" is backwards.
-
-The visible consequence today: free2z's **Login with Zcash** is *absent rather
-than stubbed behind a button that cannot work*. Password and linked accounts
-work; the Zcash method is missing and the login screen says so
-(`wallet/free2z/src/features/auth/`).
-
-Anything else that would depend on `sign-challenge` should be expected to be
-absent for the same reason. The Profile and revenue-share surfaces have not
-been ported yet — that is [#927](https://github.com/free2z/zuu/pull/927), still
-open at the time of writing.
+ZUULI answers this family with `INTENT_UNKNOWN_INTENT`. Free2Z's Login with Zcash
+is absent. The security decision remains in
+[`intent-bridge/AUTHORITY.md`](intent-bridge/AUTHORITY.md): caller attestation
+and a meaningful confirmation cannot be substituted with an opaque challenge.
+Profile and revenue-share were ported in [#927](https://github.com/free2z/zuu/pull/927);
+they are no longer missing app surfaces.
 
 ### 2.3 e2e2z shows no enrolled state
 
-Every enrollment call refuses with a typed
-`EnrollmentUnavailableError { reason: "enrollment-requires-wallet-app" }`
-without reaching Tauri IPC, and the screen renders a standing "enrollment
-happens in the wallet app" state: no claim control, no conversation list, no
-engine start/stop. Nothing synthesises an `EnrollmentStatus` — every field of
-one is a claim about the key transparency directory, and a fabricated
-`enrolled: true` would show a handle nobody published.
+[#1009](https://github.com/free2z/zuu/pull/1009) implements the install side of
+[ADR 0016](e2ee/decisions/0016-enrollment-sealing-boundary.md): the engine stores
+a device-local wrap key in the application's own custody namespace, installs a
+signed credential, and offers a seed-free unlock retry. A repeated install
+cannot overwrite an enrolled device's key; an already-unlocked retry preserves
+the engine's running state. The wire result still contains only credential bytes.
+
+**Enrollment is still unavailable in shipping builds.** The transport refuses,
+ZUULI has no `issue-device-credential` authority handler, and ADR 0016 §6 leaves
+`device_kem_pk` unresolved. The shipping directory also remains `NoDirectory`.
+No directory identity, witness policy or working chat session is supplied by this
+install step. The UI retains its wallet-app enrollment refusal and does not
+synthesize an enrolled status.
 
 ## 3. What is blocked
 
-| Issue | What it blocks |
+| Work | Current disposition |
 | --- | --- |
-| [**#461**](https://github.com/free2z/zuu/issues/461) | *Everything cross-app.* Verified App Links / Universal Links need `assetlinks.json` and `apple-app-site-association` served from a domain we control. **The client half has landed:** all three apps claim `applinks:free2z.com` and carry an `autoVerify` intent filter on their own `/bridge/<app>/` prefix, and [`intent-bridge/association/`](./intent-bridge/association/README.md) holds the reviewed record. **Still blocking:** the Android document is not served — the host returns `503` until the three Play App Signing fingerprints are deployed — and nothing has been verified on a signed device on either platform |
-| [**#928**](https://github.com/free2z/zuu/issues/928) | Enrollment could not complete **even with a transport**: `install_identity` required the seed-derived `BackupWrapKey`, which e2e2z must never hold, and e2e2z registered no install command. **Decided in [ADR 0016](./e2ee/decisions/0016-enrollment-sealing-boundary.md)** (2026-09-05) and now **implemented**: the engine seals under a per-device `DeviceWrapKey` it samples and keeps in each app's own secret-store namespace, `IdentityInstall` lost its `wrap_key`, `Engine::unlock` takes no key and is reachable from e2e2z, and e2e2z registers `e2e2z_install_device_credential` and `e2e2z_retry_device_unlock`. The wire format is untouched — no field was added, so §3.6's vector still holds. **Still missing:** the transport (#461), ZUULI's `issue-device-credential` authority handler (currently `INTENT_UNKNOWN_INTENT`), and the `device_kem_pk` binding (ADR 0016 §6). Installing a returned credential does not complete these parts of enrollment |
-| [**#918**](https://github.com/free2z/zuu/issues/918) | free2z's native layer is unwired — the HTTP plugin, the OAuth transport, and its own deep-link scheme. Its bundle is `"active": false` |
-| [**#904**](https://github.com/free2z/zuu/issues/904) phase 4 | ZUULI's hardening. See §4 |
+| Cross-app transport and caller authentication | Unimplemented; #905 and [caller-authentication decisions](intent-bridge/CALLER-AUTHENTICATION.md). No shipping dispatch path |
+| Credential issuance through the intent authority | `INTENT_UNKNOWN_INTENT`; an E2E2Z install command does not issue a credential |
+| Messaging KEM/directory deployment | ADR 0016 §6 and the undecided directory/witness configuration remain open |
+| Signed-device acceptance | Internal distribution supplies builds for observation; physical install, wallet and OS-link evidence remain separate requirements |
+| Public release and broader tester rollout | Deferred while the readiness matrix contains unresolved operations and store-presentation gaps |
 
-**Therefore: no user can claim a messaging handle in any shipped build.** #928's
-install half has landed. The request still cannot leave the app without #461's
-authenticated channel, and ZUULI still has no authority handler to issue the
-credential when it arrives. The `device_kem_pk` binding also remains unresolved:
-a round trip that completes would still attest a key nobody holds.
+## 4. ZUULI hardening
 
-Also open against the bridge, and worth reading before building on it:
-[#929](https://github.com/free2z/zuu/issues/929) (correlation is not
-authentication, and two clients now depend on it) and
-[#930](https://github.com/free2z/zuu/issues/930) (`INTENT_UNAVAILABLE` does not
-mean "nothing happened").
-
-## 4. In progress: hardening ZUULI
-
-[#904](https://github.com/free2z/zuu/issues/904) phase 4. The ports were
-**copies**, so removing the content surfaces from ZUULI is a separate step and
-is being worked now — do not infer ZUULI's current feature set from this page.
-
-The target state:
-
-- ZUULI renders no third-party content, so it needs no permissive CSP and can
-  drop the markdown and embed dependency tree.
-- Its capabilities are re-scoped to what a wallet authority actually needs.
-- The known hazard recorded on #904 is addressed: the Zcash plugin's seed lock
-  is **label-blind** — `WindowEvent::Focused(false)` ignores the label, which is
-  harmless with one window and wrong with two.
-
-Until that lands, ZUULI still contains the surfaces that were copied out of it.
+The vault extraction landed in [#943](https://github.com/free2z/zuu/pull/943),
+and [#955](https://github.com/free2z/zuu/pull/955) completed the capture-permission,
+entitlement and store-copy cleanup. ZUULI no longer mounts the content or
+messaging frontends. Its remaining feature directories are `about`, `auth`,
+`home` and `wallet`; both capability files omit `f2zmsg:*`. The messaging plugin
+remains linked for the app-crate enrollment API, which needs separate native
+authority review and is not proof of usable messaging. Native acceptance is
+still governed by the readiness record, not by the removal of those surfaces.
 
 ## 5. Keeping this page true
 
-This is the page most likely to go stale, which is why the root
-[`README.md`](../README.md) points at it rather than restating it. When you
-change any of the following, update the corresponding row here in the same pull
-request:
-
-- a transport seam stops rejecting;
-- an intent family gains an authority-side implementation;
-- a delegated surface gains or loses a capability or a plugin;
-- an issue in §3 closes.
+Update this page when a transport starts dispatching, an intent family gains an
+authority implementation, a delegated app changes its capabilities, or recorded
+source/store/device evidence changes. An issue closing is a reason to inspect the
+implementation, not proof that every dependent feature works.

--- a/wallet/e2e2z/release.json
+++ b/wallet/e2e2z/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.e2e2z",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 3,
+  "build": 4,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/e2e2z/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.e2e2z"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "3").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "4").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist
+++ b/wallet/e2e2z/src-tauri/gen/apple/e2e2z_iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/wallet/e2e2z/src-tauri/gen/apple/project.yml
+++ b/wallet/e2e2z/src-tauri/gen/apple/project.yml
@@ -52,7 +52,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "3"
+        CFBundleVersion: "4"
     entitlements:
       path: e2e2z_iOS/e2e2z_iOS.entitlements
     scheme:

--- a/wallet/e2e2z/src-tauri/tauri.conf.json
+++ b/wallet/e2e2z/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "3",
+      "bundleVersion": "4",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 3
+      "versionCode": 4
     }
   },
   "plugins": {

--- a/wallet/free2z/release.json
+++ b/wallet/free2z/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.free2z",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 2,
+  "build": 3,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/free2z/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/free2z/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.free2z"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "2").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "3").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/free2z/src-tauri/gen/apple/free2z_iOS/Info.plist
+++ b/wallet/free2z/src-tauri/gen/apple/free2z_iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/wallet/free2z/src-tauri/gen/apple/project.yml
+++ b/wallet/free2z/src-tauri/gen/apple/project.yml
@@ -52,7 +52,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "2"
+        CFBundleVersion: "3"
     entitlements:
       path: free2z_iOS/free2z_iOS.entitlements
     scheme:

--- a/wallet/free2z/src-tauri/tauri.conf.json
+++ b/wallet/free2z/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "2",
+      "bundleVersion": "3",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 2
+      "versionCode": 3
     }
   },
   "plugins": {

--- a/wallet/zuuli/STATUS.md
+++ b/wallet/zuuli/STATUS.md
@@ -22,9 +22,14 @@ it.
 **Source re-derivation and its limits**
 
 The previous substantive audit, [#986](https://github.com/free2z/zuu/pull/986),
-reviewed `44bee1a6accc8713fdb07eedb300cc94ed807089` on 2026-09-08. The current
-source was compared against that complete tree, including the shared packages,
-plugins and release/checker surfaces. The changes since it are:
+reviewed `44bee1a6accc8713fdb07eedb300cc94ed807089` on 2026-09-08. This
+preparation's substantive comparison used merged source
+`822721c6513f277e557bcc93693348a3918d0747` against that complete tree, including
+the shared packages, plugins and release/checker surfaces. The dated source,
+CI and store observations below remain historical evidence when a later narrow
+recheck advances the top marker; that recheck must inspect the intervening diff
+and retain or revise every disposition. Advancing the marker does not rerun an
+operation or bind an older CI run to a different tree. The compared changes are:
 
 - [#986](https://github.com/free2z/zuu/pull/986) itself updated the reviewed
   status-document seal. That checker change is release-impacting even though
@@ -48,8 +53,9 @@ plugins and release/checker surfaces. The changes since it are:
   coverage, #1004 corrects names of Android negative controls, and #1003/#1006
   record CI/merge-queue findings. None is a new ZUULI runtime operation.
 
-[#1009](https://github.com/free2z/zuu/pull/1009) merged at this audit's exact
-source anchor on 2026-09-10 at 20:29:11 UTC. Its complete merged tree matches
+[#1009](https://github.com/free2z/zuu/pull/1009) merged as
+`822721c6513f277e557bcc93693348a3918d0747` on 2026-09-10 at 20:29:11 UTC.
+That complete merged tree matches
 reviewed head `48cf3e4e698f2fc200415456bccf43d70a2a0c27`. It moves enrollment
 sealing to app-owned device custody and adds the E2E2Z install/retry commands.
 The review also fixed a second install overwriting a live device's wrap key
@@ -80,11 +86,12 @@ messaging enrollment.
 
 **Build and execution evidence**
 
-The audited source records ZUULI `0.1.0+21`, Free2Z `0.1.0+2`, and E2E2Z
-`0.1.0+3`, which are independent app identities. This preparation PR also carries
+At substantive-audit source `822721c6513f277e557bcc93693348a3918d0747`,
+the identities were ZUULI `0.1.0+21`, Free2Z `0.1.0+2`, and E2E2Z `0.1.0+3`.
+These are independent app identities. Preparation PR #1011 carries
 reviewed mechanical sibling bumps to Free2Z `0.1.0+3` and E2E2Z `0.1.0+4`;
 those generated version changes do not establish signing or delivery. ZUULI
-remains on build 21 here and needs a separate audit-marker/build-22 ceremony.
+stays on build 21 in #1011; build 22 requires a separate audit-marker/release ceremony.
 On 2026-09-10 GitHub still reports ZUULI's latest protected release
 as [run 34086094245](https://github.com/free2z/zuu/actions/runs/34086094245):
 build 21 failed at `Pin immutable source` before signing or uploading. The
@@ -103,8 +110,9 @@ A separate GET-only App Store Connect readback on 2026-09-10 observed E2E2Z
 `6809219101`, 20:15:28 UTC). Both were `VALID`, `IN_BETA_TESTING`, unexpired,
 and present in an internal group's build relationship. This is distribution
 evidence for those existing sibling builds only. Their groups do not grant
-access to every future build automatically; proposed builds 4/3 have not been
-dispatched or observed, and each needs its own exact-build/group readback. No
+access to every future build automatically. As of those recorded readbacks,
+proposed builds 4/3 had not been dispatched or observed; each subsequent upload
+needs its own exact-build/group readback. No
 tester identities or authenticated product operations were queried.
 
 The [#1009 packaging smoke](https://github.com/free2z/zuu/actions/runs/34522898810)
@@ -113,19 +121,19 @@ identity, unsigned iOS target app, unsigned Android AAB, Linux packages and the
 macOS universal app. These are credential-free packages, not signed-device
 operations. The matching [wallet gate](https://github.com/free2z/zuu/actions/runs/34522898867)
 completed successfully on that same head, including Windows native lint. The
-merged tree comparison above binds these results to the source anchor. A green
+merged tree comparison above binds these results specifically to `822721c6`. A green
 selected job establishes only the check it actually executed; skipped jobs
 supply no new evidence. The historical protected-release evidence in the six-row
 table below retains its original run identities and retention limits.
 
-**Committed alongside this audit, and therefore not part of its marker:**
-this document, its `STATUS_DOCUMENT_SHA256` seal in `scripts/status-freshness.mjs`,
-corrections to the three-app status and architecture pages, and generated sibling version
-files. Before the later mechanical
-release-identity commit, re-audit this merged status/checker change and record
-that merged SHA in the marker. The checker itself is release-impacting: leaving
-the marker before this PR would make the release stale again. No checker rule
-is relaxed by this audit.
+**Preparation changes after the substantive comparison source `822721c6`:**
+PR #1011 contains this document, its `STATUS_DOCUMENT_SHA256` seal in
+`scripts/status-freshness.mjs`, corrections to the three-app status and
+architecture pages, and generated sibling version files. The later mechanical
+release ceremony must re-audit the merged preparation diff and record its merged
+SHA in the top marker. The checker itself is release-impacting: leaving that
+marker before #1011 would make the release stale again. These preparation
+changes do not add runtime evidence, and no checker rule is relaxed.
 
 ## Evidence boundaries
 
@@ -176,10 +184,10 @@ execution, not a permanent artifact archive.
 
 | Surface | Real API/backend dependency | Native integration | Automated evidence | Production/native evidence | Current status and linked gaps |
 |---|---|---|---|---|---|
-| Runtime transport and content-security policy | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri; both capability files allow only `https://free2z.cash/*`, `https://*.free2z.cash/*` and `https://stage.free2z.cash/*` | Historical [#995 wallet-gate evidence](https://github.com/free2z/zuu/actions/runs/34191205336) and [packaging smoke](https://github.com/free2z/zuu/actions/runs/34191205364) cover the prior audited tree `44bee1a6`; current candidate checks are recorded above. `csp-policy.mjs` and its `tests/csp-policy.pw.ts` browser suite load the packaged `src-tauri/tauri.conf.json` policy itself. [#943](https://github.com/free2z/zuu/pull/943) narrowed that policy to `img-src 'self' data:` with `media-src`, `worker-src`, `object-src` and `frame-src` at `'none'`, and `connect-src` limited to `'self'` plus the free2z origins | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The CSP is now narrow because the surfaces that needed it wide were removed, not because a permissive policy was made safe. `#801`'s remote-image allowance and `blob:` `img-src` are **gone** with the reader that used them. **2026-09-10 internal disposition:** Retain for internal observation; packaged production HTTP remains unproven. |
+| Runtime transport and content-security policy | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri; both capability files allow only `https://free2z.cash/*`, `https://*.free2z.cash/*` and `https://stage.free2z.cash/*` | Historical [#995 wallet-gate evidence](https://github.com/free2z/zuu/actions/runs/34191205336) and [packaging smoke](https://github.com/free2z/zuu/actions/runs/34191205364) cover the prior audited tree `44bee1a6`; the checks for merged `822721c6` are recorded above. `csp-policy.mjs` and its `tests/csp-policy.pw.ts` browser suite load the packaged `src-tauri/tauri.conf.json` policy itself. [#943](https://github.com/free2z/zuu/pull/943) narrowed that policy to `img-src 'self' data:` with `media-src`, `worker-src`, `object-src` and `frame-src` at `'none'`, and `connect-src` limited to `'self'` plus the free2z origins | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The CSP is now narrow because the surfaces that needed it wide were removed, not because a permissive policy was made safe. `#801`'s remote-image allowance and `blob:` `img-src` are **gone** with the reader that used them. **2026-09-10 internal disposition:** Retain for internal observation; packaged production HTTP remains unproven. |
 | App shell, mobile navigation, and localization | None | Safe-area insets and the mobile tab bar are native-surface concerns | Playwright geometry suites at 320/360px cover the primary nav and the More sheet. [#869](https://github.com/free2z/zuu/pull/869) fixed a real defect: `DialogContent`'s variant-scoped `ltr:-translate-x-1/2` was not dropped by tailwind-merge when the sheet overrode it with an unprefixed `translate-x-0`, so once the entrance animation's effect was removed the base utility won and the sheet snapped to `translateX(-50%)` — dialog `left` at **-160 at 320px and -180 at 360px**, exactly `-width/2`, deterministically on every run. `navigation.pw.ts` now waits on the dialog's own `getAnimations()` instead of measuring mid-tween. [#863](https://github.com/free2z/zuu/pull/863) gives Sonner toasts safe-area-aware offsets that clear the whole mobile tab bar; [#861](https://github.com/free2z/zuu/pull/861) mirrors layout for RTL locales, isolates bidi identifiers, and adds a source-policy gate against physical-direction utilities | No signed build has been observed on a physical device at any viewport. All geometry evidence is headless browser measurement | **Source and browser-test evidence only; never device-confirmed.** [#943](https://github.com/free2z/zuu/pull/943) also shrank what the shell navigates to: the More sheet now holds **Log in and About**, because Articles, Messages, Profile and Revenue share are no longer this app's surfaces. The build-18/19 off-screen More-sheet defect is fixed in source and covered by a test proven to fail without the fix, and has **not** been confirmed on a device. Physical-device acceptance: [#331](https://github.com/free2z/zuu/issues/331), [#238](https://github.com/free2z/zuu/issues/238). **2026-09-10 internal disposition:** Retain for internal device checks; browser geometry and locale tests are not device acceptance. |
 | About & Feedback | None for the About row; the feedback handoff opens an external mail client or GitHub | Build identity is injected at bundle time from canonical `release.json`, the checked-out full source SHA, and the Tauri build platform; the OS opener performs the handoff | [#822](https://github.com/free2z/zuu/pull/822) binds version/build/channel/platform/source identity through release verification and artifact provenance, with drift, offline, clipboard, keyboard, screen-reader, and enlarged-text tests. [#823](https://github.com/free2z/zuu/pull/823) shows the complete outgoing subject and body before any handoff, keeps diagnostic attachment unavailable in the feedback composer, and scrubs wallet/auth/network/path/encoded-secret shapes at review and again before copy. [#868](https://github.com/free2z/zuu/pull/868) middle-truncates the commit SHA through the shared `truncateAddress()` helper instead of a head-only `slice(0, 12)`, scopes BIP-39 mnemonic detection explicitly to English and surfaces that limit in the composer copy, and fixes the regression where the new ellipsis matched the scrubber's own path shape and redacted every report. [#872](https://github.com/free2z/zuu/pull/872) binds the browser identity test to canonical `release.json` instead of a pinned build literal, so the test now actually asserts the binding `#822` claims — the literal matched only by coincidence of the current build and failed the required gate on the first release bump after it | No feedback report has been composed or sent from a signed build, and no build has been observed displaying its own identity on a device | **New visible surface in build 20; source and test evidence only.** The scrubber is a best-effort redactor over text the user can still edit before sending; it is not a guarantee, and non-English mnemonics are explicitly out of its detection scope and said so in the UI. Nothing here is device-proven. **2026-09-10 internal disposition:** Retain for internal identity/handoff checks without claiming a signed-device result. |
-| Local diagnostics capture | No API, upload endpoint, or telemetry SDK | Browser/WebView error and rejection listeners; bootstrap and React boundary reporters; localStorage when available | `src/lib/diagnostics.test.ts` verifies ZUULI build identity and recovery-phrase redaction. Shared capture/redaction tests and E2E2Z's real-browser rejection, reload, and no-request controls cover the shared implementation; the historical frontend jobs passed on reviewed #995 head; current candidate checks are identified above | No signed ZUULI diagnostic capture or recovery has been observed | **Source/test evidence only.** #978 installs local capture; ZUULI has no diagnostic viewing/export UI and its feedback composer still refuses diagnostic attachment. Redaction bounds free text, does not guarantee all prose is secret-free, and must not substitute for safe error construction. Native panic capture: [#980](https://github.com/free2z/zuu/issues/980). **2026-09-10 internal disposition:** Retain local-only capture; no upload or signed-device recovery claim. |
+| Local diagnostics capture | No API, upload endpoint, or telemetry SDK | Browser/WebView error and rejection listeners; bootstrap and React boundary reporters; localStorage when available | `src/lib/diagnostics.test.ts` verifies ZUULI build identity and recovery-phrase redaction. Shared capture/redaction tests and E2E2Z's real-browser rejection, reload, and no-request controls cover the shared implementation; the historical frontend jobs passed on reviewed #995 head; the checks for merged `822721c6` are identified above | No signed ZUULI diagnostic capture or recovery has been observed | **Source/test evidence only.** #978 installs local capture; ZUULI has no diagnostic viewing/export UI and its feedback composer still refuses diagnostic attachment. Redaction bounds free text, does not guarantee all prose is secret-free, and must not substitute for safe error construction. Native panic capture: [#980](https://github.com/free2z/zuu/issues/980). **2026-09-10 internal disposition:** Retain local-only capture; no upload or signed-device recovery claim. |
 | Username/password and TOTP sign-in | Knox Basic login, OTP status/login, and authenticated user endpoints | Token-backed HTTP; no special native plugin | Session-boundary, login-destination, component, and browser lifecycle tests | Anonymous protected reads returned HTTP 403; no successful production login is recorded | **Wired, not runtime-proven; not release-ready.** Server-side TOTP enforcement: [#369](https://github.com/free2z/zuu/issues/369). Token custody: [#377](https://github.com/free2z/zuu/issues/377). **2026-09-10 internal disposition:** Retain for internal authenticated testing; no successful login or TOTP enforcement is claimed. |
 | Login/link with Zcash | `auth/zcash/challenge` and `auth/zcash/login` | The shared plugin supports local recovery-phrase restore and transparent-address Zcash Signed Message signing | Native atomic-restore/signing tests and frontend restore/challenge lifecycle tests exercise local contracts | No production restore → native signature → Knox session round trip is recorded | **Restore is implemented and contract-tested, but the login path is not runtime-proven.** Recovery-phrase restore landed in [#428](https://github.com/free2z/zuu/pull/428); external-wallet signing remains unsupported. Physical recovery ceremony: [#246](https://github.com/free2z/zuu/issues/246). Wallet/login identity choice: [#329](https://github.com/free2z/zuu/issues/329). This is not ZIP-304. **2026-09-10 internal disposition:** Retain for isolated internal recovery/sign-in testing; no production session is claimed. |
 | Social login/link | Provider discovery, authorization start, callback exchange, and authenticated user endpoints | Desktop loopback and mobile private-scheme OAuth transports exist. #977 adds a separate verified-link claim for `/bridge/zuuli/`; it does not migrate the OAuth callback | Strict discovery parsing, transport selection, attempt fencing, error/retry UI, and 320/360 browser tests cover the client contract; the live preflight fails closed before opening provider URLs | Both discovery endpoints answered anonymously with HTTP 200 on 2026-09-10. The web/desktop endpoint reports `x` with `configured: true`, `google` and `github` `configured: false`; the mobile endpoint returns all three `configured: false`. No OAuth round trip is recorded on any platform | **Client contract fixed; backend-dependent and not runtime-proven.** A provider is selectable on desktop/web; none is on mobile. A `configured` flag is not a login — no authorization start, callback exchange, or resulting session has been performed on any platform, so signed-device login/link proof remains blocked. Public client follow-up: [#403](https://github.com/free2z/zuu/issues/403). Claimed-HTTPS release proof: [#242](https://github.com/free2z/zuu/issues/242). Association binding: [#380](https://github.com/free2z/zuu/issues/380). **2026-09-10 internal disposition:** Mobile providers remain unconfigured and unavailable; do not bypass discovery to expose one. |
@@ -194,7 +202,7 @@ execution, not a permanent artifact archive.
 
 ## Current production and distribution evidence
 
-Safe unauthenticated requests were **re-run fresh for this anchor** on
+Safe unauthenticated requests were **re-run for the substantive audit** on
 2026-09-10 at 20:10:59 UTC against the endpoints ZUULI's remaining surfaces actually reach, and
 returned the following status and top-level contracts:
 
@@ -336,10 +344,12 @@ operation. The AI-charging, Live-media and KYC-capture
 items the older pre-vault audit listed are not "still unmet" — those surfaces were
 removed, so they are off this app's checklist rather than outstanding on it.
 
-Every signed artifact named above predates the split. **Nothing in this anchor
-has been packaged into a signed build, uploaded, or read back from any store**,
-so the distribution evidence in this section is evidence about the pre-vault
-ZUULI. The store listing copy was corrected in `#955` and is in this anchor; the
+Every signed ZUULI artifact named above predates the split. **As of the
+2026-09-10 20:29:45 UTC store observation, substantive-audit source `822721c6`
+had no evidenced signed package, upload, or store readback**. The distribution
+evidence in this section therefore concerns pre-vault ZUULI, independently of
+any subsequent release ceremony. The store listing copy was corrected in
+`#955` and is present in `822721c6`; the
 twenty shipped screenshots still show routes this source does not mount.
 
 Read the "release stop" dispositions above for what they say. They bar calling

--- a/wallet/zuuli/STATUS.md
+++ b/wallet/zuuli/STATUS.md
@@ -8,248 +8,124 @@ back from the named store. Authenticated, money-moving, and wallet operations
 are not called working without recorded evidence from that path.
 
 Last re-derived from `origin/main` at
-`44bee1a6accc8713fdb07eedb300cc94ed807089` on 2026-09-08. Before a release,
+`822721c6513f277e557bcc93693348a3918d0747` on 2026-09-10. Before a release,
 update the evidence and disposition for every non-ready row; do not carry this
 commit or date forward mechanically.
 
-This re-derive is not a build cut, and it follows a failed one. **No signed
-build has been cut since `0.1.0+20`.**
-[#976](https://github.com/free2z/zuu/pull/976) wrote the identity `0.1.0+21`
-into `release.json` at `7fe1b0a8`, before this anchor, and the
-protected release that push fired
-([run 34086094245](https://github.com/free2z/zuu/actions/runs/34086094245))
-**failed in its first job**, `Pin immutable source`, because this document had
-not been re-derived after the release-impacting changes listed below. Nothing
-was built, signed, uploaded, or tagged; no protected environment was entered
-and no credential was materialized in that protected run. Later credential-free
-packaging smoke built unsigned packages with identity `0.1.0+21`; no signed or
-store-distributed build 21 is evidenced.
+This audit supports the **existing internal TestFlight cohort**, tracked in
+[#1010](https://github.com/free2z/zuu/issues/1010). It does not approve a public
+release or widening the tester cohort. The row dispositions below retain the
+missing authenticated and physical-device evidence explicitly. Internal builds
+are how that evidence is collected; neither this audit nor the build supplies
+it.
 
-The previous anchor `e129284c` was recorded by
-[#955](https://github.com/free2z/zuu/pull/955), and it was stale the moment it
-merged: [#954](https://github.com/free2z/zuu/pull/954) landed between the commit
-`#955` audited and `#955`'s own merge, so the recorded anchor never covered its
-own parent. That rebase race, not a content error, is the first thing this
-re-derive corrects. Twenty-two first-parent commits landed on `main` between
-`e129284c` and this anchor. The ZUULI changes below still reach a signed ZUULI
-build for the first time in the *next* build; separate-app evidence does not establish that
-this wallet source has shipped.
+**Source re-derivation and its limits**
 
-The split is the reason this document changed shape rather than only its
-evidence. ZUULI is no longer the app the previous anchor described:
+The previous substantive audit, [#986](https://github.com/free2z/zuu/pull/986),
+reviewed `44bee1a6accc8713fdb07eedb300cc94ed807089` on 2026-09-08. The current
+source was compared against that complete tree, including the shared packages,
+plugins and release/checker surfaces. The changes since it are:
 
-- **ZUULI is now a wallet vault.**
-  [#943](https://github.com/free2z/zuu/pull/943) (#904 phase 4) took
-  `src/features/` from twelve directories to four — `about`, `auth`, `home`,
-  `wallet` — deleted the entire Markdown/Mermaid/remote-media tree, dropped the
-  frontend lockfile from 709 to 351 packages, narrowed the packaged CSP to
-  `img-src 'self' data:` with `media-src`, `worker-src`, `object-src` and
-  `frame-src` all `'none'` and `connect-src` limited to `'self'` plus free2z,
-  and removed every `f2zmsg:*` capability grant from both capability files.
-- **The content and messaging surfaces moved into their own apps.**
-  [#912](https://github.com/free2z/zuu/pull/912) (articles),
-  [#920](https://github.com/free2z/zuu/pull/920) (Live, AI, Search),
-  [#927](https://github.com/free2z/zuu/pull/927) (Profile and revenue-share
-  application) and [#938](https://github.com/free2z/zuu/pull/938) (their
-  Playwright coverage) built `wallet/free2z`;
-  [#913](https://github.com/free2z/zuu/pull/913) built `wallet/e2e2z` and
-  [#941](https://github.com/free2z/zuu/pull/941) gave it a mobile release path;
-  [#909](https://github.com/free2z/zuu/pull/909) and
-  [#942](https://github.com/free2z/zuu/pull/942) scaffolded and wired their
-  native layers. Since the previous anchor both of those apps have moved on
-  without ZUULI: [#963](https://github.com/free2z/zuu/pull/963) stood up the
-  free2z mobile release path and
-  [#972](https://github.com/free2z/zuu/pull/972) cut `cash.free2z.free2z`
-  `0.1.0+2`, while [#959](https://github.com/free2z/zuu/pull/959),
-  [#968](https://github.com/free2z/zuu/pull/968) and
-  [#974](https://github.com/free2z/zuu/pull/974) cut and fixed
-  `cash.free2z.e2e2z` `0.1.0+2`. Those are separate apps with separate
-  evidence, and **none of their store or build evidence is ZUULI's**. For
-  **this** document they only subtract: a row deleted below is a surface ZUULI
-  no longer ships, not a surface that became proven somewhere else.
-- **The cross-surface intent bridge**, which is how a delegated surface asks
-  this one to spend: [#911](https://github.com/free2z/zuu/pull/911) (versioned
-  protocol, no transport), [#914](https://github.com/free2z/zuu/pull/914) (the
-  ZUULI authority side, natively confirmed),
-  [#924](https://github.com/free2z/zuu/pull/924) (the free2z caller side),
-  [#926](https://github.com/free2z/zuu/pull/926) (the issue-device-credential
-  intent, still fail closed), and ADR 0016
-  ([#935](https://github.com/free2z/zuu/pull/935)) on where enrollment sealing
-  happens. Custom-scheme deep links are not an authenticated channel, so no
-  cross-surface transport ships: [#461](https://github.com/free2z/zuu/issues/461).
-- **`rs/` messaging and key transparency** —
-  [#944](https://github.com/free2z/zuu/pull/944),
-  [#953](https://github.com/free2z/zuu/pull/953),
-  [#950](https://github.com/free2z/zuu/pull/950),
-  [#937](https://github.com/free2z/zuu/pull/937),
-  [#902](https://github.com/free2z/zuu/pull/902),
-  [#899](https://github.com/free2z/zuu/pull/899),
-  [#898](https://github.com/free2z/zuu/pull/898),
-  [#897](https://github.com/free2z/zuu/pull/897),
-  [#896](https://github.com/free2z/zuu/pull/896),
-  [#895](https://github.com/free2z/zuu/pull/895),
-  [#885](https://github.com/free2z/zuu/pull/885),
-  [#882](https://github.com/free2z/zuu/pull/882),
-  [#879](https://github.com/free2z/zuu/pull/879), and
-  [#878](https://github.com/free2z/zuu/pull/878).
-- **ZUULI-local and tooling** —
-  [#875](https://github.com/free2z/zuu/pull/875) (TestFlight beta-tester invite
-  capability), [#888](https://github.com/free2z/zuu/pull/888) (the release-step
-  evidence policy this document's disposition table answers to),
-  [#886](https://github.com/free2z/zuu/pull/886),
-  [#883](https://github.com/free2z/zuu/pull/883),
-  [#919](https://github.com/free2z/zuu/pull/919),
-  [#933](https://github.com/free2z/zuu/pull/933),
-  [#932](https://github.com/free2z/zuu/pull/932),
-  [#887](https://github.com/free2z/zuu/pull/887), and
-  [#881](https://github.com/free2z/zuu/pull/881).
+- [#986](https://github.com/free2z/zuu/pull/986) itself updated the reviewed
+  status-document seal. That checker change is release-impacting even though
+  it changes no product operation; the old marker did not cover it.
+- [#996](https://github.com/free2z/zuu/pull/996) preserves uncertainty when an
+  intent response has an unfamiliar status. Shared wire/caller handling and
+  ZUULI's intent fixture changed. An unknown answer must not become evidence
+  that no payment happened. This is a tested response contract, not a live
+  payment or a cross-app transport.
+- [#997](https://github.com/free2z/zuu/pull/997) anchors the auth-session
+  source guard to parsed TypeScript declarations. It changes test selection of
+  guarded declarations, not the sign-in or token-custody implementation.
+- [#1002](https://github.com/free2z/zuu/pull/1002) gives cold all-root clippy
+  builds time to finish; [#1008](https://github.com/free2z/zuu/pull/1008)
+  isolates Ubuntu package installation from unrelated APT sources. Both change
+  required CI execution, not proof of a product operation.
+- [#999](https://github.com/free2z/zuu/pull/999) updates the parser in the
+  Free2Z and legacy web dependency trees; [#1005](https://github.com/free2z/zuu/pull/1005)
+  contains detached asynchronous failures in Free2Z. They affect the delegated
+  content app, not ZUULI's removed content frontend. #1000 expands code-owner
+  coverage, #1004 corrects names of Android negative controls, and #1003/#1006
+  record CI/merge-queue findings. None is a new ZUULI runtime operation.
 
-**What the previous anchor listed as *not yet* in it, and what has landed
-since.** The vault cleanup `#943` deferred is now in this source and verified
-against it: [#945](https://github.com/free2z/zuu/issues/945) dropped the Android
-`CAMERA`/`RECORD_AUDIO`/`MODIFY_AUDIO_SETTINGS` permissions, the macOS
-`com.apple.security.device.camera`/`.audio-input` entitlements, and the Apple
-camera/microphone usage strings; [#946](https://github.com/free2z/zuu/issues/946)
-was this document and the store listing; and
-[#916](https://github.com/free2z/zuu/issues/916) was verified as already closed
-by `#943`. All three shipped in `#955`, and at this anchor
-`src-tauri/gen/android/app/src/main/AndroidManifest.xml` declares
-`android.permission.INTERNET` and nothing else. The release-impacting changes
-after that are:
+[#1009](https://github.com/free2z/zuu/pull/1009) merged at this audit's exact
+source anchor on 2026-09-10 at 20:29:11 UTC. Its complete merged tree matches
+reviewed head `48cf3e4e698f2fc200415456bccf43d70a2a0c27`. It moves enrollment
+sealing to app-owned device custody and adds the E2E2Z install/retry commands.
+The review also fixed a second install overwriting a live device's wrap key
+before a failed commit, and an unlock retry silently stopping an active engine.
+A first install remains available; an enrolled device refuses preparation and
+replacement before custody mutation, and a loaded engine retains its state on
+retry. Local pinned Rust tests pass 118 cases (one real-keychain case deliberately
+ignored); three new lifecycle regressions each fail against the original PR
+implementation. These tests prove the custody/lifecycle contracts, not a native
+Keychain ceremony, existing-device migration, or cross-app enrollment.
 
-- [#954](https://github.com/free2z/zuu/pull/954) added `wallet/free2z` to
-  `scripts/rtl-source-policy.mjs`'s reviewed surfaces with an empty residual
-  inventory and pinned its one directional-transform site. The policy checker
-  lives in ZUULI's `scripts/` and is gated by ZUULI's own suite, so a change to
-  it is release-impacting here even though the defect it fixed was free2z's.
-- [#957](https://github.com/free2z/zuu/pull/957) added prose/delegated-test
-  exclusions to the `wallet/zuuli` workflow and gated the surface suites, and
-  [#963](https://github.com/free2z/zuu/pull/963) extended the same workflow
-  again. Job selection is now conditional, so **which** jobs a given commit's
-  gate actually ran has to be read off that commit's run rather than assumed.
-- [#962](https://github.com/free2z/zuu/pull/962) added
-  `scripts/verify-signing-identity.mjs` and wired a certificate-against-profile
-  preflight into `zuuli-release.yml`, so an imported `.p12` holding an identity
-  the provisioning profile does not embed now fails before signing. Its
-  disposition under [`docs/releasing.md`](docs/releasing.md) is option 2, the
-  mutation-sensitive fixture `scripts/verify-signing-identity.node-test.mjs`.
-  **The preflight itself has never executed in a protected release run**: the
-  only release fired since it merged is build 21's, which failed in
-  `Pin immutable source` before any signing job started.
-- [#966](https://github.com/free2z/zuu/pull/966) added
-  [`docs/export-classification.md`](docs/export-classification.md), a per-app
-  export-compliance record. It is a reviewed written record, not evidence of a
-  filing or of any store's acceptance of one.
-- [#971](https://github.com/free2z/zuu/pull/971) changed
-  `wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs` while fixing the fake
-  relay's keepalive. ZUULI links that plugin for enrollment only and grants its
-  webview no `f2zmsg:` permission, so this changes the crate ZUULI builds
-  without changing anything ZUULI can reach.
-- [#976](https://github.com/free2z/zuu/pull/976) is the build-21 identity
-  itself, described above.
-- [#979](https://github.com/free2z/zuu/pull/979) deleted the dead content-API
-  client layer the previous anchor recorded as residual: the profile, AI,
-  articles, comments, live and KYC clients, the livestream/subscription/search
-  helpers, the `tuzi` subscription methods and the `discover` creator-page
-  methods, with their fixtures, types and contract tests. `src/lib/api/` now
-  holds only `checkout`, `donation`, `http`, `social-providers`, and the trimmed
-  `free2z`/`mock-data`/`types`. This removes unreachable code; it proves nothing
-  new about the surfaces that remain.
+The unchanged wallet, authentication, checkout, shell and vault-boundary source
+retains its prior source/test evidence and its prior missing native evidence.
+Every non-ready row below was reconsidered for this **internal-only** cut; no
+row was upgraded merely because code compiled or a different app shipped.
 
-- [#977](https://github.com/free2z/zuu/pull/977) added each app's separate
-  `https://free2z.com/bridge/<app>/` App Link / Universal Link claim,
-  regenerated Android filters and iOS associated-domain entitlements, and
-  added mutation-sensitive association and release-identity checks. ZUULI's
-  OAuth registration tests now distinguish its two existing custom-scheme
-  routes from the third, domain-bound bridge route. This is client
-  registration evidence only: it neither supplies bridge transport nor proves
-  OS verification or an OAuth round trip on a signed device. The serving-side
-  deployment and device verification remain tracked in
-  [#461](https://github.com/free2z/zuu/issues/461).
-- [#985](https://github.com/free2z/zuu/pull/985) advanced E2E2Z's release
-  identity to `0.1.0+3`; that is separate from ZUULI's build 21.
-- [#978](https://github.com/free2z/zuu/pull/978) installed shared local
-  diagnostics capture in all three apps. ZUULI now records window errors,
-  unhandled rejections, bootstrap failures and error-boundary failures into a
-  bounded store, with localStorage persistence when available. Its About
-  feedback composer still attaches no diagnostics and has no diagnostics
-  screen; E2E2Z alone gained the screen. This changes ZUULI's runtime data
-  handling even though it adds no ZUULI UI or upload path. The shared
-  redactor runs before storage, but short ordinary prose can survive, so
-  error messages must not interpolate sensitive user content. Native panic
-  capture remains separate work in [#980](https://github.com/free2z/zuu/issues/980).
+The cross-app product is still unavailable. Both installed transports reject;
+ZUULI still has no `issue-device-credential` authority handler, and the
+credential's `device_kem_pk` binding remains unresolved in ADR 0016 §6. Client
+App Link/Universal Link declarations landed in #977. The now-closed
+[#461](https://github.com/free2z/zuu/issues/461) is historical association work,
+not evidence that a transport was implemented. On 2026-09-10 the production
+AASA returned 200 and exactly matched the reviewed repository bytes, while
+`assetlinks.json` still returned 503. No signed-device OS verification was
+recorded. The live bridge scope remains [#905](https://github.com/free2z/zuu/issues/905).
+Do not describe this internal build as providing cross-app payments or working
+messaging enrollment.
 
-- [#992](https://github.com/free2z/zuu/pull/992) added independent Free2Z and
-  E2E2Z store catalogs, icons, feature graphics and their validators. Those
-  catalogs are checked by ZUULI's store tooling, so this changes the wallet's
-  release-validation inputs without replacing ZUULI's historical screenshots.
-- [#993](https://github.com/free2z/zuu/pull/993) removed the unused ZUULI
-  `article-tags`, `private-live` and `participant-count` helpers and their two
-  isolated tests. No mounted wallet flow changes; Free2Z retains its own live
-  implementations. This finishes another piece of the vault source cleanup.
-- [#994](https://github.com/free2z/zuu/pull/994) separates Rust selection from
-  frontend selection. The new production-source exemption is limited to
-  TS/TSX/CSS beneath the three app `src/` trees, alongside the existing prose
-  and delegated-test exemptions. The embedded messaging bridge, fixtures,
-  shared packages, scripts, unknown inputs and native/release configuration still select it. The policy
-  inventories Rust embeds across `wallet/` and `rs/`, and the required gate
-  rejects missing or skipped selected Rust jobs. Missing bases and failed diffs
-  still select the full suite. A release-number/configuration bump intentionally
-  continues to run native checks. This changes CI selection, not product proof.
-- [#995](https://github.com/free2z/zuu/pull/995) adds six draft screenshots per
-  delegated app, covering two views at phone, seven-inch and ten-inch tablet
-  geometries, with two matching capture passes and source/tooling hashes.
-  These are pinned Linux Chromium renders of production frontend bundles:
-  Free2Z uses signed-out public editorial fixtures; E2E2Z simulates its
-  unenrolled native contract and empty local diagnostics. They prove neither
-  physical Android behavior nor working enrollment/chat. Both catalogs retain
-  `publicationReady: false` pending copy reconciliation and owner review.
-  Capture also exposed overlapping Free2Z navigation labels at 360px; shorter
-  localized labels preserve descriptive accessible names and have a rendered
-  overlap regression. ZUULI's old screenshots are unchanged. See the
-  [capture evidence](../../docs/release/SURFACE-STORE-CAPTURE.md).
+**Build and execution evidence**
 
-**What is committed alongside this re-derive and is therefore *not* in the
-anchor:** this document, and the `STATUS_DOCUMENT_SHA256` re-pin in
-`scripts/status-freshness.mjs` that seals it. Nothing else.
+The audited source records ZUULI `0.1.0+21`, Free2Z `0.1.0+2`, and E2E2Z
+`0.1.0+3`, which are independent app identities. This preparation PR also carries
+reviewed mechanical sibling bumps to Free2Z `0.1.0+3` and E2E2Z `0.1.0+4`;
+those generated version changes do not establish signing or delivery. ZUULI
+remains on build 21 here and needs a separate audit-marker/build-22 ceremony.
+On 2026-09-10 GitHub still reports ZUULI's latest protected release
+as [run 34086094245](https://github.com/free2z/zuu/actions/runs/34086094245):
+build 21 failed at `Pin immutable source` before signing or uploading. The
+latest successful protected ZUULI run remains
+[build 20](https://github.com/free2z/zuu/actions/runs/33494458918). Its recorded
+store readbacks below prove distribution of the **pre-vault** app, not physical
+acceptance of this source. A fresh GET-only App Store Connect audit on
+2026-09-10 at 20:29:43 UTC confirmed exact ZUULI `0.1.0+20` build
+`9282bd69-a781-44e1-9621-4457aa5daf0f` as `VALID`, `IN_BETA_TESTING`, unexpired,
+with `usesNonExemptEncryption: false` and its exact build linked to existing
+internal groups. At 20:29:45 UTC, exact `0.1.0+21` was absent (`uploaded: false`).
+No store mutation or device operation was performed for ZUULI in this audit.
 
-CI evidence was checked on 2026-09-08. The final reviewed #995 head
-`04f3cd559cc3bef0e4f12dc3c1308490dba147c3` has the same complete tree as this
-anchor (`git diff` is empty), but its successful runs are pull-request evidence,
-not successful push runs at the merge SHA:
+A separate GET-only App Store Connect readback on 2026-09-10 observed E2E2Z
+`0.1.0+3` (app `6809219394`, 20:15:27 UTC) and Free2Z `0.1.0+2` (app
+`6809219101`, 20:15:28 UTC). Both were `VALID`, `IN_BETA_TESTING`, unexpired,
+and present in an internal group's build relationship. This is distribution
+evidence for those existing sibling builds only. Their groups do not grant
+access to every future build automatically; proposed builds 4/3 have not been
+dispatched or observed, and each needs its own exact-build/group readback. No
+tester identities or authenticated product operations were queried.
 
-- The [`wallet/zuuli` gate](https://github.com/free2z/zuu/actions/runs/34191205336)
-  succeeded. Frontend, both delegated-surface suites, ZUULI backend, shared and
-  messaging plugins, Android 32-bit, formatting, supply-chain, crypto targets,
-  and native macOS/Windows lint and test jobs succeeded. Only Zuuallet schema
-  freshness was skipped. The new Rust selector selected the native jobs for
-  the capture tooling changes; this was not a frontend-only skip.
-- The [`rs` gate](https://github.com/free2z/zuu/actions/runs/34191205321)
-  succeeded after change detection; its Rust formatting, tests, clippy,
-  cargo-deny and WASM jobs were legitimately skipped. The separate
-  [`wallet/surfaces` run](https://github.com/free2z/zuu/actions/runs/34191205356)
-  successfully ran both delegated apps' Rust jobs.
-- [Packaging smoke](https://github.com/free2z/zuu/actions/runs/34191205364)
-  succeeded: release identity, unsigned iOS target app, unsigned Android AAB,
-  Linux packages and macOS universal app. These are credential-free package
-  builds, not signed-device observations.
-- At this audit, the anchor's own push-triggered
-  [wallet gate](https://github.com/free2z/zuu/actions/runs/34196175870),
-  [rs gate](https://github.com/free2z/zuu/actions/runs/34196175892),
-  [surfaces](https://github.com/free2z/zuu/actions/runs/34196175869) and
-  [packaging](https://github.com/free2z/zuu/actions/runs/34196175970) runs were
-  pending. No successful conclusion is claimed for those runs here. This
-  status PR also requires its own current-head gate and packaging evidence.
-- The [protected build-21 release](https://github.com/free2z/zuu/actions/runs/34086094245)
-  at `7fe1b0a8` failed in `Pin immutable source`; every subsequent job was
-  skipped. No protected release run was fired at this anchor.
+The [#1009 packaging smoke](https://github.com/free2z/zuu/actions/runs/34522898810)
+for reviewed head `48cf3e4e698f2fc200415456bccf43d70a2a0c27` passed release
+identity, unsigned iOS target app, unsigned Android AAB, Linux packages and the
+macOS universal app. These are credential-free packages, not signed-device
+operations. The matching [wallet gate](https://github.com/free2z/zuu/actions/runs/34522898867)
+completed successfully on that same head, including Windows native lint. The
+merged tree comparison above binds these results to the source anchor. A green
+selected job establishes only the check it actually executed; skipped jobs
+supply no new evidence. The historical protected-release evidence in the six-row
+table below retains its original run identities and retention limits.
 
-These are source, test, and package-build evidence only. They add no
-product-operation or physical-device evidence. Nothing in this anchor was
-exercised on a physical device, and nothing in it has been built into a signed
-artifact at all: the newest signed build remains `0.1.0+20`, which predates the
-whole split. Build 20 was read back from both stores as recorded below; that is
-distribution evidence for an app that no longer resembles this source.
+**Committed alongside this audit, and therefore not part of its marker:**
+this document, its `STATUS_DOCUMENT_SHA256` seal in `scripts/status-freshness.mjs`,
+corrections to the three-app status and architecture pages, and generated sibling version
+files. Before the later mechanical
+release-identity commit, re-audit this merged status/checker change and record
+that merged SHA in the marker. The checker itself is release-impacting: leaving
+the marker before this PR would make the release stale again. No checker rule
+is relaxed by this audit.
 
 ## Evidence boundaries
 
@@ -300,26 +176,26 @@ execution, not a permanent artifact archive.
 
 | Surface | Real API/backend dependency | Native integration | Automated evidence | Production/native evidence | Current status and linked gaps |
 |---|---|---|---|---|---|
-| Runtime transport and content-security policy | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri; both capability files allow only `https://free2z.cash/*`, `https://*.free2z.cash/*` and `https://stage.free2z.cash/*` | The required `wallet/zuuli` gate, the separate delegated-surface Rust run, and four-target packaging smoke succeeded on reviewed #995 head, whose complete tree matches this anchor; see the exact run provenance and job selection above. `csp-policy.mjs` and its `tests/csp-policy.pw.ts` browser suite load the packaged `src-tauri/tauri.conf.json` policy itself. [#943](https://github.com/free2z/zuu/pull/943) narrowed that policy to `img-src 'self' data:` with `media-src`, `worker-src`, `object-src` and `frame-src` at `'none'`, and `connect-src` limited to `'self'` plus the free2z origins | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The CSP is now narrow because the surfaces that needed it wide were removed, not because a permissive policy was made safe. `#801`'s remote-image allowance and `blob:` `img-src` are **gone** with the reader that used them. |
-| App shell, mobile navigation, and localization | None | Safe-area insets and the mobile tab bar are native-surface concerns | Playwright geometry suites at 320/360px cover the primary nav and the More sheet. [#869](https://github.com/free2z/zuu/pull/869) fixed a real defect: `DialogContent`'s variant-scoped `ltr:-translate-x-1/2` was not dropped by tailwind-merge when the sheet overrode it with an unprefixed `translate-x-0`, so once the entrance animation's effect was removed the base utility won and the sheet snapped to `translateX(-50%)` — dialog `left` at **-160 at 320px and -180 at 360px**, exactly `-width/2`, deterministically on every run. `navigation.pw.ts` now waits on the dialog's own `getAnimations()` instead of measuring mid-tween. [#863](https://github.com/free2z/zuu/pull/863) gives Sonner toasts safe-area-aware offsets that clear the whole mobile tab bar; [#861](https://github.com/free2z/zuu/pull/861) mirrors layout for RTL locales, isolates bidi identifiers, and adds a source-policy gate against physical-direction utilities | No signed build has been observed on a physical device at any viewport. All geometry evidence is headless browser measurement | **Source and browser-test evidence only; never device-confirmed.** [#943](https://github.com/free2z/zuu/pull/943) also shrank what the shell navigates to: the More sheet now holds **Log in and About**, because Articles, Messages, Profile and Revenue share are no longer this app's surfaces. The build-18/19 off-screen More-sheet defect is fixed in source and covered by a test proven to fail without the fix, and has **not** been confirmed on a device. Physical-device acceptance: [#331](https://github.com/free2z/zuu/issues/331), [#238](https://github.com/free2z/zuu/issues/238). |
-| About & Feedback | None for the About row; the feedback handoff opens an external mail client or GitHub | Build identity is injected at bundle time from canonical `release.json`, the checked-out full source SHA, and the Tauri build platform; the OS opener performs the handoff | [#822](https://github.com/free2z/zuu/pull/822) binds version/build/channel/platform/source identity through release verification and artifact provenance, with drift, offline, clipboard, keyboard, screen-reader, and enlarged-text tests. [#823](https://github.com/free2z/zuu/pull/823) shows the complete outgoing subject and body before any handoff, keeps diagnostic attachment unavailable in the feedback composer, and scrubs wallet/auth/network/path/encoded-secret shapes at review and again before copy. [#868](https://github.com/free2z/zuu/pull/868) middle-truncates the commit SHA through the shared `truncateAddress()` helper instead of a head-only `slice(0, 12)`, scopes BIP-39 mnemonic detection explicitly to English and surfaces that limit in the composer copy, and fixes the regression where the new ellipsis matched the scrubber's own path shape and redacted every report. [#872](https://github.com/free2z/zuu/pull/872) binds the browser identity test to canonical `release.json` instead of a pinned build literal, so the test now actually asserts the binding `#822` claims — the literal matched only by coincidence of the current build and failed the required gate on the first release bump after it | No feedback report has been composed or sent from a signed build, and no build has been observed displaying its own identity on a device | **New visible surface in build 20; source and test evidence only.** The scrubber is a best-effort redactor over text the user can still edit before sending; it is not a guarantee, and non-English mnemonics are explicitly out of its detection scope and said so in the UI. Nothing here is device-proven. |
-| Local diagnostics capture | No API, upload endpoint, or telemetry SDK | Browser/WebView error and rejection listeners; bootstrap and React boundary reporters; localStorage when available | `src/lib/diagnostics.test.ts` verifies ZUULI build identity and recovery-phrase redaction. Shared capture/redaction tests and E2E2Z's real-browser rejection, reload, and no-request controls cover the shared implementation; the frontend jobs passed on reviewed #995 head, whose complete tree matches this anchor (run provenance above) | No signed ZUULI diagnostic capture or recovery has been observed | **Source/test evidence only.** #978 installs local capture; ZUULI has no diagnostic viewing/export UI and its feedback composer still refuses diagnostic attachment. Redaction bounds free text, does not guarantee all prose is secret-free, and must not substitute for safe error construction. Native panic capture: [#980](https://github.com/free2z/zuu/issues/980). |
-| Username/password and TOTP sign-in | Knox Basic login, OTP status/login, and authenticated user endpoints | Token-backed HTTP; no special native plugin | Session-boundary, login-destination, component, and browser lifecycle tests | Anonymous protected reads returned HTTP 403; no successful production login is recorded | **Wired, not runtime-proven; not release-ready.** Server-side TOTP enforcement: [#369](https://github.com/free2z/zuu/issues/369). Token custody: [#377](https://github.com/free2z/zuu/issues/377). |
-| Login/link with Zcash | `auth/zcash/challenge` and `auth/zcash/login` | The shared plugin supports local recovery-phrase restore and transparent-address Zcash Signed Message signing | Native atomic-restore/signing tests and frontend restore/challenge lifecycle tests exercise local contracts | No production restore → native signature → Knox session round trip is recorded | **Restore is implemented and contract-tested, but the login path is not runtime-proven.** Recovery-phrase restore landed in [#428](https://github.com/free2z/zuu/pull/428); external-wallet signing remains unsupported. Physical recovery ceremony: [#246](https://github.com/free2z/zuu/issues/246). Wallet/login identity choice: [#329](https://github.com/free2z/zuu/issues/329). This is not ZIP-304. |
-| Social login/link | Provider discovery, authorization start, callback exchange, and authenticated user endpoints | Desktop loopback and mobile private-scheme OAuth transports exist. #977 adds a separate verified-link claim for `/bridge/zuuli/`; it does not migrate the OAuth callback | Strict discovery parsing, transport selection, attempt fencing, error/retry UI, and 320/360 browser tests cover the client contract; the live preflight fails closed before opening provider URLs | Both discovery endpoints answered anonymously with HTTP 200 on 2026-09-01. The web/desktop endpoint reports `x` with `configured: true`, `google` and `github` `configured: false`; the mobile endpoint returns all three `configured: false`. No OAuth round trip is recorded on any platform | **Client contract fixed; backend-dependent and not runtime-proven.** A provider is selectable on desktop/web; none is on mobile. A `configured` flag is not a login — no authorization start, callback exchange, or resulting session has been performed on any platform, so signed-device login/link proof remains blocked. Public client follow-up: [#403](https://github.com/free2z/zuu/issues/403). Claimed-HTTPS release proof: [#242](https://github.com/free2z/zuu/issues/242). Association binding: [#380](https://github.com/free2z/zuu/issues/380). |
-| Wallet create/restore/sync/receive/send/history | Lightwalletd and librustzcash through the shared plugin | Real Tauri Zcash plugin is registered. [#805](https://github.com/free2z/zuu/pull/805) adds typed multi-wallet listing and switching through the ZUULI bridge and a new mobile capability, publishing inventory, active identity, and account-scoped data atomically and serializing concurrent switches | Plugin Rust tests, frontend wallet tests, and backend compilation run in CI. `#805` adds identity-store, bridge, lifecycle, concurrency, and fail-closed suites; the deterministic mock is what those exercise | Packages have built, but no signed-device create/restore/sync/receive/send record is checked into this repository. `#805` adds no device or lightwalletd evidence | **Wired, not runtime-proven; release stop until kick-the-tires evidence exists.** The identity store is a **foundation**: a switchable wallet inventory now exists in source and under test, and it has never selected a real account on a real device. Send confirmation integrity: [#368](https://github.com/free2z/zuu/issues/368). Preserved-wallet import: [#272](https://github.com/free2z/zuu/issues/272). |
-| 2Z send/tip/membership, and the creator ZEC tip landing | Authenticated donation and subscription APIs; a ZEC tip is a wallet spend, not a 2Z charge | Native HTTP. The Wallet Send route still accepts a creator-tip route state and carries an alteration-detecting in-memory intent into the proposal/confirmation/execution path, locking the creator recipient and disclosing transparent-address privacy and memo limits | Donation and membership idempotency/reconciliation contract tests, plus the creator-tip unit and browser suites, including the fail-closed suites for missing, reloaded, changed, and wrong-network state | No production charge is recorded, and **no ZEC creator tip has ever been proposed or broadcast from a signed device** | **Contract-tested, not runtime-proven; the tip's originating surface is gone.** [#943](https://github.com/free2z/zuu/pull/943) removed the creator profile that issued the tip, so in a shipping ZUULI nothing can populate that route state and the landing route **always fails closed** — by design until [#905](https://github.com/free2z/zuu/issues/905) lands an authenticated issuer over a channel that is not a custom-scheme deep link ([#461](https://github.com/free2z/zuu/issues/461)). The 2Z send/membership tabs under `/wallet/fund` remain reachable and remain unproven. Follow versus paid membership: [#261](https://github.com/free2z/zuu/issues/261). Creator purchase integrity: [#336](https://github.com/free2z/zuu/issues/336). |
-| Buy 2Z with card | Authenticated Stripe Checkout creation, hosted Checkout, signed webhook credit, and a server-controlled return bridge | Native OS opener is used in packaged apps; the exact `cash.free2z.zuuli://checkout/return` route is registered on iOS/Android and claimed through the authenticated server bridge | #400 added signed-out gating, exact HTTPS host validation, actionable failures, and opener tests | Anonymous production checkout returned HTTP 403; no signed-in staging/live charge or signed-build return is recorded | **Wired, not runtime-proven.** Backend deployment/enablement and signed-build charge/return evidence remain unverified. Track the end-to-end path in [#388](https://github.com/free2z/zuu/issues/388) and exact charge/credit integrity in [#399](https://github.com/free2z/zuu/issues/399). |
-| Buy 2Z with ZEC | Public pricing/quote plus wallet spend and backend settlement/credit | Wallet bridge exists; production settlement is intentionally disabled | Quote parsing and explicit browser-only demo-boundary tests | Pricing and an exact 100-2Z quote returned HTTP 200; no spend/settlement exists | **Mock/demo only for settlement; unavailable in release builds:** [#155](https://github.com/free2z/zuu/issues/155). A price quote is not a top-up. |
-| 2Z Activity | Authenticated Stripe purchase ledger | Native HTTP | Parsing/UI tests do not prove a complete ledger | Protected endpoint returned HTTP 403 anonymously; authenticated ledger not exercised | **Known incomplete:** the endpoint is purchases-only and cannot substantiate tips/AI/PPV totals ([#172](https://github.com/free2z/zuu/issues/172)). |
-| E2EE messaging (enrollment only; no frontend) | Relay, key-transparency, and MLS services under `rs/` | `wallet/plugins/tauri-plugin-f2zmsg` builds, its two-instance integration test drives two engines over a real relay, and `wallet/zuuli/src-tauri` links and registers it — but **no capability grants the webview any `f2zmsg:` permission**. The plugin stays registered because enrollment needs its engine and store, and enrollment is the one messaging operation that needs the wallet seed, which must never cross IPC (`src/messaging.rs`, ADR 0016) | The plugin's own crate gate runs in `zuuli.yml`; the app's gate additionally builds it into ZUULI for desktop, iOS and Android. `the_capability_set_refuses_plugin_commands_but_not_the_enrollment_trio` drives the shipping capability set through a mock webview and shows the two halves answering differently: `plugin:f2zmsg|…` is refused by the ACL before its body runs, with the refusal naming the `f2zmsg:` permissions ZUULI no longer grants, while the three app-crate enroll commands are still routed because `generate_handler!` does not consult the ACL at all. `shipping_capabilities_grant_no_messaging_permission` reads the same shipping artifact and asserts no `f2zmsg:` grant survives under any name, with a positive control on the Zcash grants | **None.** No enrollment and no message has ever been performed in a running ZUULI, and after the split there is no messaging UI in this app to perform one from | **Reachable only as an enrollment authority, and still not usable.** The surface moved to `wallet/e2e2z` ([#913](https://github.com/free2z/zuu/pull/913)); this app keeps the seed and the ability to issue a `DeviceCredential`, and nothing else. The shipping directory default is still `directory::NoDirectory`, which fails closed, because `KT.md` §12 has not decided the log identity, signing key, shipped witness list, or default *t*, so `start_conversation` on the shipped configuration refuses with `witness-threshold-unmet`. The residual risk that is written down rather than fixed: the enrollment trio is webview-reachable and, under [#367](https://github.com/free2z/zuu/issues/367), reachable from a frame that resolves as the main window; a hostile caller could submit an attacker-chosen handle or unenroll behind a confirmation string. Closing that is [#905](https://github.com/free2z/zuu/issues/905)'s job. Epic: [#305](https://github.com/free2z/zuu/issues/305). Do not describe ZUULI as having messaging. |
-| Vault boundary: no remote content, no capture authority | None — that is the property | The packaged CSP, both capability files, the Android manifest, and the Apple entitlements and plists are all native-surface declarations | `csp-policy.mjs` with a `--self-test`, `surface-capability-authority.mjs`, `mobile-webview-authority.mjs`, `media-permission-manifests.node-test.mjs`, `android-device-catalog.node-test.mjs` and `macos-keychain-entitlements.mjs` each assert one half and each carries a negative control that fails on a reintroduced grant. The Rust IPC probe above proves the capability refusal at runtime rather than by re-reading JSON | The permission boundary is asserted against the **merged** manifest, not the source file: `zuuli-packaging.yml` checks AGP's merged manifest on every pull request and cross-checks the AAB member's bytes, and `zuuli-release.yml` re-checks it through `bundletool dump manifest` on the artifact that ships — the shape [#941](https://github.com/free2z/zuu/pull/941) established for e2e2z, with ZUULI's own reviewed list. Only `<uses-permission>` elements count, which is what tells a grant apart from a receiver's `android:permission` guard. No signed device has been observed installing without a camera or microphone prompt | **Source- and artifact-asserted; not device-observed.** After [#943](https://github.com/free2z/zuu/pull/943) and [#945](https://github.com/free2z/zuu/issues/945), ZUULI's own manifest declares `android.permission.INTERNET` and nothing else, and the *merged* manifest adds exactly three reviewed entries: `USE_BIOMETRIC`, which `ZcashPlugin.kt` uses to authenticate a `BiometricPrompt.CryptoObject` over the seed cipher; `androidx.biometric`'s `USE_FINGERPRINT`, which is unreachable at `minSdk 29` and is allowlisted rather than removed because it sits on the unlock path and removal needs a signed-device check ([#958](https://github.com/free2z/zuu/issues/958)); and `cash.free2z.zuuli.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`, which `androidx.core` injects at API 33+ so dynamically registered receivers are not exported — app-scoped by its package prefix and signature-level, both checked in CI rather than assumed. `android.permission.DUMP` appears in the merged manifest too and is **not** a grant: it is the `android:permission` guard on `androidx.profileinstaller`'s `ProfileInstallReceiver`, and the CI assertion requires it to stay one. ZUULI additionally claims no macOS capture entitlement, ships no camera or microphone usage string, renders no remote or third-party content, and grants its webview no `f2zmsg:` permission. This row exists because the property is the product: every one of those is a grant on the process that holds the master seed ([#367](https://github.com/free2z/zuu/issues/367)). It has **not** been confirmed on a signed device that ZUULI installs and runs with no capture prompt and that wallet create/restore/send still work: [#238](https://github.com/free2z/zuu/issues/238). |
-| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons; desktop packages are built only by credential-free packaging smoke while desktop distribution is deferred | Release identity, icon/store validators, protected state machines, and all-target packaging are gated. The release-step execution table above records which protected and packaging-only paths have actually run. [#962](https://github.com/free2z/zuu/pull/962) added a certificate-against-profile signing preflight to `zuuli-release.yml`, held to option 2 of the release-step evidence policy by `scripts/verify-signing-identity.node-test.mjs`; [#966](https://github.com/free2z/zuu/pull/966) added [`docs/export-classification.md`](docs/export-classification.md), which is a written record and not a filing | Build 20's [TestFlight readback](https://github.com/free2z/zuu/actions/runs/33496768135) proved `uploaded`, `processed`, and `availableToInternalTesters`, `VALID`/`IN_BETA_TESTING`, and the exact internal-group relationship. Its [Play audit](https://github.com/free2z/zuu/actions/runs/33496770265) found the exact build 20 release present and destroyed the uncommitted audit edit. No physical-device acceptance or protected desktop execution is recorded, and the newest release run — build 21's — failed before entering any protected environment, so the `#962` preflight has never run | **Build 20 is confirmed in both mobile stores, and build 20 is not this app.** Build 21 has later unsigned smoke packages, but its protected release produced no artifact and no signed/store-distributed build 21 is evidenced. Build 20 predates the whole split, so what is confirmed in the stores is the pre-vault ZUULI. The listing copy and questionnaire notes were corrected in `#955` ([#946](https://github.com/free2z/zuu/issues/946)) and are in this anchor; **all 20 shipped screenshots — five device sets × `01-articles-fresh`, `02-semantic-search`, `03-article-reader`, `04-creator-profile` — still depict routes this app no longer mounts** and cannot be re-captured here, because `store-screenshot-contract.mjs`'s `CAPTURE_SHOTS` hard-codes those four routes and capture is pinned to a `linux/amd64` Playwright container. That is tracked in [#956](https://github.com/free2z/zuu/issues/956), not fixed. Store media [#387](https://github.com/free2z/zuu/issues/387), shipped-artifact dependency reconciliation [#379](https://github.com/free2z/zuu/issues/379), and physical installs [#238](https://github.com/free2z/zuu/issues/238) remain open. Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). |
+| Runtime transport and content-security policy | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri; both capability files allow only `https://free2z.cash/*`, `https://*.free2z.cash/*` and `https://stage.free2z.cash/*` | Historical [#995 wallet-gate evidence](https://github.com/free2z/zuu/actions/runs/34191205336) and [packaging smoke](https://github.com/free2z/zuu/actions/runs/34191205364) cover the prior audited tree `44bee1a6`; current candidate checks are recorded above. `csp-policy.mjs` and its `tests/csp-policy.pw.ts` browser suite load the packaged `src-tauri/tauri.conf.json` policy itself. [#943](https://github.com/free2z/zuu/pull/943) narrowed that policy to `img-src 'self' data:` with `media-src`, `worker-src`, `object-src` and `frame-src` at `'none'`, and `connect-src` limited to `'self'` plus the free2z origins | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The CSP is now narrow because the surfaces that needed it wide were removed, not because a permissive policy was made safe. `#801`'s remote-image allowance and `blob:` `img-src` are **gone** with the reader that used them. **2026-09-10 internal disposition:** Retain for internal observation; packaged production HTTP remains unproven. |
+| App shell, mobile navigation, and localization | None | Safe-area insets and the mobile tab bar are native-surface concerns | Playwright geometry suites at 320/360px cover the primary nav and the More sheet. [#869](https://github.com/free2z/zuu/pull/869) fixed a real defect: `DialogContent`'s variant-scoped `ltr:-translate-x-1/2` was not dropped by tailwind-merge when the sheet overrode it with an unprefixed `translate-x-0`, so once the entrance animation's effect was removed the base utility won and the sheet snapped to `translateX(-50%)` — dialog `left` at **-160 at 320px and -180 at 360px**, exactly `-width/2`, deterministically on every run. `navigation.pw.ts` now waits on the dialog's own `getAnimations()` instead of measuring mid-tween. [#863](https://github.com/free2z/zuu/pull/863) gives Sonner toasts safe-area-aware offsets that clear the whole mobile tab bar; [#861](https://github.com/free2z/zuu/pull/861) mirrors layout for RTL locales, isolates bidi identifiers, and adds a source-policy gate against physical-direction utilities | No signed build has been observed on a physical device at any viewport. All geometry evidence is headless browser measurement | **Source and browser-test evidence only; never device-confirmed.** [#943](https://github.com/free2z/zuu/pull/943) also shrank what the shell navigates to: the More sheet now holds **Log in and About**, because Articles, Messages, Profile and Revenue share are no longer this app's surfaces. The build-18/19 off-screen More-sheet defect is fixed in source and covered by a test proven to fail without the fix, and has **not** been confirmed on a device. Physical-device acceptance: [#331](https://github.com/free2z/zuu/issues/331), [#238](https://github.com/free2z/zuu/issues/238). **2026-09-10 internal disposition:** Retain for internal device checks; browser geometry and locale tests are not device acceptance. |
+| About & Feedback | None for the About row; the feedback handoff opens an external mail client or GitHub | Build identity is injected at bundle time from canonical `release.json`, the checked-out full source SHA, and the Tauri build platform; the OS opener performs the handoff | [#822](https://github.com/free2z/zuu/pull/822) binds version/build/channel/platform/source identity through release verification and artifact provenance, with drift, offline, clipboard, keyboard, screen-reader, and enlarged-text tests. [#823](https://github.com/free2z/zuu/pull/823) shows the complete outgoing subject and body before any handoff, keeps diagnostic attachment unavailable in the feedback composer, and scrubs wallet/auth/network/path/encoded-secret shapes at review and again before copy. [#868](https://github.com/free2z/zuu/pull/868) middle-truncates the commit SHA through the shared `truncateAddress()` helper instead of a head-only `slice(0, 12)`, scopes BIP-39 mnemonic detection explicitly to English and surfaces that limit in the composer copy, and fixes the regression where the new ellipsis matched the scrubber's own path shape and redacted every report. [#872](https://github.com/free2z/zuu/pull/872) binds the browser identity test to canonical `release.json` instead of a pinned build literal, so the test now actually asserts the binding `#822` claims — the literal matched only by coincidence of the current build and failed the required gate on the first release bump after it | No feedback report has been composed or sent from a signed build, and no build has been observed displaying its own identity on a device | **New visible surface in build 20; source and test evidence only.** The scrubber is a best-effort redactor over text the user can still edit before sending; it is not a guarantee, and non-English mnemonics are explicitly out of its detection scope and said so in the UI. Nothing here is device-proven. **2026-09-10 internal disposition:** Retain for internal identity/handoff checks without claiming a signed-device result. |
+| Local diagnostics capture | No API, upload endpoint, or telemetry SDK | Browser/WebView error and rejection listeners; bootstrap and React boundary reporters; localStorage when available | `src/lib/diagnostics.test.ts` verifies ZUULI build identity and recovery-phrase redaction. Shared capture/redaction tests and E2E2Z's real-browser rejection, reload, and no-request controls cover the shared implementation; the historical frontend jobs passed on reviewed #995 head; current candidate checks are identified above | No signed ZUULI diagnostic capture or recovery has been observed | **Source/test evidence only.** #978 installs local capture; ZUULI has no diagnostic viewing/export UI and its feedback composer still refuses diagnostic attachment. Redaction bounds free text, does not guarantee all prose is secret-free, and must not substitute for safe error construction. Native panic capture: [#980](https://github.com/free2z/zuu/issues/980). **2026-09-10 internal disposition:** Retain local-only capture; no upload or signed-device recovery claim. |
+| Username/password and TOTP sign-in | Knox Basic login, OTP status/login, and authenticated user endpoints | Token-backed HTTP; no special native plugin | Session-boundary, login-destination, component, and browser lifecycle tests | Anonymous protected reads returned HTTP 403; no successful production login is recorded | **Wired, not runtime-proven; not release-ready.** Server-side TOTP enforcement: [#369](https://github.com/free2z/zuu/issues/369). Token custody: [#377](https://github.com/free2z/zuu/issues/377). **2026-09-10 internal disposition:** Retain for internal authenticated testing; no successful login or TOTP enforcement is claimed. |
+| Login/link with Zcash | `auth/zcash/challenge` and `auth/zcash/login` | The shared plugin supports local recovery-phrase restore and transparent-address Zcash Signed Message signing | Native atomic-restore/signing tests and frontend restore/challenge lifecycle tests exercise local contracts | No production restore → native signature → Knox session round trip is recorded | **Restore is implemented and contract-tested, but the login path is not runtime-proven.** Recovery-phrase restore landed in [#428](https://github.com/free2z/zuu/pull/428); external-wallet signing remains unsupported. Physical recovery ceremony: [#246](https://github.com/free2z/zuu/issues/246). Wallet/login identity choice: [#329](https://github.com/free2z/zuu/issues/329). This is not ZIP-304. **2026-09-10 internal disposition:** Retain for isolated internal recovery/sign-in testing; no production session is claimed. |
+| Social login/link | Provider discovery, authorization start, callback exchange, and authenticated user endpoints | Desktop loopback and mobile private-scheme OAuth transports exist. #977 adds a separate verified-link claim for `/bridge/zuuli/`; it does not migrate the OAuth callback | Strict discovery parsing, transport selection, attempt fencing, error/retry UI, and 320/360 browser tests cover the client contract; the live preflight fails closed before opening provider URLs | Both discovery endpoints answered anonymously with HTTP 200 on 2026-09-10. The web/desktop endpoint reports `x` with `configured: true`, `google` and `github` `configured: false`; the mobile endpoint returns all three `configured: false`. No OAuth round trip is recorded on any platform | **Client contract fixed; backend-dependent and not runtime-proven.** A provider is selectable on desktop/web; none is on mobile. A `configured` flag is not a login — no authorization start, callback exchange, or resulting session has been performed on any platform, so signed-device login/link proof remains blocked. Public client follow-up: [#403](https://github.com/free2z/zuu/issues/403). Claimed-HTTPS release proof: [#242](https://github.com/free2z/zuu/issues/242). Association binding: [#380](https://github.com/free2z/zuu/issues/380). **2026-09-10 internal disposition:** Mobile providers remain unconfigured and unavailable; do not bypass discovery to expose one. |
+| Wallet create/restore/sync/receive/send/history | Lightwalletd and librustzcash through the shared plugin | Real Tauri Zcash plugin is registered. [#805](https://github.com/free2z/zuu/pull/805) adds typed multi-wallet listing and switching through the ZUULI bridge and a new mobile capability, publishing inventory, active identity, and account-scoped data atomically and serializing concurrent switches | Plugin Rust tests, frontend wallet tests, and backend compilation run in CI. `#805` adds identity-store, bridge, lifecycle, concurrency, and fail-closed suites; the deterministic mock is what those exercise | Packages have built, but no signed-device create/restore/sync/receive/send record is checked into this repository. `#805` adds no device or lightwalletd evidence | **Wired, not runtime-proven; release stop until kick-the-tires evidence exists.** The identity store is a **foundation**: a switchable wallet inventory now exists in source and under test, and it has never selected a real account on a real device. Send confirmation integrity: [#368](https://github.com/free2z/zuu/issues/368). Preserved-wallet import: [#272](https://github.com/free2z/zuu/issues/272). **2026-09-10 internal disposition:** Retain for existing internal testers to collect #238 evidence; no cohort expansion or public readiness. |
+| 2Z send/tip/membership, and the creator ZEC tip landing | Authenticated donation and subscription APIs; a ZEC tip is a wallet spend, not a 2Z charge | Native HTTP. The Wallet Send route still accepts a creator-tip route state and carries an alteration-detecting in-memory intent into the proposal/confirmation/execution path, locking the creator recipient and disclosing transparent-address privacy and memo limits | Donation and membership idempotency/reconciliation contract tests, plus the creator-tip unit and browser suites, including the fail-closed suites for missing, reloaded, changed, and wrong-network state | No production charge is recorded, and **no ZEC creator tip has ever been proposed or broadcast from a signed device** | **Contract-tested, not runtime-proven; the tip's originating surface is gone.** [#943](https://github.com/free2z/zuu/pull/943) removed the creator profile that issued the tip, so in a shipping ZUULI nothing can populate that route state and the landing route **always fails closed** — by design until [#905](https://github.com/free2z/zuu/issues/905) lands an authenticated issuer over a channel that is not a custom-scheme deep link (client association declarations from the closed [#461](https://github.com/free2z/zuu/issues/461) do not provide that transport). The 2Z send/membership tabs under `/wallet/fund` remain reachable and remain unproven. Follow versus paid membership: [#261](https://github.com/free2z/zuu/issues/261). Creator purchase integrity: [#336](https://github.com/free2z/zuu/issues/336). **2026-09-10 internal disposition:** Keep the creator-tip landing fail-closed; retain 2Z tabs as unproven internal paths. |
+| Buy 2Z with card | Authenticated Stripe Checkout creation, hosted Checkout, signed webhook credit, and a server-controlled return bridge | Native OS opener is used in packaged apps; the exact `cash.free2z.zuuli://checkout/return` route is registered on iOS/Android and claimed through the authenticated server bridge | #400 added signed-out gating, exact HTTPS host validation, actionable failures, and opener tests | Anonymous production checkout returned HTTP 403; no signed-in staging/live charge or signed-build return is recorded | **Wired, not runtime-proven.** Backend deployment/enablement and signed-build charge/return evidence remain unverified. Track the end-to-end path in [#388](https://github.com/free2z/zuu/issues/388) and exact charge/credit integrity in [#399](https://github.com/free2z/zuu/issues/399). **2026-09-10 internal disposition:** Retain the guarded internal path; charge, credit and native return remain unverified. |
+| Buy 2Z with ZEC | Public pricing/quote plus wallet spend and backend settlement/credit | Wallet bridge exists; production settlement is intentionally disabled | Quote parsing and explicit browser-only demo-boundary tests | Pricing and an exact 100-2Z quote returned HTTP 200; no spend/settlement exists | **Mock/demo only for settlement; unavailable in release builds:** [#155](https://github.com/free2z/zuu/issues/155). A price quote is not a top-up. **2026-09-10 internal disposition:** Keep release settlement disabled; do not present quote availability as a completed purchase. |
+| 2Z Activity | Authenticated Stripe purchase ledger | Native HTTP | Parsing/UI tests do not prove a complete ledger | Protected endpoint returned HTTP 403 anonymously; authenticated ledger not exercised | **Known incomplete:** the endpoint is purchases-only and cannot substantiate tips/AI/PPV totals ([#172](https://github.com/free2z/zuu/issues/172)). **2026-09-10 internal disposition:** Retain the purchases-only experimental view; do not claim a complete ledger. |
+| E2EE messaging (enrollment only; no frontend) | Relay, key-transparency, and MLS services under `rs/` | `wallet/plugins/tauri-plugin-f2zmsg` builds, its two-instance integration test drives two engines over a real relay, and `wallet/zuuli/src-tauri` links and registers it — but **no capability grants the webview any `f2zmsg:` permission**. The plugin stays registered because enrollment needs its engine and store, and enrollment is the one messaging operation that needs the wallet seed, which must never cross IPC (`src/messaging.rs`, ADR 0016) | The plugin's own crate gate runs in `zuuli.yml`; the app's gate additionally builds it into ZUULI for desktop, iOS and Android. `the_capability_set_refuses_plugin_commands_but_not_the_enrollment_trio` drives the shipping capability set through a mock webview and shows the two halves answering differently: `plugin:f2zmsg|…` is refused by the ACL before its body runs, with the refusal naming the `f2zmsg:` permissions ZUULI no longer grants, while the three app-crate enroll commands are still routed because `generate_handler!` does not consult the ACL at all. `shipping_capabilities_grant_no_messaging_permission` reads the same shipping artifact and asserts no `f2zmsg:` grant survives under any name, with a positive control on the Zcash grants | **None.** No enrollment and no message has ever been performed in a running ZUULI, and after the split there is no messaging UI in this app to perform one from | **Reachable only as an enrollment authority, and still not usable.** The surface moved to `wallet/e2e2z` ([#913](https://github.com/free2z/zuu/pull/913)); this app keeps the seed and the ability to issue a `DeviceCredential`, and nothing else. The shipping directory default is still `directory::NoDirectory`, which fails closed, because `KT.md` §12 has not decided the log identity, signing key, shipped witness list, or default *t*, so `start_conversation` on the shipped configuration refuses with `witness-threshold-unmet`. The residual risk that is written down rather than fixed: the enrollment trio is webview-reachable and, under [#367](https://github.com/free2z/zuu/issues/367), reachable from a frame that resolves as the main window; a hostile caller could submit an attacker-chosen handle or unenroll behind a confirmation string. Closing that is [#905](https://github.com/free2z/zuu/issues/905)'s job. Epic: [#305](https://github.com/free2z/zuu/issues/305). Do not describe ZUULI as having messaging. **2026-09-10 internal disposition:** Keep messaging absent from ZUULI UI and cross-app enrollment unavailable; device-custody tests are not enrollment proof. |
+| Vault boundary: no remote content, no capture authority | None — that is the property | The packaged CSP, both capability files, the Android manifest, and the Apple entitlements and plists are all native-surface declarations | `csp-policy.mjs` with a `--self-test`, `surface-capability-authority.mjs`, `mobile-webview-authority.mjs`, `media-permission-manifests.node-test.mjs`, `android-device-catalog.node-test.mjs` and `macos-keychain-entitlements.mjs` each assert one half and each carries a negative control that fails on a reintroduced grant. The Rust IPC probe above proves the capability refusal at runtime rather than by re-reading JSON | The permission boundary is asserted against the **merged** manifest, not the source file: `zuuli-packaging.yml` checks AGP's merged manifest on every pull request and cross-checks the AAB member's bytes, and `zuuli-release.yml` re-checks it through `bundletool dump manifest` on the artifact that ships — the shape [#941](https://github.com/free2z/zuu/pull/941) established for e2e2z, with ZUULI's own reviewed list. Only `<uses-permission>` elements count, which is what tells a grant apart from a receiver's `android:permission` guard. No signed device has been observed installing without a camera or microphone prompt | **Source- and artifact-asserted; not device-observed.** After [#943](https://github.com/free2z/zuu/pull/943) and [#945](https://github.com/free2z/zuu/issues/945), ZUULI's own manifest declares `android.permission.INTERNET` and nothing else, and the *merged* manifest adds exactly three reviewed entries: `USE_BIOMETRIC`, which `ZcashPlugin.kt` uses to authenticate a `BiometricPrompt.CryptoObject` over the seed cipher; `androidx.biometric`'s `USE_FINGERPRINT`, which is unreachable at `minSdk 29` and is allowlisted rather than removed because it sits on the unlock path and removal needs a signed-device check ([#958](https://github.com/free2z/zuu/issues/958)); and `cash.free2z.zuuli.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`, which `androidx.core` injects at API 33+ so dynamically registered receivers are not exported — app-scoped by its package prefix and signature-level, both checked in CI rather than assumed. `android.permission.DUMP` appears in the merged manifest too and is **not** a grant: it is the `android:permission` guard on `androidx.profileinstaller`'s `ProfileInstallReceiver`, and the CI assertion requires it to stay one. ZUULI additionally claims no macOS capture entitlement, ships no camera or microphone usage string, renders no remote or third-party content, and grants its webview no `f2zmsg:` permission. This row exists because the property is the product: every one of those is a grant on the process that holds the master seed ([#367](https://github.com/free2z/zuu/issues/367)). It has **not** been confirmed on a signed device that ZUULI installs and runs with no capture prompt and that wallet create/restore/send still work: [#238](https://github.com/free2z/zuu/issues/238). **2026-09-10 internal disposition:** Retain the narrowed declarations and required artifact checks; device installation and wallet operation still need #238 evidence. |
+| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons; desktop packages are built only by credential-free packaging smoke while desktop distribution is deferred | Release identity, icon/store validators, protected state machines, and all-target packaging are gated. The release-step execution table above records which protected and packaging-only paths have actually run. [#962](https://github.com/free2z/zuu/pull/962) added a certificate-against-profile signing preflight to `zuuli-release.yml`, held to option 2 of the release-step evidence policy by `scripts/verify-signing-identity.node-test.mjs`; [#966](https://github.com/free2z/zuu/pull/966) added [`docs/export-classification.md`](docs/export-classification.md), which is a written record and not a filing | Build 20's [TestFlight readback](https://github.com/free2z/zuu/actions/runs/33496768135) proved `uploaded`, `processed`, and `availableToInternalTesters`, `VALID`/`IN_BETA_TESTING`, and the exact internal-group relationship. Its [Play audit](https://github.com/free2z/zuu/actions/runs/33496770265) found the exact build 20 release present and destroyed the uncommitted audit edit. No physical-device acceptance or protected desktop execution is recorded, and the newest release run — build 21's — failed before entering any protected environment, so the `#962` preflight has never run | **Build 20 is confirmed in both mobile stores, and build 20 is not this app.** Build 21 has later unsigned smoke packages, but its protected release produced no artifact and no signed/store-distributed build 21 is evidenced. Build 20 predates the whole split, so what is confirmed in the stores is the pre-vault ZUULI. The listing copy and questionnaire notes were corrected in `#955` ([#946](https://github.com/free2z/zuu/issues/946)) and are in this anchor; **all 20 shipped screenshots — five device sets × `01-articles-fresh`, `02-semantic-search`, `03-article-reader`, `04-creator-profile` — still depict routes this app no longer mounts** and cannot be re-captured here, because `store-screenshot-contract.mjs`'s `CAPTURE_SHOTS` hard-codes those four routes and capture is pinned to a `linux/amd64` Playwright container. That is tracked in [#956](https://github.com/free2z/zuu/issues/956), not fixed. Store media [#387](https://github.com/free2z/zuu/issues/387), shipped-artifact dependency reconciliation [#379](https://github.com/free2z/zuu/issues/379), and physical installs [#238](https://github.com/free2z/zuu/issues/238) remain open. Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). **2026-09-10 internal disposition:** Existing internal TestFlight cohort only; keep public publication and cohort widening deferred, including the known screenshot mismatch. |
 
 ## Current production and distribution evidence
 
 Safe unauthenticated requests were **re-run fresh for this anchor** on
-2026-09-08 against the endpoints ZUULI's remaining surfaces actually reach, and
+2026-09-10 at 20:10:59 UTC against the endpoints ZUULI's remaining surfaces actually reach, and
 returned the following status and top-level contracts:
 
 ```text
@@ -331,20 +207,21 @@ GET  /api/stripe/create-checkout-session/    403  detail: authentication credent
 GET  /api/tuzis/my-subscriptions             403  detail: authentication credentials were not provided
 ```
 
-The public content endpoints the previous anchor probed — `zpage`, `creator`,
+The public content endpoints older pre-vault audits probed — `zpage`, `creator`,
 `ai/models`, `dyte/public`, `pricing`, and `pricing/quote` — are **deliberately
 absent from this list**. They are not endpoints this app calls any more, so
 their availability is `wallet/free2z`'s evidence, not ZUULI's. The legacy client
-functions and contract tests that still reached them at the previous anchor are
+functions and contract tests that still reached them are
 **gone** as of [#979](https://github.com/free2z/zuu/pull/979); `src/lib/api/`
 now holds only what `auth`, `home` and `wallet` import.
 
 The 403s prove only the anonymous access boundary; they do not prove any
 authenticated success path. `/api/kyc/user-profile` and `/api/openai/prompt`
-answered 403 anonymously as well, but ZUULI mounts neither surface any more, so
-that is recorded as a fact about the backend rather than about this app.
+answered 403 anonymously in prior audits; they were not re-probed here. ZUULI
+mounts neither surface any more, so that historical backend evidence is not a
+claim about this app.
 
-The social-provider configuration is unchanged from the 2026-09-01 audit and was
+The social-provider configuration is unchanged from the 2026-09-08 audit and was
 re-confirmed by this probe. `/api/auth/social/providers/`, the web/desktop
 endpoint, reports `x` with `configured: true`; `google` and `github` remain
 `configured: false` there, and the mobile endpoint
@@ -453,10 +330,10 @@ These runs prove package/store state, not product operations. No repository
 record yet demonstrates the full physical-device checklist for the surfaces this
 app still has: wallet recovery/sync/spend, OAuth, card checkout, or ZEC top-up.
 That checklist was re-derived for this audit and is still unmet: as of
-2026-09-08, neither the repository nor the physical-device tracking issue
+2026-09-10, neither the repository nor the physical-device tracking issue
 [#238](https://github.com/free2z/zuu/issues/238) records a signed-device wallet
 operation. The AI-charging, Live-media and KYC-capture
-items the previous anchor listed are not "still unmet" — those surfaces were
+items the older pre-vault audit listed are not "still unmet" — those surfaces were
 removed, so they are off this app's checklist rather than outstanding on it.
 
 Every signed artifact named above predates the split. **Nothing in this anchor

--- a/wallet/zuuli/scripts/status-freshness.mjs
+++ b/wallet/zuuli/scripts/status-freshness.mjs
@@ -23,7 +23,7 @@ const releasingPath = "wallet/zuuli/docs/releasing.md";
 const RELEASING_DOCUMENT_SHA256 =
   "352cf01bb042188fb514b9157b22e6e292064566dd2bb1cfcd0673724436b100";
 const STATUS_DOCUMENT_SHA256 =
-  "b8930ee969efeda439171397e08d211b1ff8201822d0df3862d27d4a7763510b";
+  "a8b4d01386c1e5d00bc92064fc5d0a73bf8a51a1fda51250394cc73dd8419302";
 const statusSourceMarkerPattern =
   /^Last re-derived from `origin\/main` at\n`[0-9a-f]{40}` on \d{4}-\d{2}-\d{2}\. Before a release,\nupdate the evidence and disposition for every non-ready row; do not carry this\ncommit or date forward mechanically\.$/gm;
 const canonicalStatusSourceMarker = "<STATUS_SOURCE_MARKER>";

--- a/wallet/zuuli/scripts/status-freshness.mjs
+++ b/wallet/zuuli/scripts/status-freshness.mjs
@@ -23,7 +23,7 @@ const releasingPath = "wallet/zuuli/docs/releasing.md";
 const RELEASING_DOCUMENT_SHA256 =
   "352cf01bb042188fb514b9157b22e6e292064566dd2bb1cfcd0673724436b100";
 const STATUS_DOCUMENT_SHA256 =
-  "a8b4d01386c1e5d00bc92064fc5d0a73bf8a51a1fda51250394cc73dd8419302";
+  "8d5cbbc8838c85c9aa53ba118672c79ab4937c696f7d4114c565dd8bb76afc91";
 const statusSourceMarkerPattern =
   /^Last re-derived from `origin\/main` at\n`[0-9a-f]{40}` on \d{4}-\d{2}-\d{2}\. Before a release,\nupdate the evidence and disposition for every non-ready row; do not carry this\ncommit or date forward mechanically\.$/gm;
 const canonicalStatusSourceMarker = "<STATUS_SOURCE_MARKER>";


### PR DESCRIPTION
The latest ZUULI release stopped before signing because its readiness audit predated release-impacting changes. Re-derive the source and execution evidence at merged #1009 (`822721c6`), preserve the explicit existing-internal-cohort dispositions for all unfinished surfaces, and reseal the reviewed document without changing any checker rule. Correct the related architecture/status claims about Free2Z's native layer and the still-unimplemented cross-app transport.

Prepare the independent E2E2Z `0.1.0+4` and Free2Z `0.1.0+3` identities using their generated version files. ZUULI remains at build 21 here: its separate build-22 ceremony must re-audit this merged preparation commit and record that SHA before release. No device, authenticated product, or new upload success is claimed. Fresh GET-only store evidence covers only existing builds ZUULI 20, E2E2Z 3, and Free2Z 2; exact ZUULI 21 remains absent.

Validation: all 118 status-freshness tests pass; live release-evidence policy/seal validation, both sibling release-identity checks, project boundary (including three constrained Vite builds), capability authority, CSP, app-link association, plugin permissions, Markdown links, and `git diff --check` pass. The #1009 evidence is bound to its identical merged tree and successful wallet/packaging runs; no signed-device acceptance is substituted.

Refs #1010.
